### PR TITLE
fix(drag): bank tile hover preview + tile-place sound on return to bank

### DIFF
--- a/src/components/answer-game/Slot/Slot.test.tsx
+++ b/src/components/answer-game/Slot/Slot.test.tsx
@@ -1,12 +1,18 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { useEffect } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AnswerGameProvider } from '../AnswerGameProvider';
 import { useAnswerGameDispatch } from '../useAnswerGameDispatch';
 import { Slot } from './Slot';
-import type { AnswerGameConfig, AnswerZone, TileItem } from '../types';
+import type {
+  AnswerGameAction,
+  AnswerGameConfig,
+  AnswerZone,
+  TileItem,
+} from '../types';
 import type { SlotRenderProps } from './useSlotBehavior';
-import type { ReactNode } from 'react';
+import type { Dispatch, ReactNode } from 'react';
+import { playSound } from '@/lib/audio/AudioFeedback';
 
 vi.mock('@/lib/game-event-bus', () => ({
   getGameEventBus: () => ({ emit: vi.fn(), subscribe: vi.fn() }),
@@ -96,6 +102,18 @@ function createWrapper(
   Provider.displayName = 'AnswerGameTestWrapper';
   return Provider;
 }
+
+const dispatchHolderRef: {
+  current: Dispatch<AnswerGameAction> | null;
+} = { current: null };
+
+const CaptureDispatch = () => {
+  const dispatch = useAnswerGameDispatch();
+  useEffect(() => {
+    dispatchHolderRef.current = dispatch;
+  }, [dispatch]);
+  return null;
+};
 
 describe('Slot', () => {
   it('renders as li by default', () => {
@@ -198,5 +216,85 @@ describe('Slot', () => {
       'aria-label',
       'Slot 1, filled with A',
     );
+  });
+
+  describe('tile-place sound when a tile leaves the slot', () => {
+    beforeEach(() => {
+      vi.mocked(playSound).mockClear();
+      dispatchHolderRef.current = null;
+    });
+
+    it("does not play 'tile-place' when the tile moves to another slot (swap)", () => {
+      const Wrapper = createWrapper(baseConfig, emptyZones);
+      render(
+        <Wrapper>
+          <CaptureDispatch />
+          <ol>
+            <Slot index={0}>
+              {({ label }: SlotRenderProps) => (
+                <span>{label ?? 'empty'}</span>
+              )}
+            </Slot>
+          </ol>
+        </Wrapper>,
+      );
+      act(() => {
+        dispatchHolderRef.current?.({
+          type: 'PLACE_TILE',
+          tileId: 'tile-1',
+          zoneIndex: 0,
+        });
+      });
+      act(() => {
+        dispatchHolderRef.current?.({
+          type: 'SET_DRAG_ACTIVE',
+          tileId: 'tile-1',
+        });
+      });
+      act(() => {
+        dispatchHolderRef.current?.({
+          type: 'SWAP_TILES',
+          fromZoneIndex: 0,
+          toZoneIndex: 1,
+        });
+      });
+      expect(playSound).not.toHaveBeenCalledWith('tile-place');
+    });
+
+    it("plays 'tile-place' when the tile returns to the bank (remove)", () => {
+      const Wrapper = createWrapper(baseConfig, emptyZones);
+      render(
+        <Wrapper>
+          <CaptureDispatch />
+          <ol>
+            <Slot index={0}>
+              {({ label }: SlotRenderProps) => (
+                <span>{label ?? 'empty'}</span>
+              )}
+            </Slot>
+          </ol>
+        </Wrapper>,
+      );
+      act(() => {
+        dispatchHolderRef.current?.({
+          type: 'PLACE_TILE',
+          tileId: 'tile-1',
+          zoneIndex: 0,
+        });
+      });
+      act(() => {
+        dispatchHolderRef.current?.({
+          type: 'SET_DRAG_ACTIVE',
+          tileId: 'tile-1',
+        });
+      });
+      act(() => {
+        dispatchHolderRef.current?.({
+          type: 'REMOVE_TILE',
+          zoneIndex: 0,
+        });
+      });
+      expect(playSound).toHaveBeenCalledWith('tile-place');
+    });
   });
 });

--- a/src/components/answer-game/Slot/useSlotBehavior.ts
+++ b/src/components/answer-game/Slot/useSlotBehavior.ts
@@ -47,6 +47,7 @@ export const useSlotBehavior = (
   const {
     zones,
     allTiles,
+    bankTileIds,
     activeSlotIndex,
     config,
     dragActiveTileId,
@@ -266,10 +267,13 @@ export const useSlotBehavior = (
       triggerPop(el);
     } else if (tileId === null && prevTileId !== null) {
       // Tile left this slot.
-      // If the tile that left matches the previously-active drag tile, this is
-      // a swap/move — the sound was already played in handleDrop.
-      const wasSwapOrMove = prevTileId === prevDragActiveTileId;
-      if (!wasSwapOrMove) {
+      // Suppress the sound only when the tile moved to another slot (swap/move),
+      // where handleDrop already played the sound. If the tile went back to the
+      // bank (REMOVE_TILE via drag), play 'tile-place' here.
+      const movedToSlot =
+        prevTileId === prevDragActiveTileId &&
+        !bankTileIds.includes(prevTileId);
+      if (!movedToSlot) {
         playSound('tile-place');
       }
       startFadeRef.current?.();
@@ -278,6 +282,7 @@ export const useSlotBehavior = (
   }, [
     isWrong,
     tileId,
+    bankTileIds,
     config.wrongTileBehavior,
     dragRef,
     dragActiveTileId,

--- a/src/components/answer-game/useBankDropTarget.test.tsx
+++ b/src/components/answer-game/useBankDropTarget.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useBankDropTarget } from './useBankDropTarget';
+
+const mockDropTargetForElements = vi.fn().mockReturnValue(() => {});
+
+vi.mock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
+  dropTargetForElements: (...args: unknown[]) =>
+    mockDropTargetForElements(...args),
+}));
+
+const BankHost = () => {
+  const { bankRef } = useBankDropTarget();
+  return (
+    <div ref={bankRef} data-testid="bank-root">
+      bank
+    </div>
+  );
+};
+
+describe('useBankDropTarget', () => {
+  it('registers a drop target on the bank container when mounted', () => {
+    mockDropTargetForElements.mockClear();
+    render(<BankHost />);
+    expect(screen.getByTestId('bank-root')).toBeInTheDocument();
+    expect(mockDropTargetForElements).toHaveBeenCalledTimes(1);
+    const args = mockDropTargetForElements.mock.calls[0]?.[0] as {
+      element: HTMLElement;
+    };
+    expect(args.element).toBeInstanceOf(HTMLElement);
+  });
+});

--- a/src/components/answer-game/useBankDropTarget.ts
+++ b/src/components/answer-game/useBankDropTarget.ts
@@ -1,5 +1,5 @@
 import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { RefObject } from 'react';
 
 /**
@@ -10,11 +10,18 @@ import type { RefObject } from 'react';
  * tile is dragged over it. The actual REMOVE_TILE dispatch is handled by
  * useSlotTileDrag's onDrop — the bank target intentionally carries no
  * zoneIndex so that path treats it as "return to bank".
+ *
+ * isDragOver is true while any drag is over the bank container. Bank
+ * components use this to show a dashed-border preview on the dragged
+ * tile's own hole when that tile came from a slot (its hole is not a
+ * registered drop target, so onDragEnter on the individual hole never fires).
  */
 export const useBankDropTarget = (): {
   bankRef: RefObject<HTMLDivElement | null>;
+  isDragOver: boolean;
 } => {
   const bankRef = useRef<HTMLDivElement>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
 
   useEffect(() => {
     const el = bankRef.current;
@@ -22,8 +29,11 @@ export const useBankDropTarget = (): {
     return dropTargetForElements({
       element: el,
       getData: () => ({ isBankTarget: true }),
+      onDragEnter: () => setIsDragOver(true),
+      onDragLeave: () => setIsDragOver(false),
+      onDrop: () => setIsDragOver(false),
     });
   }, []);
 
-  return { bankRef };
+  return { bankRef, isDragOver };
 };

--- a/src/components/answer-game/useDraggableTile.test.tsx
+++ b/src/components/answer-game/useDraggableTile.test.tsx
@@ -1,9 +1,16 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, render, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { AnswerGameProvider } from './AnswerGameProvider';
 import { useDraggableTile } from './useDraggableTile';
+import type { AnswerGameConfig } from './types';
+
+const mockDraggable = vi.fn().mockReturnValue(() => {});
+const mockDropTargetForElements = vi.fn().mockReturnValue(() => {});
 
 vi.mock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
-  draggable: vi.fn().mockReturnValue(() => {}),
+  draggable: (...args: unknown[]) => mockDraggable(...args),
+  dropTargetForElements: (...args: unknown[]) =>
+    mockDropTargetForElements(...args),
 }));
 
 const mockPlaceInNextSlot = vi.fn();
@@ -51,6 +58,26 @@ vi.mock('./useTileEvaluation', () => ({
   useTileEvaluation: () => ({ placeTile: mockPlaceTile }),
 }));
 
+const providerConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: false,
+};
+
+const hostTile = { id: 't1', label: 'C', value: 'c' };
+
+const DraggableHost = () => {
+  const { ref } = useDraggableTile(hostTile);
+  return (
+    <button ref={ref} type="button">
+      drag me
+    </button>
+  );
+};
+
 describe('useDraggableTile', () => {
   const tile = { id: 't1', label: 'C', value: 'c' };
 
@@ -81,5 +108,21 @@ describe('useDraggableTile', () => {
     const { result } = renderHook(() => useDraggableTile(tile));
     act(() => result.current.handleClick());
     expect(mockPlaceInNextSlot).toHaveBeenCalledWith(tile.id);
+  });
+
+  it('registers draggable and bank swap drop target when the button mounts', () => {
+    mockDraggable.mockClear();
+    mockDropTargetForElements.mockClear();
+    render(
+      <AnswerGameProvider config={providerConfig}>
+        <DraggableHost />
+      </AnswerGameProvider>,
+    );
+    expect(mockDraggable).toHaveBeenCalledTimes(1);
+    expect(mockDropTargetForElements).toHaveBeenCalledTimes(1);
+    const dropArgs = mockDropTargetForElements.mock.calls[0]?.[0] as {
+      onDragEnter: () => void;
+    };
+    expect(typeof dropArgs.onDragEnter).toBe('function');
   });
 });

--- a/src/components/answer-game/useDraggableTile.ts
+++ b/src/components/answer-game/useDraggableTile.ts
@@ -53,6 +53,8 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
       getData: () => ({ bankTileId: tile.id, isBankTarget: true }),
       onDragEnter: () =>
         dispatch({ type: 'SET_DRAG_HOVER_BANK', tileId: tile.id }),
+      onDragLeave: () =>
+        dispatch({ type: 'SET_DRAG_HOVER_BANK', tileId: null }),
     });
     return () => {
       cleanupDraggable();
@@ -75,6 +77,8 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
         dispatch({ type: 'SET_DRAG_ACTIVE', tileId: null });
         placeTile(droppedTileId, zoneIndex);
       },
