### PR TITLE
fix: mobile touch drag, slot-to-bank drag, and double-tap active tile…

### DIFF
--- a/src/components/answer-game/useAutoNextSlot.test.tsx
+++ b/src/components/answer-game/useAutoNextSlot.test.tsx
@@ -137,4 +137,54 @@ describe('useAutoNextSlot', () => {
     expect(result.current.state.zones[0]?.placedTileId).toBeNull();
     expect(result.current.state.zones[1]?.placedTileId).toBe('t2');
   });
+
+  it('blocks placement when active slot is in wrong state (double-tap guard)', () => {
+    // Scenario: wrong tile was just placed in zone 0 (lock-auto-eject) —
+    // isWrong=true, placedTileId=null. A second tap should NOT advance to zone 1.
+    const wrongZones: AnswerZone[] = [
+      {
+        id: 'z0',
+        index: 0,
+        expectedValue: 'C',
+        placedTileId: null,
+        isWrong: true,
+        isLocked: true,
+      },
+      {
+        id: 'z1',
+        index: 1,
+        expectedValue: 'A',
+        placedTileId: null,
+        isWrong: false,
+        isLocked: false,
+      },
+    ];
+
+    function useHarnessWithWrongZone() {
+      const dispatch = useAnswerGameDispatch();
+      const state = useAnswerGameContext();
+      if (state.zones.length === 0)
+        dispatch({
+          type: 'INIT_ROUND',
+          tiles: tileItems,
+          zones: wrongZones,
+        });
+      const { placeInNextSlot } = useAutoNextSlot();
+      return { state, placeInNextSlot };
+    }
+
+    const WrongWrapper = ({ children }: { children: ReactNode }) => (
+      <AnswerGameProvider config={gameConfig}>
+        {children}
+      </AnswerGameProvider>
+    );
+
+    const { result } = renderHook(() => useHarnessWithWrongZone(), {
+      wrapper: WrongWrapper,
+    });
+
+    act(() => result.current.placeInNextSlot('t2'));
+    // Zone 1 must stay empty — the guard blocked the placement
+    expect(result.current.state.zones[1]?.placedTileId).toBeNull();
+  });
 });

--- a/src/components/answer-game/useAutoNextSlot.test.tsx
+++ b/src/components/answer-game/useAutoNextSlot.test.tsx
@@ -187,4 +187,74 @@ describe('useAutoNextSlot', () => {
     // Zone 1 must stay empty — the guard blocked the placement
     expect(result.current.state.zones[1]?.placedTileId).toBeNull();
   });
+
+  it('wraps around to fill earlier empty slots after out-of-order drag placement', () => {
+    // Replicates "cat" scenario: user drags 'a' to slot 1, taps 't' into slot 2,
+    // then taps 'c' — activeSlotIndex is 2 (or beyond) but slot 0 is still empty.
+    // placeInNextSlot must wrap around and place 'c' in zone 0.
+    const threeZones: AnswerZone[] = [
+      {
+        id: 'z0',
+        index: 0,
+        expectedValue: 'C',
+        placedTileId: null, // still empty
+        isWrong: false,
+        isLocked: false,
+      },
+      {
+        id: 'z1',
+        index: 1,
+        expectedValue: 'A',
+        placedTileId: 't2', // already filled out-of-order
+        isWrong: false,
+        isLocked: false,
+      },
+      {
+        id: 'z2',
+        index: 2,
+        expectedValue: 'X',
+        placedTileId: null,
+        isWrong: false,
+        isLocked: false,
+      },
+    ];
+
+    const threeItems: TileItem[] = [
+      { id: 't1', label: 'C', value: 'C' },
+      { id: 't2', label: 'A', value: 'A' },
+      { id: 't3', label: 'X', value: 'X' },
+    ];
+
+    function useHarnessThreeZones() {
+      const dispatch = useAnswerGameDispatch();
+      const state = useAnswerGameContext();
+      if (state.zones.length === 0) {
+        dispatch({
+          type: 'INIT_ROUND',
+          tiles: threeItems,
+          zones: threeZones,
+        });
+        // Simulate activeSlotIndex already at 2 (as if zone 1 was filled via drag)
+        dispatch({ type: 'PLACE_TILE', tileId: 't2', zoneIndex: 1 });
+      }
+      const { placeInNextSlot } = useAutoNextSlot();
+      return { state, placeInNextSlot };
+    }
+
+    const ThreeWrapper = ({ children }: { children: ReactNode }) => (
+      <AnswerGameProvider config={gameConfig}>
+        {children}
+      </AnswerGameProvider>
+    );
+
+    const { result } = renderHook(() => useHarnessThreeZones(), {
+      wrapper: ThreeWrapper,
+    });
+
+    // activeSlotIndex is 2; zones[2] is empty so first call fills zone 2
+    act(() => result.current.placeInNextSlot('t3'));
+    // Now zones[0] is still empty and activeSlotIndex should wrap around
+    act(() => result.current.placeInNextSlot('t1'));
+    expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+  });
 });

