### PR TITLE
fix(storybook): restore MDX demos on static build / GitHub Pages

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,5 @@
 import rehypeFormat from 'rehype-format';
 import rehypeRaw from 'rehype-raw';
-import rehypeSanitize from 'rehype-sanitize';
 import remarkDirective from 'remark-directive';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
@@ -33,7 +32,12 @@ const config: StorybookConfig = {
             ],
             rehypePlugins: [
               [rehypeRaw, { passThrough: [...mdxRehypePassThrough] }],
-              rehypeSanitize,
+              // No `rehype-sanitize` here: `hast-util-sanitize` only handles HAST
+              // `element` nodes. MDX custom components are `mdxJsxFlowElement` etc.,
+              // which the sanitizer drops in its default branch—so interactive
+              // demos vanished from `storybook build` / GitHub Pages while dev
+              // could still look fine depending on cache. MDX under `src/` is
+              // trusted first-party content.
               rehypeFormat,
             ],
           },

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "prettier": "^3.8.1",
     "rehype-format": "^5.0.1",
     "rehype-raw": "^7.0.0",
-    "rehype-sanitize": "^6.0.0",
     "remark-directive": "^4.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",

--- a/src/db/hooks/useRxQuery.demo.tsx
+++ b/src/db/hooks/useRxQuery.demo.tsx
@@ -25,13 +25,17 @@ export const UseRxQueryDemo = () => {
   };
 
   return (
-    <div className="flex flex-col items-start gap-4 p-4">
-      <CounterDemo source$={source$} />
-      <div className="flex gap-2">
-        <Button onClick={increment}>Increment</Button>
-        <Button variant="outline" onClick={reset}>
-          Reset
-        </Button>
+    <div className="flex flex-col gap-3 p-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <CounterDemo source$={source$} />
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" onClick={increment}>
+            Increment
+          </Button>
+          <Button type="button" variant="outline" onClick={reset}>
+            Reset
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -7479,15 +7479,6 @@ hast-util-raw@^9.0.0:
     web-namespaces "^2.0.0"
     zwitch "^2.0.0"
 
-hast-util-sanitize@^5.0.0:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz#edb260d94e5bba2030eb9375790a8753e5bf391f"
-  integrity sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==
-  dependencies:
-    "@types/hast" "^3.0.0"
-    "@ungap/structured-clone" "^1.0.0"
-    unist-util-position "^5.0.0"
-
 hast-util-to-parse5@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz#95aa391cc0514b4951418d01c883d1038af42f5d"
@@ -11085,14 +11076,6 @@ rehype-raw@^7.0.0:
     "@types/hast" "^3.0.0"
     hast-util-raw "^9.0.0"
     vfile "^6.0.0"
-
-rehype-sanitize@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz#16e95f4a67a69cbf0f79e113c8e0df48203db73c"
-  integrity sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==
-  dependencies:
-    "@types/hast" "^3.0.0"
-    hast-util-sanitize "^5.0.0"
 
 release-zalgo@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Problem

On [published Storybook](https://leocaseiro.github.io/base-skill/docs/?path=/docs/db-hooks-userxquery--docs), the `useRxQuery` (and other) MDX pages showed headings and prose but **no interactive demo** — no Increment button.

## Root cause

`rehype-sanitize` delegates to `hast-util-sanitize`, which only handles HAST nodes with `type: "element"`. MDX compiles `<UseRxQueryDemo />` to **`mdxJsxFlowElement`** (and related) nodes. Those hit the sanitizer’s `default` branch and are **dropped entirely** before MDX codegen, so `yarn build-storybook` emitted docs without the demo components. Dev mode could mask this with caching.

Layout / iframe height was a red herring; the demo was not in the bundle at all.

## Fix

- Remove `rehype-sanitize` from the MDX `rehypePlugins` chain. MDX under `src/` is trusted first-party content.
- Remove the unused `rehype-sanitize` devDependency.
- Keep the `useRxQuery` demo layout tweak (count + controls on one row) for nicer docs previews.

## After merge

Merge to `master` so [`deploy.yml`](.github/workflows/deploy.yml) rebuilds Storybook for GitHub Pages.

## Verification

- `yarn build-storybook` output now includes `UseRxQueryDemo` / Increment in the compiled chunks.
- Local pre-push: lint, typecheck, unit, VR, E2E (Storybook test-runner skipped — no server on 6006).

Made with [Cursor](https://cursor.com)