+      onHoverZone: (zoneIndex) =>
+        dispatch({ type: 'SET_DRAG_HOVER', zoneIndex }),
     });
 
   const handleClick = () => {

--- a/src/games/number-match/NumeralTileBank/NumeralTileBank.stories.tsx
+++ b/src/games/number-match/NumeralTileBank/NumeralTileBank.stories.tsx
@@ -63,6 +63,33 @@ export default meta;
 
 type Story = StoryObj<typeof NumeralTileBank>;
 
-export const DotsStyle: Story = { args: { tileStyle: 'dots' } };
+export const Default: Story = { args: { tileStyle: 'dots' } };
 export const FingersStyle: Story = { args: { tileStyle: 'fingers' } };
 export const ObjectsStyle: Story = { args: { tileStyle: 'objects' } };
+
+const DragHoverBankTileSetup = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const dispatch = useAnswerGameDispatch();
+  dispatch({ type: 'INIT_ROUND', tiles, zones });
+  dispatch({ type: 'PLACE_TILE', tileId: 't1', zoneIndex: 0 });
+  dispatch({ type: 'SET_DRAG_ACTIVE', tileId: 't1' });
+  dispatch({ type: 'SET_DRAG_HOVER_BANK', tileId: 't2' });
+  return <>{children}</>;
+};
+
+export const DragHoverBankTile: Story = {
+  args: { tileStyle: 'dots' },
+  decorators: [
+    withDb,
+    (Story) => (
+      <AnswerGameProvider config={config}>
+        <DragHoverBankTileSetup>
+          <Story />
+        </DragHoverBankTileSetup>
+      </AnswerGameProvider>
+    ),
+  ],
+};