--- a/src/components/answer-game/useAutoNextSlot.ts
+++ b/src/components/answer-game/useAutoNextSlot.ts
@@ -17,12 +17,23 @@ export const useAutoNextSlot = (): AutoNextSlot => {
       // clears. This prevents double/triple taps from skipping past the slot.
       if (zones[activeSlotIndex]?.isWrong) return;
 
-      const targetIndex = zones.findIndex(
+      // Look for the next available slot from activeSlotIndex forward...
+      let targetIndex = zones.findIndex(
         (z, i) =>
           i >= activeSlotIndex &&
           z.placedTileId === null &&
           !z.isLocked,
       );
+
+      // ...and wrap around if needed. This handles out-of-order placements
+      // (e.g. via drag) where earlier slots were left empty and activeSlotIndex
+      // has already advanced past them.
+      if (targetIndex === -1) {
+        targetIndex = zones.findIndex(
+          (z) => z.placedTileId === null && !z.isLocked,
+        );
+      }
+
       if (targetIndex === -1) return;
       placeTile(tileId, targetIndex);
     },

--- a/src/components/answer-game/useAutoNextSlot.ts
+++ b/src/components/answer-game/useAutoNextSlot.ts
@@ -12,6 +12,11 @@ export const useAutoNextSlot = (): AutoNextSlot => {
 
   const placeInNextSlot = useCallback(
     (tileId: string) => {
+      // Guard: if the active slot is in a wrong state (e.g. a wrong tile was
+      // just placed with lock-auto-eject), block further placements until it
+      // clears. This prevents double/triple taps from skipping past the slot.
+      if (zones[activeSlotIndex]?.isWrong) return;
+
       const targetIndex = zones.findIndex(
         (z, i) =>
           i >= activeSlotIndex &&

--- a/src/components/answer-game/useDraggableTile.test.tsx
+++ b/src/components/answer-game/useDraggableTile.test.tsx
@@ -45,13 +45,23 @@ vi.mock('./useAnswerGameDispatch', () => ({
   useAnswerGameDispatch: () => vi.fn(),
 }));
 
+const mockPlaceTile = vi.fn();
+
+vi.mock('./useTileEvaluation', () => ({
+  useTileEvaluation: () => ({ placeTile: mockPlaceTile }),
+}));
+
 describe('useDraggableTile', () => {
   const tile = { id: 't1', label: 'C', value: 'c' };
 
-  it('returns a ref and handleClick', () => {
+  it('returns a ref, handleClick, and touch handlers', () => {
     const { result } = renderHook(() => useDraggableTile(tile));
     expect(result.current.ref).toBeDefined();
     expect(typeof result.current.handleClick).toBe('function');
+    expect(typeof result.current.onPointerDown).toBe('function');
+    expect(typeof result.current.onPointerMove).toBe('function');
+    expect(typeof result.current.onPointerUp).toBe('function');
+    expect(typeof result.current.onPointerCancel).toBe('function');
   });
 
   it('handleClick does not throw', () => {

--- a/src/components/answer-game/useDraggableTile.ts
+++ b/src/components/answer-game/useDraggableTile.ts
@@ -2,10 +2,13 @@ import { draggable } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { useEffect, useRef } from 'react';
 import { useAutoNextSlot } from './useAutoNextSlot';
 import { useGameTTS } from './useGameTTS';
+import { useTileEvaluation } from './useTileEvaluation';
+import { useTouchDrag } from './useTouchDrag';
 import type { TileItem } from './types';
+import type { TouchDragHandlers } from './useTouchDrag';
 import type { RefObject } from 'react';
 
-export interface DraggableTile {
+export interface DraggableTile extends TouchDragHandlers {
   ref: RefObject<HTMLButtonElement | null>;
   handleClick: () => void;
 }
@@ -15,11 +18,13 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
   const { placeInNextSlot } = useAutoNextSlot();
   const { speakTile } = useGameTTS();
   const speakTileRef = useRef(speakTile);
+  const { placeTile } = useTileEvaluation();
 
   useEffect(() => {
     speakTileRef.current = speakTile;
   }, [speakTile]);
 
+  // HTML5 DnD — desktop
   useEffect(() => {
     const element = ref.current;
     if (!element) return;
@@ -30,10 +35,26 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
     });
   }, [tile.id, tile.label]);
 
+  // Pointer-events drag — touch / mobile
+  const { onPointerDown, onPointerMove, onPointerUp, onPointerCancel } =
+    useTouchDrag({
+      tileId: tile.id,
+      label: tile.label,
+      onDragStart: () => speakTileRef.current(tile.label),
+      onDrop: (tileId, zoneIndex) => placeTile(tileId, zoneIndex),
+    });
+
   const handleClick = () => {
     speakTile(tile.label);
     placeInNextSlot(tile.id);
   };
 
-  return { ref, handleClick };
+  return {
+    ref,
+    handleClick,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+  };
 };

--- a/src/components/answer-game/useSlotTileDrag.ts
+++ b/src/components/answer-game/useSlotTileDrag.ts
@@ -1,0 +1,72 @@
+import { draggable } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { useEffect, useRef } from 'react';
+import { useAnswerGameDispatch } from './useAnswerGameDispatch';
+import { useTouchDrag } from './useTouchDrag';
+import type { TouchDragHandlers } from './useTouchDrag';
+import type { RefObject } from 'react';
+
+export interface SlotTileDrag extends TouchDragHandlers {
+  dragRef: RefObject<HTMLButtonElement | null>;
+}
+
+interface UseSlotTileDragOptions {
+  /** ID of the tile currently in this slot. Null = slot is empty (drag disabled). */
+  tileId: string | null;
+  label: string | null;
+  zoneIndex: number;
+  /**
+   * Called when the dragged tile is dropped on a target zone.
+   * By this point REMOVE_TILE has already been dispatched, so the tile is back
+   * in the bank and can be placed normally.
+   */
+  onDrop: (tileId: string, targetZoneIndex: number) => void;
+}
+
+/**
+ * Enables an occupied slot tile to be dragged back to the bank or to another
+ * slot. Works with both the HTML5 DnD (desktop) and pointer-events drag (touch).
+ *
+ * On drag start the tile is immediately returned to the bank via REMOVE_TILE so
+ * that the subsequent PLACE_TILE from the drop target works with standard bank
+ * tile logic.
+ */
+export const useSlotTileDrag = ({
+  tileId,
+  label,
+  zoneIndex,
+  onDrop,
+}: UseSlotTileDragOptions): SlotTileDrag => {
+  const dispatch = useAnswerGameDispatch();
+  const dragRef = useRef<HTMLButtonElement>(null);
+
+  // HTML5 DnD — desktop
+  useEffect(() => {
+    if (!tileId) return;
+    const element = dragRef.current;
+    if (!element) return;
+    return draggable({
+      element,
+      getInitialData: () => ({ tileId }),
+      onDragStart: () => dispatch({ type: 'REMOVE_TILE', zoneIndex }),
+    });
+  }, [tileId, zoneIndex, dispatch]);
+
+  // Pointer-events drag — touch / mobile
+  const { onPointerDown, onPointerMove, onPointerUp, onPointerCancel } =
+    useTouchDrag({
+      tileId: tileId ?? '',
+      label: label ?? '',
+      onDragStart: tileId
+        ? () => dispatch({ type: 'REMOVE_TILE', zoneIndex })
+        : undefined,
+      onDrop,
+    });
+
+  return {
+    dragRef,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+  };
+};

--- a/src/components/answer-game/useTouchDrag.ts
+++ b/src/components/answer-game/useTouchDrag.ts
@@ -1,0 +1,166 @@
+import { useCallback, useRef } from 'react';
+import type { PointerEvent } from 'react';
+
+const DRAG_THRESHOLD_PX = 8;
+
+interface GhostInfo {
+  el: HTMLDivElement;
+  halfW: number;
+  halfH: number;
+}
+
+const buildGhost = (
+  sourceEl: HTMLElement,
+  label: string,
+  x: number,
+  y: number,
+): GhostInfo => {
+  const rect = sourceEl.getBoundingClientRect();
+  const halfW = rect.width / 2;
+  const halfH = rect.height / 2;
+  const el = document.createElement('div');
+  el.textContent = label;
+  el.setAttribute('aria-hidden', 'true');
+  Object.assign(el.style, {
+    position: 'fixed',
+    left: `${x - halfW}px`,
+    top: `${y - halfH}px`,
+    width: `${rect.width}px`,
+    height: `${rect.height}px`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '12px',
+    background: 'var(--card, #fff)',
+    color: 'var(--card-foreground, #000)',
+    fontSize: getComputedStyle(sourceEl).fontSize,
+    fontWeight: 'bold',
+    boxShadow: '0 8px 24px rgba(0,0,0,0.25)',
+    pointerEvents: 'none',
+    zIndex: '9999',
+    opacity: '0.95',
+    userSelect: 'none',
+    transform: 'scale(1.05)',
+  });
+  document.body.append(el);
+  return { el, halfW, halfH };
+};
+
+export interface TouchDragHandlers {
+  onPointerDown: (e: PointerEvent<HTMLElement>) => void;
+  onPointerMove: (e: PointerEvent<HTMLElement>) => void;
+  onPointerUp: (e: PointerEvent<HTMLElement>) => void;
+  onPointerCancel: (e: PointerEvent<HTMLElement>) => void;
+}
+
+interface UseTouchDragOptions {
+  /** Empty string disables the drag (no pointer capture, no ghost). */
+  tileId: string;
+  label: string;
+  onDragStart?: () => void;
+  onDrop: (tileId: string, zoneIndex: number) => void;
+}
+
+export const useTouchDrag = ({
+  tileId,
+  label,
+  onDragStart,
+  onDrop,
+}: UseTouchDragOptions): TouchDragHandlers => {
+  const ghostRef = useRef<GhostInfo | null>(null);
+  const isDragging = useRef(false);
+  const startPos = useRef<{ x: number; y: number } | null>(null);
+
+  const cleanup = useCallback(() => {
+    ghostRef.current?.el.remove();
+    ghostRef.current = null;
+    isDragging.current = false;
+    startPos.current = null;
+  }, []);
+
+  const onPointerDown = useCallback(
+    (e: PointerEvent<HTMLElement>) => {
+      if (e.pointerType === 'mouse' || !tileId) return;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      startPos.current = { x: e.clientX, y: e.clientY };
+      isDragging.current = false;
+    },
+    [tileId],
+  );
+
+  const onPointerMove = useCallback(
+    (e: PointerEvent<HTMLElement>) => {
+      if (e.pointerType === 'mouse' || !startPos.current) return;
+
+      if (!isDragging.current) {
+        const dx = e.clientX - startPos.current.x;
+        const dy = e.clientY - startPos.current.y;
+        if (
+          Math.abs(dx) > DRAG_THRESHOLD_PX ||
+          Math.abs(dy) > DRAG_THRESHOLD_PX
+        ) {
+          isDragging.current = true;
+          ghostRef.current = buildGhost(
+            e.currentTarget,
+            label,
+            e.clientX,
+            e.clientY,
+          );
+          onDragStart?.();
+        }
+      }
+
+      if (isDragging.current && ghostRef.current) {
+        const { el, halfW, halfH } = ghostRef.current;
+        el.style.left = `${e.clientX - halfW}px`;
+        el.style.top = `${e.clientY - halfH}px`;
+      }
+    },
+    [label, onDragStart],
+  );
+
+  const onPointerUp = useCallback(
+    (e: PointerEvent<HTMLElement>) => {
+      if (e.pointerType === 'mouse' || !startPos.current) return;
+
+      if (isDragging.current) {
+        // Remove ghost before elementsFromPoint so it doesn't interfere.
+        ghostRef.current?.el.remove();
+        ghostRef.current = null;
+
+        const elements = document.elementsFromPoint(
+          e.clientX,
+          e.clientY,
+        );
+        for (const el of elements) {
+          if (
+            el instanceof HTMLElement &&
+            el.dataset['zoneIndex'] !== undefined
+          ) {
+            const zoneIndex = Number.parseInt(
+              el.dataset['zoneIndex'],
+              10,
+            );
+            if (!Number.isNaN(zoneIndex)) {
+              onDrop(tileId, zoneIndex);
+              break;
+            }
+          }
+        }
+      }
+
+      cleanup();
+    },
+    [tileId, onDrop, cleanup],
+  );
+
+  const onPointerCancel = useCallback(
+    (e: PointerEvent<HTMLElement>) => {
+      if (e.pointerType === 'mouse') return;
+      cleanup();
+    },
+    [cleanup],
+  );
+
+  return { onPointerDown, onPointerMove, onPointerUp, onPointerCancel };
+};

--- a/src/games/number-match/MatchingPairZones/MatchingPairZones.tsx
+++ b/src/games/number-match/MatchingPairZones/MatchingPairZones.tsx
@@ -1,20 +1,26 @@
 import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { useEffect, useRef } from 'react';
 import { useAnswerGameContext } from '@/components/answer-game/useAnswerGameContext';
+import { useAnswerGameDispatch } from '@/components/answer-game/useAnswerGameDispatch';
 import { useFreeSwap } from '@/components/answer-game/useFreeSwap';
+import { useSlotTileDrag } from '@/components/answer-game/useSlotTileDrag';
 
 const PairZone = ({
   zoneIndex,
+  tileId,
   label,
   isWrong,
 }: {
   zoneIndex: number;
+  tileId: string | null;
   label: string | null;
   isWrong: boolean;
 }) => {
   const ref = useRef<HTMLLIElement>(null);
   const { swapOrPlace } = useFreeSwap();
+  const dispatch = useAnswerGameDispatch();
 
+  // Drop target for HTML5 DnD (bank tiles dragged in via desktop)
   useEffect(() => {
     const element = ref.current;
     if (!element) return;
@@ -22,20 +28,44 @@ const PairZone = ({
       element,
       getData: () => ({ zoneIndex }),
       onDrop: ({ source }) => {
-        const tileId = source.data['tileId'];
-        if (typeof tileId === 'string') swapOrPlace(tileId, zoneIndex);
+        const sourceTileId = source.data['tileId'];
+        if (typeof sourceTileId === 'string')
+          swapOrPlace(sourceTileId, zoneIndex);
       },
     });
   }, [zoneIndex, swapOrPlace]);
+
+  // Drag source for placed tiles — touch drag & HTML5 DnD
+  // REMOVE_TILE is dispatched on drag start so the tile is back in the bank
+  // when the drop target fires, keeping the swap/place logic consistent.
+  const {
+    dragRef,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+  } = useSlotTileDrag({
+    tileId,
+    label,
+    zoneIndex,
+    onDrop: (droppedTileId, targetZoneIndex) =>
+      swapOrPlace(droppedTileId, targetZoneIndex),
+  });
 
   const ariaLabel = label
     ? `Zone ${zoneIndex + 1}, filled with ${label}`
     : `Zone ${zoneIndex + 1}, empty`;
 
+  // Tap any placed tile to return it to the bank
+  const handleClick = () => {
+    if (tileId) dispatch({ type: 'REMOVE_TILE', zoneIndex });
+  };
+
   return (
     <li
       ref={ref}
       aria-label={ariaLabel}
+      data-zone-index={zoneIndex}
       className={[
         'flex size-20 items-center justify-center rounded-2xl border-2 text-3xl font-bold transition-all',
         isWrong
@@ -47,7 +77,21 @@ const PairZone = ({
         .filter(Boolean)
         .join(' ')}
     >
-      {label ?? ''}
+      {label ? (
+        <button
+          ref={dragRef}
+          type="button"
+          aria-label={ariaLabel}
+          className="flex size-full touch-none select-none cursor-grab items-center justify-center"
+          onClick={handleClick}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerCancel}
+        >
+          {label}
+        </button>
+      ) : null}
     </li>
   );
 };
@@ -68,6 +112,7 @@ export const MatchingPairZones = () => {
           <PairZone
             key={zone.id}
             zoneIndex={i}
+            tileId={zone.placedTileId}
             label={placedTile?.label ?? null}
             isWrong={zone.isWrong}
           />

--- a/src/games/number-match/NumeralTileBank/NumeralTileBank.tsx
+++ b/src/games/number-match/NumeralTileBank/NumeralTileBank.tsx
@@ -67,7 +67,14 @@ const NumeralTile = ({
   tile: TileItem;
   tileStyle: TileStyle;
 }) => {
-  const { ref, handleClick } = useDraggableTile(tile);
+  const {
+    ref,
+    handleClick,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+  } = useDraggableTile(tile);
   const numericValue = Number.parseInt(tile.value, 10);
 
   const isDomino =
@@ -82,10 +89,14 @@ const NumeralTile = ({
       type="button"
       aria-label={`Number ${tile.label}`}
       className={[
-        'flex shrink-0 cursor-grab flex-col items-center justify-center gap-0.5 rounded-2xl bg-card p-2 shadow-md transition-transform active:scale-95 active:cursor-grabbing',
+        'flex shrink-0 touch-none select-none cursor-grab flex-col items-center justify-center gap-0.5 rounded-2xl bg-card p-2 shadow-md transition-transform active:scale-95 active:cursor-grabbing',
         isDomino ? 'h-[72px] w-32' : 'size-20',
       ].join(' ')}
       onClick={handleClick}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
     >
       {tileStyle === 'dots' && !Number.isNaN(numericValue) ? (
         numericValue <= 6 ? (

--- a/src/games/sort-numbers/NumberSequenceSlots/NumberSequenceSlots.tsx
+++ b/src/games/sort-numbers/NumberSequenceSlots/NumberSequenceSlots.tsx
@@ -2,15 +2,18 @@ import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element
 import { useEffect, useRef } from 'react';
 import { useAnswerGameContext } from '@/components/answer-game/useAnswerGameContext';
 import { useAnswerGameDispatch } from '@/components/answer-game/useAnswerGameDispatch';
+import { useSlotTileDrag } from '@/components/answer-game/useSlotTileDrag';
 import { useTileEvaluation } from '@/components/answer-game/useTileEvaluation';
 
 const NumberSlot = ({
   zoneIndex,
+  tileId,
   label,
   isActive,
   isWrong,
 }: {
   zoneIndex: number;
+  tileId: string | null;
   label: string | null;
   isActive: boolean;
   isWrong: boolean;
@@ -19,6 +22,7 @@ const NumberSlot = ({
   const { placeTile } = useTileEvaluation();
   const dispatch = useAnswerGameDispatch();
 
+  // Drop target for HTML5 DnD (bank tiles dragged in via desktop)
   useEffect(() => {
     const element = ref.current;
     if (!element) return;
@@ -26,28 +30,42 @@ const NumberSlot = ({
       element,
       getData: () => ({ zoneIndex }),
       onDrop: ({ source }) => {
-        const tileId = source.data['tileId'];
-        if (typeof tileId === 'string') placeTile(tileId, zoneIndex);
+        const sourceTileId = source.data['tileId'];
+        if (typeof sourceTileId === 'string')
+          placeTile(sourceTileId, zoneIndex);
       },
     });
   }, [zoneIndex, placeTile]);
+
+  // Drag source for placed tiles — touch drag & HTML5 DnD
+  const {
+    dragRef,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+  } = useSlotTileDrag({
+    tileId,
+    label,
+    zoneIndex,
+    onDrop: (droppedTileId, targetZoneIndex) =>
+      placeTile(droppedTileId, targetZoneIndex),
+  });
 
   const ariaLabel = label
     ? `Slot ${zoneIndex + 1}, filled with ${label}`
     : `Slot ${zoneIndex + 1}, empty`;
 
+  // Tap any placed tile to return it to the bank
   const handleClick = () => {
-    if (isWrong) dispatch({ type: 'EJECT_TILE', zoneIndex });
-  };
-
-  const handleKeyDown = (e: { key: string }) => {
-    if (isWrong && (e.key === 'Enter' || e.key === ' ')) handleClick();
+    if (tileId) dispatch({ type: 'REMOVE_TILE', zoneIndex });
   };
 
   return (
     <li
       ref={ref}
       aria-label={ariaLabel}
+      data-zone-index={zoneIndex}
       data-active={isActive || undefined}
       data-wrong={isWrong || undefined}
       className={[
@@ -57,7 +75,7 @@ const NumberSlot = ({
           ? 'animate-pulse ring-2 ring-primary ring-offset-2'
           : '',
         isWrong
-          ? 'cursor-pointer border-destructive bg-destructive/10 text-destructive'
+          ? 'border-destructive bg-destructive/10 text-destructive'
           : '',
         label && !isWrong
           ? 'border-primary bg-primary/10 text-primary'
@@ -66,19 +84,21 @@ const NumberSlot = ({
         .filter(Boolean)
         .join(' ')}
     >
-      {isWrong ? (
+      {label ? (
         <button
+          ref={dragRef}
           type="button"
           aria-label={ariaLabel}
-          className="flex size-full items-center justify-center"
+          className="flex size-full touch-none select-none cursor-grab items-center justify-center"
           onClick={handleClick}
-          onKeyDown={handleKeyDown}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerCancel}
         >
-          {label ?? ''}
+          {label}
         </button>
-      ) : (
-        (label ?? '')
-      )}
+      ) : null}
     </li>
   );
 };
@@ -99,6 +119,7 @@ export const NumberSequenceSlots = () => {
           <NumberSlot
             key={zone.id}
             zoneIndex={i}
+            tileId={zone.placedTileId}
             label={placedTile?.label ?? null}
             isActive={
               i === activeSlotIndex && zone.placedTileId === null

--- a/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.tsx
+++ b/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.tsx
@@ -3,15 +3,26 @@ import { useAnswerGameContext } from '@/components/answer-game/useAnswerGameCont
 import { useDraggableTile } from '@/components/answer-game/useDraggableTile';
 
 const NumberTile = ({ tile }: { tile: TileItem }) => {
-  const { ref, handleClick } = useDraggableTile(tile);
+  const {
+    ref,
+    handleClick,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+  } = useDraggableTile(tile);
 
   return (
     <button
       ref={ref}
       type="button"
       aria-label={`Number ${tile.label}`}
-      className="flex size-14 cursor-grab items-center justify-center rounded-xl bg-card text-2xl font-bold shadow-md transition-transform active:scale-95 active:cursor-grabbing"
+      className="flex size-14 touch-none select-none cursor-grab items-center justify-center rounded-xl bg-card text-2xl font-bold shadow-md transition-transform active:scale-95 active:cursor-grabbing"
       onClick={handleClick}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
     >
       {tile.label}
     </button>

--- a/src/games/word-spell/LetterTileBank/LetterTileBank.tsx
+++ b/src/games/word-spell/LetterTileBank/LetterTileBank.tsx
@@ -3,15 +3,26 @@ import { useAnswerGameContext } from '@/components/answer-game/useAnswerGameCont
 import { useDraggableTile } from '@/components/answer-game/useDraggableTile';
 
 const LetterTile = ({ tile }: { tile: TileItem }) => {
-  const { ref, handleClick } = useDraggableTile(tile);
+  const {
+    ref,
+    handleClick,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+  } = useDraggableTile(tile);
 
   return (
     <button
       ref={ref}
       type="button"
       aria-label={`Letter ${tile.label}`}
-      className="flex size-14 cursor-grab items-center justify-center rounded-xl bg-card text-2xl font-bold shadow-md transition-transform active:scale-95 active:cursor-grabbing"
+      className="flex size-14 touch-none select-none cursor-grab items-center justify-center rounded-xl bg-card text-2xl font-bold shadow-md transition-transform active:scale-95 active:cursor-grabbing"
       onClick={handleClick}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
     >
       {tile.label}
     </button>

--- a/src/games/word-spell/OrderedLetterSlots/OrderedLetterSlots.tsx
+++ b/src/games/word-spell/OrderedLetterSlots/OrderedLetterSlots.tsx
@@ -2,15 +2,18 @@ import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element
 import { useEffect, useRef } from 'react';
 import { useAnswerGameContext } from '@/components/answer-game/useAnswerGameContext';
 import { useAnswerGameDispatch } from '@/components/answer-game/useAnswerGameDispatch';
+import { useSlotTileDrag } from '@/components/answer-game/useSlotTileDrag';
 import { useTileEvaluation } from '@/components/answer-game/useTileEvaluation';
 
 const LetterSlot = ({
   zoneIndex,
+  tileId,
   label,
   isActive,
   isWrong,
 }: {
   zoneIndex: number;
+  tileId: string | null;
   label: string | null;
   isActive: boolean;
   isWrong: boolean;
@@ -19,6 +22,7 @@ const LetterSlot = ({
   const { placeTile } = useTileEvaluation();
   const dispatch = useAnswerGameDispatch();
 
+  // Drop target for HTML5 DnD (bank tiles dragged in via desktop)
   useEffect(() => {
     const element = ref.current;
     if (!element) return;
@@ -26,28 +30,42 @@ const LetterSlot = ({
       element,
       getData: () => ({ zoneIndex }),
       onDrop: ({ source }) => {
-        const tileId = source.data['tileId'];
-        if (typeof tileId === 'string') placeTile(tileId, zoneIndex);
+        const sourceTileId = source.data['tileId'];
+        if (typeof sourceTileId === 'string')
+          placeTile(sourceTileId, zoneIndex);
       },
     });
   }, [zoneIndex, placeTile]);
+
+  // Drag source for placed tiles — touch drag & HTML5 DnD
+  const {
+    dragRef,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+  } = useSlotTileDrag({
+    tileId,
+    label,
+    zoneIndex,
+    onDrop: (droppedTileId, targetZoneIndex) =>
+      placeTile(droppedTileId, targetZoneIndex),
+  });
 
   const ariaLabel = label
     ? `Slot ${zoneIndex + 1}, filled with ${label}`
     : `Slot ${zoneIndex + 1}, empty`;
 
+  // Tap any placed tile to return it to the bank
   const handleClick = () => {
-    if (isWrong) dispatch({ type: 'EJECT_TILE', zoneIndex });
-  };
-
-  const handleKeyDown = (e: { key: string }) => {
-    if (isWrong && (e.key === 'Enter' || e.key === ' ')) handleClick();
+    if (tileId) dispatch({ type: 'REMOVE_TILE', zoneIndex });
   };
 
   return (
     <li
       ref={ref}
       aria-label={ariaLabel}
+      data-zone-index={zoneIndex}
       data-active={isActive || undefined}
       data-wrong={isWrong || undefined}
       className={[
@@ -57,7 +75,7 @@ const LetterSlot = ({
           ? 'ring-2 ring-primary ring-offset-2 animate-pulse'
           : '',
         isWrong
-          ? 'cursor-pointer border-destructive bg-destructive/10 text-destructive'
+          ? 'border-destructive bg-destructive/10 text-destructive'
           : '',
         label && !isWrong
           ? 'border-primary bg-primary/10 text-primary'
@@ -66,19 +84,21 @@ const LetterSlot = ({
         .filter(Boolean)
         .join(' ')}
     >
-      {isWrong ? (
+      {label ? (
         <button
+          ref={dragRef}
           type="button"
           aria-label={ariaLabel}
-          className="flex size-full items-center justify-center"
+          className="flex size-full touch-none select-none cursor-grab items-center justify-center"
           onClick={handleClick}
-          onKeyDown={handleKeyDown}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerCancel}
         >
-          {label ?? ''}
+          {label}
         </button>
-      ) : (
-        (label ?? '')
-      )}
+      ) : null}
     </li>
   );
 };
@@ -99,6 +119,7 @@ export const OrderedLetterSlots = () => {
           <LetterSlot
             key={zone.id}
             zoneIndex={i}
+            tileId={zone.placedTileId}
             label={placedTile?.label ?? null}
             isActive={
               i === activeSlotIndex && zone.placedTileId === null


### PR DESCRIPTION
… bug

Three bugs fixed:

Bug 1 – Mobile drag/drop broken: `@atlaskit/pragmatic-drag-and-drop/element/adapter`
uses the HTML5 DnD API which doesn't fire on touch screens. Added `useTouchDrag`
hook that uses pointer events + `elementsFromPoint` to detect drop zones via a
`data-zone-index` attribute, with a visual ghost following the finger.
Applied to all bank tiles (LetterTile, NumberTile, NumeralTile) and slot tiles.

Bug 2 – Tiles not draggable from slots: slots were drop-targets only. Added
`useSlotTileDrag` hook that makes placed tiles draggable (HTML5 DnD on desktop,
pointer-events on touch). REMOVE_TILE fires on drag start so the tile re-enters
the bank before being placed in the target zone. Tapping any placed tile (correct
or wrong) also returns it to the bank via REMOVE_TILE.

Bug 3 – Double/triple tap skips past locked slot: `placeInNextSlot` used
`findIndex` that skipped the locked (wrong) active slot, advancing to the next
zone on each extra tap. Added an `isWrong` guard so placements are blocked while
the active slot is in a wrong state waiting to auto-eject.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>