### PR TITLE
fix(e2e): make all 9 smoke and a11y tests pass

### DIFF
--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -8,7 +8,7 @@ test.describe('@a11y accessibility', () => {
     await page.goto('/en/');
     await page.getByRole('main').waitFor({ state: 'visible' });
     await page
-      .getByRole('heading', { level: 1 })
+      .getByRole('group', { name: /filter by grade level/i })
       .waitFor({ state: 'visible' });
     const accessibilityScanResults = await new AxeBuilder({
       page,

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -11,10 +11,10 @@ test('home page loads', async ({ page }) => {
   await expect(page).toHaveTitle(/BaseSkill/);
 });
 
-test('profile picker renders', async ({ page }) => {
+test('game catalog renders', async ({ page }) => {
   await page.goto(localeHomePath('en'));
   await page.getByRole('main').waitFor({ state: 'visible' });
   await expect(
-    page.getByRole('heading', { name: /profile picker/i }),
+    page.getByRole('group', { name: /filter by grade level/i }),
   ).toBeVisible();
 });

--- a/scripts/check-node-version.mjs
+++ b/scripts/check-node-version.mjs
@@ -3,27 +3,23 @@
  * Override: SKIP_NODE_VERSION_CHECK=1
  */
 import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-if (process.env.SKIP_NODE_VERSION_CHECK === '1') {
-  process.exit(0);
-}
+if (process.env.SKIP_NODE_VERSION_CHECK !== '1') {
+  const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const raw = readFileSync(path.join(root, '.nvmrc'), 'utf8').trim();
+  const major = Number(/^(\d+)/.exec(raw)?.[1]);
+  if (!Number.isFinite(major)) {
+    throw new TypeError(
+      'check-node-version: could not read a numeric Node major from .nvmrc',
+    );
+  }
 
-const root = join(dirname(fileURLToPath(import.meta.url)), '..');
-const raw = readFileSync(join(root, '.nvmrc'), 'utf8').trim();
-const major = Number(/^(\d+)/.exec(raw)?.[1]);
-if (!Number.isFinite(major)) {
-  console.error(
-    'check-node-version: could not read a numeric Node major from .nvmrc',
-  );
-  process.exit(1);
-}
-
-const currentMajor = Number(process.version.slice(1).split('.')[0]);
-if (currentMajor !== major) {
-  console.error(
-    `check-node-version: Node ${currentMajor}.x is active; .nvmrc requires ${major}.x (CI uses node-version-file: .nvmrc). Try: nvm use`,
-  );
-  process.exit(1);
+  const currentMajor = Number(process.version.slice(1).split('.')[0]);
+  if (currentMajor !== major) {
+    throw new Error(
+      `check-node-version: Node ${currentMajor}.x is active; .nvmrc requires ${major}.x (CI uses node-version-file: .nvmrc). Try: nvm use`,
+    );
+  }
 }

--- a/scripts/check-node-version.mjs
+++ b/scripts/check-node-version.mjs
@@ -7,7 +7,10 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 if (process.env.SKIP_NODE_VERSION_CHECK !== '1') {
-  const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const root = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+  );
   const raw = readFileSync(path.join(root, '.nvmrc'), 'utf8').trim();
   const major = Number(/^(\d+)/.exec(raw)?.[1]);
   if (!Number.isFinite(major)) {

--- a/src/routes/$locale/_app/index.tsx
+++ b/src/routes/$locale/_app/index.tsx
@@ -4,6 +4,7 @@ import {
   useParams,
 } from '@tanstack/react-router';
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { GameLevel, GameSubject } from '@/games/registry';
 import type { ValidatorAdapter } from '@tanstack/react-router';
 import { GameGrid } from '@/components/GameGrid';
@@ -52,6 +53,7 @@ const catalogSearchValidator: ValidatorAdapter<
 const PAGE_SIZE = 12;
 
 const HomeScreen = () => {
+  const { t } = useTranslation('common');
   const { level, subject, search, page } = Route.useSearch();
   const { locale } = useParams({ from: '/$locale' });
   const navigate = useNavigate({ from: '/$locale/' });
@@ -98,6 +100,7 @@ const HomeScreen = () => {
 
   return (
     <div className="px-4 py-2">
+      <h1 className="sr-only">{t('home.title')}</h1>
       <LevelRow
         currentLevel={level as GameLevel | ''}
         onLevelChange={(l) => updateSearch({ level: l, page: 1 })}


### PR DESCRIPTION
## Summary

Replace stale tests and fix real a11y violation.

- Replace stale profile picker renders test with game catalog renders
- Fix a11y sync guard to wait for level-filter group instead of missing h1
- Add visually-hidden h1 to HomeScreen to fix axe page-has-heading-one

## Test plan

- yarn test:e2e: 9/9 pass (chromium, firefox, webkit)
- yarn test: 53/53 pass

Generated with Claude Code