--- a/src/games/number-match/NumeralTileBank/NumeralTileBank.test.tsx
+++ b/src/games/number-match/NumeralTileBank/NumeralTileBank.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   DiceFace,
@@ -42,6 +43,17 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
     i18n: { language: 'en' },
+  }),
+}));
+
+const bankDropState = vi.hoisted(() => ({ isDragOver: false }));
+
+vi.mock('@/components/answer-game/useBankDropTarget', () => ({
+  useBankDropTarget: () => ({
+    bankRef: { current: null },
+    get isDragOver() {
+      return bankDropState.isDragOver;
+    },
   }),
 }));
 
@@ -123,6 +135,28 @@ describe('DominoTile', () => {
 describe('NumeralTileBank', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    bankDropState.isDragOver = false;
+  });
+
+  it('shows dashed hole preview when dragging a placed tile over the bank', () => {
+    bankDropState.isDragOver = true;
+    const Preview = () => {
+      const dispatch = useAnswerGameDispatch();
+      useEffect(() => {
+        dispatch({ type: 'INIT_ROUND', tiles, zones });
+        dispatch({ type: 'PLACE_TILE', tileId: 't1', zoneIndex: 0 });
+        dispatch({ type: 'SET_DRAG_ACTIVE', tileId: 't1' });
+      }, [dispatch]);
+      return <NumeralTileBank tileStyle="dots" />;
+    };
+    const { container } = render(
+      <AnswerGameProvider config={config}>
+        <Preview />
+      </AnswerGameProvider>,
+    );
+    const hole = container.querySelector('[data-tile-bank-hole="t1"]');
+    expect(hole?.className).toMatch(/border-dashed/);
+    expect(hole?.textContent).toContain('3');
   });
 
   it('renders tiles for all bank tile IDs', () => {

--- a/src/games/number-match/NumeralTileBank/NumeralTileBank.tsx
+++ b/src/games/number-match/NumeralTileBank/NumeralTileBank.tsx
@@ -197,7 +197,7 @@ export const NumeralTileBank = ({
             key={tile.id}
             data-tile-bank-hole={tile.id}
             className={[
-              'rounded-2xl bg-muted/60 shadow-inner transition-all',
+              'relative rounded-2xl bg-muted/60 shadow-inner transition-all',
               holeSizeClass,
               isHoverTarget
                 ? 'border-2 border-dashed border-primary'
@@ -206,7 +206,13 @@ export const NumeralTileBank = ({
               .filter(Boolean)
               .join(' ')}
             aria-hidden="true"
-          />
+          >
+            {isHoverTarget && (
+              <span className="absolute inset-0 flex items-center justify-center text-2xl font-bold opacity-50">
+                {tile.label}
+              </span>
+            )}
+          </div>
         );
       })}
     </div>

--- a/src/games/number-match/NumeralTileBank/NumeralTileBank.tsx
+++ b/src/games/number-match/NumeralTileBank/NumeralTileBank.tsx
@@ -149,20 +149,14 @@ export const NumeralTileBank = ({
         const numericValue = Number.parseInt(tile.value, 10);
         const isDomino = getIsDomino(tileStyle, numericValue);
         const holeSizeClass = isDomino ? 'h-[72px] w-32' : 'size-20';
-        const hoverClass = isHoverTarget
-          ? ' border-2 border-dashed border-primary'
-          : '';
 
         if (inBank) {
           return (
             <div
               key={tile.id}
               className={[
-                'relative transition-all',
+                'relative rounded-2xl transition-all',
                 holeSizeClass,
-                isHoverTarget
-                  ? 'rounded-2xl ring-2 ring-primary ring-offset-2'
-                  : '',
               ]
                 .filter(Boolean)
                 .join(' ')}
@@ -172,7 +166,6 @@ export const NumeralTileBank = ({
                 className={[
                   'rounded-2xl bg-muted/60 shadow-inner',
                   holeSizeClass,
-                  hoverClass,
                 ]
                   .filter(Boolean)
                   .join(' ')}
@@ -184,6 +177,12 @@ export const NumeralTileBank = ({
               >
                 <NumeralTile tile={tile} tileStyle={tileStyle} />
               </div>
+              {isHoverTarget && (
+                <div
+                  className="pointer-events-none absolute inset-0 rounded-2xl border-2 border-dashed border-primary"
+                  aria-hidden="true"
+                />
+              )}
             </div>
           );
         }
@@ -195,7 +194,9 @@ export const NumeralTileBank = ({
             className={[
               'rounded-2xl bg-muted/60 shadow-inner transition-all',
               holeSizeClass,
-              hoverClass,
+              isHoverTarget
+                ? 'border-2 border-dashed border-primary'
+                : '',
             ]
               .filter(Boolean)
               .join(' ')}

--- a/src/games/number-match/NumeralTileBank/NumeralTileBank.tsx
+++ b/src/games/number-match/NumeralTileBank/NumeralTileBank.tsx
@@ -135,7 +135,7 @@ export const NumeralTileBank = ({
     dragActiveTileId,
     dragHoverBankTileId,
   } = useAnswerGameContext();
-  const { bankRef } = useBankDropTarget();
+  const { bankRef, isDragOver } = useBankDropTarget();
   return (
     <div
       ref={bankRef}
@@ -145,7 +145,12 @@ export const NumeralTileBank = ({
       {allTiles.map((tile) => {
         const inBank = bankTileIds.includes(tile.id);
         const isDragging = tile.id === dragActiveTileId;
-        const isHoverTarget = tile.id === dragHoverBankTileId;
+        const isHoverTarget =
+          tile.id === dragHoverBankTileId ||
+          (!dragHoverBankTileId &&
+            isDragOver &&
+            !inBank &&
+            tile.id === dragActiveTileId);
         const numericValue = Number.parseInt(tile.value, 10);
         const isDomino = getIsDomino(tileStyle, numericValue);
         const holeSizeClass = isDomino ? 'h-[72px] w-32' : 'size-20';

--- a/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.stories.tsx
+++ b/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.stories.tsx
@@ -1,9 +1,12 @@
+import { useEffect } from 'react';
 import { withDarkMode } from '../../../../.storybook/decorators';
 import { withDb } from '../../../../.storybook/decorators/withDb';
 import { SortNumbersTileBank } from './SortNumbersTileBank';
 import type { AnswerGameConfig } from '@/components/answer-game/types';
 import type { Meta, StoryObj } from '@storybook/react';
+import type { ReactNode } from 'react';
 import { AnswerGameProvider } from '@/components/answer-game/AnswerGameProvider';
+import { useAnswerGameDispatch } from '@/components/answer-game/useAnswerGameDispatch';
 
 const config: AnswerGameConfig = {
   gameId: 'sort-numbers-story',
@@ -73,4 +76,32 @@ export const Default: Story = {};
 
 export const DefaultDark: Story = {
   decorators: [withDarkMode],
+};
+
+const SortNumbersDragHoverSetup = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const dispatch = useAnswerGameDispatch();
+  useEffect(() => {
+    dispatch({ type: 'PLACE_TILE', tileId: 't3', zoneIndex: 0 });
+    dispatch({ type: 'SET_DRAG_ACTIVE', tileId: 't3' });
+    dispatch({ type: 'SET_DRAG_HOVER_BANK', tileId: 't1' });
+  }, [dispatch]);
+  return <>{children}</>;
+};
+
+/** Tile `1` is in the first slot; dashed hover on bank tile `3`. */
+export const DragHoverBankTile: Story = {
+  decorators: [
+    withDb,
+    (Story) => (
+      <AnswerGameProvider config={config}>
+        <SortNumbersDragHoverSetup>
+          <Story />
+        </SortNumbersDragHoverSetup>
+      </AnswerGameProvider>
+    ),
+  ],
 };

--- a/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.test.tsx
+++ b/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { useEffect } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { SortNumbersTileBank } from './SortNumbersTileBank';
 import type {
@@ -32,6 +33,17 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
     i18n: { language: 'en' },
+  }),
+}));
+
+const bankDropState = vi.hoisted(() => ({ isDragOver: false }));
+
+vi.mock('@/components/answer-game/useBankDropTarget', () => ({
+  useBankDropTarget: () => ({
+    bankRef: { current: null },
+    get isDragOver() {
+      return bankDropState.isDragOver;
+    },
   }),
 }));
 
@@ -76,6 +88,28 @@ function wrapper({ children }: { children: ReactNode }) {
 }
 
 describe('SortNumbersTileBank', () => {
+  it('shows dashed hole preview when dragging a placed tile over the bank', () => {
+    bankDropState.isDragOver = true;
+    const Preview = () => {
+      const dispatch = useAnswerGameDispatch();
+      useEffect(() => {
+        dispatch({ type: 'INIT_ROUND', tiles, zones });
+        dispatch({ type: 'PLACE_TILE', tileId: 't2', zoneIndex: 0 });
+        dispatch({ type: 'SET_DRAG_ACTIVE', tileId: 't2' });
+      }, [dispatch]);
+      return <SortNumbersTileBank />;
+    };
+    const { container } = render(
+      <AnswerGameProvider config={config}>
+        <Preview />
+      </AnswerGameProvider>,
+    );
+    const hole = container.querySelector('[data-tile-bank-hole="t2"]');
+    expect(hole?.className).toMatch(/border-dashed/);
+    expect(hole?.textContent).toContain('1');
+    bankDropState.isDragOver = false;
+  });
+
   it('renders bank tiles as buttons', () => {
     render(<SortNumbersTileBank />, { wrapper });
     expect(

--- a/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.tsx
+++ b/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.tsx
@@ -39,7 +39,7 @@ export const SortNumbersTileBank = () => {
     dragActiveTileId,
     dragHoverBankTileId,
   } = useAnswerGameContext();
-  const { bankRef } = useBankDropTarget();
+  const { bankRef, isDragOver } = useBankDropTarget();
 
   return (
     <div
@@ -50,7 +50,12 @@ export const SortNumbersTileBank = () => {
       {allTiles.map((tile) => {
         const inBank = bankTileIds.includes(tile.id);
         const isDragging = tile.id === dragActiveTileId;
-        const isHoverTarget = tile.id === dragHoverBankTileId;
+        const isHoverTarget =
+          tile.id === dragHoverBankTileId ||
+          (!dragHoverBankTileId &&
+            isDragOver &&
+            !inBank &&
+            tile.id === dragActiveTileId);
 
         if (inBank) {
           return (

--- a/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.tsx
+++ b/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.tsx
@@ -88,9 +88,15 @@ export const SortNumbersTileBank = () => {
           <div
             key={tile.id}
             data-tile-bank-hole={tile.id}
-            className={`size-14 rounded-xl bg-muted/60 shadow-inner transition-all${isHoverTarget ? ' border-2 border-dashed border-primary' : ''}`}
+            className={`relative size-14 rounded-xl bg-muted/60 shadow-inner transition-all${isHoverTarget ? ' border-2 border-dashed border-primary' : ''}`}
             aria-hidden="true"
-          />
+          >
+            {isHoverTarget && (
+              <span className="absolute inset-0 flex items-center justify-center text-2xl font-bold opacity-50">
+                {tile.label}
+              </span>
+            )}
+          </div>
         );
       })}
     </div>

--- a/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.tsx
+++ b/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.tsx
@@ -56,11 +56,11 @@ export const SortNumbersTileBank = () => {
           return (
             <div
               key={tile.id}
-              className={`relative size-14 rounded-xl transition-all${isHoverTarget ? ' ring-2 ring-primary ring-offset-2' : ''}`}
+              className="relative size-14 rounded-xl transition-all"
             >
               <div
                 data-tile-bank-hole={tile.id}
-                className={`size-14 rounded-xl bg-muted/60 shadow-inner${isHoverTarget ? ' border-2 border-dashed border-primary' : ''}`}
+                className="size-14 rounded-xl bg-muted/60 shadow-inner"
                 aria-hidden="true"
               />
               <div
@@ -69,6 +69,12 @@ export const SortNumbersTileBank = () => {
               >
                 <NumberTile tile={tile} />
               </div>
+              {isHoverTarget && (
+                <div
+                  className="pointer-events-none absolute inset-0 rounded-xl border-2 border-dashed border-primary"
+                  aria-hidden="true"
+                />
+              )}
             </div>
           );
         }

--- a/src/games/word-spell/LetterTileBank/LetterTileBank.stories.tsx
+++ b/src/games/word-spell/LetterTileBank/LetterTileBank.stories.tsx
@@ -95,3 +95,30 @@ export const WithDistractors: Story = {
     ),
   ],
 };
+
+/** Slot tile `t1` is placed; dashed hover highlight on bank tile `t2` (swap / return target). */
+const DragHoverBankTileSetup = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const dispatch = useAnswerGameDispatch();
+  dispatch({ type: 'INIT_ROUND', tiles, zones });
+  dispatch({ type: 'PLACE_TILE', tileId: 't1', zoneIndex: 0 });
+  dispatch({ type: 'SET_DRAG_ACTIVE', tileId: 't1' });
+  dispatch({ type: 'SET_DRAG_HOVER_BANK', tileId: 't2' });
+  return <>{children}</>;
+};
+
+export const DragHoverBankTile: Story = {
+  decorators: [
+    withDb,
+    (Story) => (
+      <AnswerGameProvider config={config}>
+        <DragHoverBankTileSetup>
+          <Story />
+        </DragHoverBankTileSetup>
+      </AnswerGameProvider>
+    ),
+  ],
+};

--- a/src/games/word-spell/LetterTileBank/LetterTileBank.test.tsx
+++ b/src/games/word-spell/LetterTileBank/LetterTileBank.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { useEffect } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { LetterTileBank } from './LetterTileBank';
 import type {
@@ -32,6 +33,17 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
     i18n: { language: 'en' },
+  }),
+}));
+
+const bankDropState = vi.hoisted(() => ({ isDragOver: false }));
+
+vi.mock('@/components/answer-game/useBankDropTarget', () => ({
+  useBankDropTarget: () => ({
+    bankRef: { current: null },
+    get isDragOver() {
+      return bankDropState.isDragOver;
+    },
   }),
 }));
 
@@ -76,6 +88,52 @@ function wrapper({ children }: { children: ReactNode }) {
 }
 
 describe('LetterTileBank', () => {
+  it('shows dashed hole preview when a slot tile is dragged over the bank (isDragOver)', () => {
+    bankDropState.isDragOver = true;
+    const Preview = () => {
+      const dispatch = useAnswerGameDispatch();
+      useEffect(() => {
+        dispatch({ type: 'INIT_ROUND', tiles, zones });
+        dispatch({ type: 'PLACE_TILE', tileId: 't1', zoneIndex: 0 });
+        dispatch({ type: 'SET_DRAG_ACTIVE', tileId: 't1' });
+      }, [dispatch]);
+      return <LetterTileBank />;
+    };
+    const { container } = render(
+      <AnswerGameProvider config={config}>
+        <Preview />
+      </AnswerGameProvider>,
+    );
+    const hole = container.querySelector('[data-tile-bank-hole="t1"]');
+    expect(hole?.className).toMatch(/border-dashed/);
+    expect(hole?.textContent).toContain('c');
+    bankDropState.isDragOver = false;
+  });
+
+  it('shows dashed overlay on a bank tile when drag hovers that bank tile', () => {
+    bankDropState.isDragOver = false;
+    const Preview = () => {
+      const dispatch = useAnswerGameDispatch();
+      useEffect(() => {
+        dispatch({ type: 'INIT_ROUND', tiles, zones });
+        dispatch({ type: 'PLACE_TILE', tileId: 't1', zoneIndex: 0 });
+        dispatch({ type: 'SET_DRAG_ACTIVE', tileId: 't1' });
+        dispatch({ type: 'SET_DRAG_HOVER_BANK', tileId: 't2' });
+      }, [dispatch]);
+      return <LetterTileBank />;
+    };
+    const { container } = render(
+      <AnswerGameProvider config={config}>
+        <Preview />
+      </AnswerGameProvider>,
+    );
+    const overlays = container.querySelectorAll(
+      '.border-dashed.border-primary',
+    );
+    expect(overlays.length).toBeGreaterThanOrEqual(1);
+    bankDropState.isDragOver = false;
+  });
+
   it('renders all bank tiles as buttons', () => {
     render(<LetterTileBank />, { wrapper });
     expect(

--- a/src/games/word-spell/LetterTileBank/LetterTileBank.tsx
+++ b/src/games/word-spell/LetterTileBank/LetterTileBank.tsx
@@ -103,9 +103,15 @@ export const LetterTileBank = () => {
           <div
             key={tile.id}
             data-tile-bank-hole={tile.id}
-            className={`size-14 rounded-xl bg-muted/60 shadow-inner transition-all${isHoverTarget ? ' border-2 border-dashed border-primary' : ''}`}
+            className={`relative size-14 rounded-xl bg-muted/60 shadow-inner transition-all${isHoverTarget ? ' border-2 border-dashed border-primary' : ''}`}
             aria-hidden="true"
-          />
+          >
+            {isHoverTarget && (
+              <span className="absolute inset-0 flex items-center justify-center text-2xl font-bold opacity-50">
+                {tile.label}
+              </span>
+            )}
+          </div>
         );
       })}
     </div>

--- a/src/games/word-spell/LetterTileBank/LetterTileBank.tsx
+++ b/src/games/word-spell/LetterTileBank/LetterTileBank.tsx
@@ -40,7 +40,7 @@ export const LetterTileBank = () => {
     dragActiveTileId,
     dragHoverBankTileId,
   } = useAnswerGameContext();
-  const { bankRef } = useBankDropTarget();
+  const { bankRef, isDragOver } = useBankDropTarget();
 
   if (config.inputMethod === 'type') {
     const isTouch = navigator.maxTouchPoints > 0;
@@ -62,7 +62,15 @@ export const LetterTileBank = () => {
       {allTiles.map((tile) => {
         const inBank = bankTileIds.includes(tile.id);
         const isDragging = tile.id === dragActiveTileId;
-        const isHoverTarget = tile.id === dragHoverBankTileId;
+        // Occupied bank tile being hovered by a slot tile (HTML5 + touch), OR
+        // slot tile being dragged back over its own bank hole (HTML5 only —
+        // the hole div is not a registered drop target, so we use isDragOver).
+        const isHoverTarget =
+          tile.id === dragHoverBankTileId ||
+          (!dragHoverBankTileId &&
+            isDragOver &&
+            !inBank &&
+            tile.id === dragActiveTileId);
 
         if (inBank) {
           return (

--- a/src/games/word-spell/LetterTileBank/LetterTileBank.tsx
+++ b/src/games/word-spell/LetterTileBank/LetterTileBank.tsx
@@ -68,11 +68,11 @@ export const LetterTileBank = () => {
           return (
             <div
               key={tile.id}
-              className={`relative size-14 rounded-xl transition-all${isHoverTarget ? ' ring-2 ring-primary ring-offset-2' : ''}`}
+              className="relative size-14 rounded-xl transition-all"
             >
               <div
                 data-tile-bank-hole={tile.id}
-                className={`size-14 rounded-xl bg-muted/60 shadow-inner${isHoverTarget ? ' border-2 border-dashed border-primary' : ''}`}
+                className="size-14 rounded-xl bg-muted/60 shadow-inner"
                 aria-hidden="true"
               />
               <div
@@ -81,6 +81,12 @@ export const LetterTileBank = () => {
               >
                 <LetterTile tile={tile} />
               </div>
+              {isHoverTarget && (
+                <div
+                  className="pointer-events-none absolute inset-0 rounded-xl border-2 border-dashed border-primary"
+                  aria-hidden="true"
+                />
+              )}
             </div>
           );
         }


### PR DESCRIPTION
## Summary

- **Dashed border hidden behind button**: The `border-dashed` was on the `data-tile-bank-hole` div which sits behind the absolutely-positioned tile button — invisible. Added a `pointer-events-none` overlay div on top so the dashed border renders over the tile.
- **Bank hole shows no label on hover**: When a slot tile is dragged over its own bank hole, the hole had no content. Added a faded label (`opacity-50`) inside the hole on hover, matching the slot preview style.
- **Bank hole not a registered drop target**: The hole div has no pragmatic DnD registration, so `onDragEnter` never fired for HTML5. Added `isDragOver` tracking to `useBankDropTarget` (container-level `onDragEnter`/`onDragLeave`) and used it in all three bank components to compute `isHoverTarget` for the hole case.
- **`tile-place` sound silenced on bank return**: The `wasSwapOrMove` guard checked `prevTileId === prevDragActiveTileId` — always true during slot→bank drag. Fixed by also checking `!bankTileIds.includes(prevTileId)`: only suppress the sound when the tile moved to another slot, not when it returned to the bank.
- **`onDragLeave` missing on bank tile drop target**: Hover ring persisted when a slot tile moved off without dropping. Added `onDragLeave → SET_DRAG_HOVER_BANK(null)`.
- **`onHoverZone` missing for touch bank drags**: Bank tile touch drags never dispatched `SET_DRAG_HOVER`, so slots showed no dashed-border preview on mobile. Added `onHoverZone` callback.

## Test plan

- [ ] WordSpell: drag `c` to slot 1, drag `c` from slot back to bank → dashed border + faded letter visible on bank hole, `tile-place` sound plays
- [ ] WordSpell: drag `c` to slot 1, drag `c` from slot over an occupied bank tile → dashed border visible over the tile button
- [ ] Slot preview: drag any bank tile over a slot → dashed border appears on slot (desktop + touch)
- [ ] Swap: drag slot tile over occupied bank tile → ring/dashed highlights, drop swaps positions
- [ ] All unit tests pass (`yarn test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)