### PR TITLE
fix(stories): remove duplicate decorators in NumberMatch and WordSpell

### DIFF
--- a/src/games/number-match/NumberMatch/NumberMatch.stories.tsx
+++ b/src/games/number-match/NumberMatch/NumberMatch.stories.tsx
@@ -22,7 +22,6 @@ const baseConfig: NumberMatchConfig = {
 const meta: Meta<typeof NumberMatch> = {
   component: NumberMatch,
   tags: ['autodocs'],
-  decorators: [withRouter],
   args: { config: baseConfig },
   decorators: [withDb, withRouter],
 };

--- a/src/games/word-spell/WordSpell/WordSpell.stories.tsx
+++ b/src/games/word-spell/WordSpell/WordSpell.stories.tsx
@@ -24,7 +24,6 @@ const baseConfig: WordSpellConfig = {
 const meta: Meta<typeof WordSpell> = {
   component: WordSpell,
   tags: ['autodocs'],
-  decorators: [withRouter],
   args: { config: baseConfig },
   decorators: [withDb, withRouter],
 };


### PR DESCRIPTION
## Summary

- Removes the duplicate `decorators` property in `NumberMatch.stories.tsx` and `WordSpell.stories.tsx` that was causing `TS1117` on master CI
- The incomplete `decorators: [withRouter]` line (from an earlier edit) was left in alongside the complete `decorators: [withDb, withRouter]` line; keeping only the correct one

## Root cause

The fix was applied locally during development but was not committed before the PR was squash-merged.

Made with [Cursor](https://cursor.com)