### PR TITLE
fix(answer-game): show tile content while red during lock-auto-eject

### DIFF
--- a/src/components/answer-game/answer-game-reducer.test.ts
+++ b/src/components/answer-game/answer-game-reducer.test.ts
@@ -83,7 +83,7 @@ describe('answerGameReducer', () => {
     expect(next.retryCount).toBe(0);
   });
 
-  it('PLACE_TILE wrong: tile stays in bank, zone marked wrong, retryCount incremented', () => {
+  it('PLACE_TILE wrong (lock-auto-eject): tile placed in slot, removed from bank, zone marked wrong', () => {
     const state = answerGameReducer(makeInitialState(config), {
       type: 'INIT_ROUND',
       tiles,
@@ -94,7 +94,8 @@ describe('answerGameReducer', () => {
       tileId: 't2',
       zoneIndex: 0,
     });
-    expect(next.bankTileIds).toContain('t2');
+    expect(next.zones[0]!.placedTileId).toBe('t2');
+    expect(next.bankTileIds).not.toContain('t2');
     expect(next.zones[0]!.isWrong).toBe(true);
     expect(next.zones[0]!.isLocked).toBe(true);
     expect(next.retryCount).toBe(1);
@@ -228,7 +229,10 @@ describe('answerGameReducer', () => {
       tileId: 't2',
       zoneIndex: 0,
     });
+    // tile is visible in the slot while wrong (content displayed in red)
+    expect(state.zones[0]!.placedTileId).toBe('t2');
     expect(state.zones[0]!.isWrong).toBe(true);
+    expect(state.bankTileIds).not.toContain('t2');
     state = answerGameReducer(state, {
       type: 'EJECT_TILE',
       zoneIndex: 0,

--- a/src/components/answer-game/answer-game-reducer.ts
+++ b/src/components/answer-game/answer-game-reducer.ts
@@ -94,22 +94,23 @@ export function answerGameReducer(
         };
       }
 
-      const lockManual =
-        state.config.wrongTileBehavior === 'lock-manual';
+      const shouldLock =
+        state.config.wrongTileBehavior === 'lock-manual' ||
+        state.config.wrongTileBehavior === 'lock-auto-eject';
       const newZone: AnswerZone = {
         ...zone,
-        placedTileId: lockManual ? action.tileId : zone.placedTileId,
+        placedTileId: shouldLock ? action.tileId : zone.placedTileId,
         isWrong: true,
         isLocked: true,
       };
       const newZones = state.zones.map((z, i) =>
         i === action.zoneIndex ? newZone : z,
       );
-      let newBankTileIds = lockManual
+      let newBankTileIds = shouldLock
         ? state.bankTileIds.filter((id) => id !== action.tileId)
         : state.bankTileIds;
       if (
-        lockManual &&
+        shouldLock &&
         zone.placedTileId &&
         zone.placedTileId !== action.tileId
       ) {


### PR DESCRIPTION
## Summary

- Wrong tiles placed with `lock-auto-eject` were not stored in the zone's `placedTileId`, so the slot turned red but showed no content
- Root cause: the reducer only set `placedTileId` and removed the tile from the bank for `lock-manual`, not `lock-auto-eject`
- Fix: unify both behaviors — tile moves into the slot (visible in red) and is removed from the bank; the auto-eject timer returns it via the existing `EJECT_TILE` path

## Test plan

- [x] Updated existing test to assert tile IS placed in slot during wrong state (was passing accidentally due to the bug)
- [x] Renamed test description to reflect correct expected behavior
- [x] 265/265 unit tests pass
- [x] Lint, typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)