### PR TITLE
feat(answer-game): AnswerGame primitive + exit confirmation with session abandonment

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -48,6 +48,8 @@ const config: KnipConfig = {
     // Optional direct pins for TanStack Start / router tooling (not always imported from app TS).
     '@tanstack/react-router-ssr-query',
     '@tanstack/router-plugin',
+    // Pragmatic DnD: consumed by game slot components (WordSpell / NumberMatch), not the primitive layer.
+    '@atlaskit/pragmatic-drag-and-drop',
     // Vitest coverage provider (CLI-only).
     '@vitest/coverage-v8',
     // Storybook / MDX (resolved via Storybook; not direct app imports).

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@atlaskit/pragmatic-drag-and-drop": "^1.7.10",
     "@fontsource-variable/geist": "^5.2.8",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-devtools": "latest",

--- a/src/components/answer-game/AnswerGame/AnswerGame.stories.tsx
+++ b/src/components/answer-game/AnswerGame/AnswerGame.stories.tsx
@@ -1,0 +1,72 @@
+import { AnswerGame } from './AnswerGame';
+import type { AnswerGameConfig } from '../types';
+import type { Meta, StoryObj } from '@storybook/react';
+import { AudioButton } from '@/components/questions/AudioButton/AudioButton';
+import { ImageQuestion } from '@/components/questions/ImageQuestion/ImageQuestion';
+import { TextQuestion } from '@/components/questions/TextQuestion/TextQuestion';
+
+const baseConfig: AnswerGameConfig = {
+  gameId: 'storybook',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 3,
+  ttsEnabled: true,
+};
+
+const meta: Meta<typeof AnswerGame> = {
+  component: AnswerGame,
+  tags: ['autodocs'],
+  args: { config: baseConfig },
+};
+export default meta;
+
+type Story = StoryObj<typeof AnswerGame>;
+
+export const Default: Story = {
+  render: (args) => (
+    <AnswerGame {...args}>
+      <AnswerGame.Question>
+        <ImageQuestion src="https://placehold.co/160" prompt="cat" />
+        <AudioButton prompt="cat" />
+      </AnswerGame.Question>
+      <AnswerGame.Answer>
+        <div className="flex gap-2 rounded-lg border-2 border-dashed p-4 text-muted-foreground">
+          Answer slots here
+        </div>
+      </AnswerGame.Answer>
+      <AnswerGame.Choices>
+        <div className="flex gap-2 rounded-lg border-2 border-dashed p-4 text-muted-foreground">
+          Tile bank here
+        </div>
+      </AnswerGame.Choices>
+    </AnswerGame>
+  ),
+};
+
+export const TextQuestionMode: Story = {
+  args: { config: { ...baseConfig, inputMethod: 'type' } },
+  render: (args) => (
+    <AnswerGame {...args}>
+      <AnswerGame.Question>
+        <TextQuestion text="three" />
+        <AudioButton prompt="three" />
+      </AnswerGame.Question>
+      <AnswerGame.Answer>
+        <div className="flex gap-2 rounded-lg border-2 border-dashed p-4 text-muted-foreground">
+          Typed slots here
+        </div>
+      </AnswerGame.Answer>
+    </AnswerGame>
+  ),
+};
+
+export const RejectMode: Story = {
+  args: { config: { ...baseConfig, wrongTileBehavior: 'reject' } },
+  render: Default.render,
+};
+
+export const LockManualMode: Story = {
+  args: { config: { ...baseConfig, wrongTileBehavior: 'lock-manual' } },
+  render: Default.render,
+};

--- a/src/components/answer-game/AnswerGame/AnswerGame.test.tsx
+++ b/src/components/answer-game/AnswerGame/AnswerGame.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AnswerGame } from './AnswerGame';
+import type { AnswerGameConfig } from '../types';
+
+const gameConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: false,
+};
+
+describe('AnswerGame', () => {
+  it('renders Question slot children', () => {
+    render(
+      <AnswerGame config={gameConfig}>
+        <AnswerGame.Question>
+          <span>Question content</span>
+        </AnswerGame.Question>
+      </AnswerGame>,
+    );
+    expect(screen.getByText('Question content')).toBeInTheDocument();
+  });
+
+  it('renders Answer slot children', () => {
+    render(
+      <AnswerGame config={gameConfig}>
+        <AnswerGame.Answer>
+          <span>Answer content</span>
+        </AnswerGame.Answer>
+      </AnswerGame>,
+    );
+    expect(screen.getByText('Answer content')).toBeInTheDocument();
+  });
+
+  it('renders Choices slot children', () => {
+    render(
+      <AnswerGame config={gameConfig}>
+        <AnswerGame.Choices>
+          <span>Choices content</span>
+        </AnswerGame.Choices>
+      </AnswerGame>,
+    );
+    expect(screen.getByText('Choices content')).toBeInTheDocument();
+  });
+
+  it('slot wrappers render nothing when no children provided', () => {
+    const { container } = render(
+      <AnswerGame config={gameConfig}>
+        <AnswerGame.Question />
+      </AnswerGame>,
+    );
+    expect(
+      container.querySelector('.game-question-zone'),
+    ).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/answer-game/AnswerGame/AnswerGame.tsx
+++ b/src/components/answer-game/AnswerGame/AnswerGame.tsx
@@ -1,0 +1,38 @@
+import { AnswerGameProvider } from '../AnswerGameProvider';
+import type { AnswerGameConfig } from '../types';
+import type { ReactNode } from 'react';
+
+interface AnswerGameProps {
+  config: AnswerGameConfig;
+  children: ReactNode;
+}
+
+const AnswerGameRoot = ({ config, children }: AnswerGameProps) => (
+  <AnswerGameProvider config={config}>
+    <div className="flex min-h-dvh flex-col">{children}</div>
+  </AnswerGameProvider>
+);
+
+const Question = ({ children }: { children?: ReactNode }) => (
+  <div className="game-question-zone flex flex-col items-center gap-4 px-4 py-6">
+    {children}
+  </div>
+);
+
+const Answer = ({ children }: { children?: ReactNode }) => (
+  <div className="game-answer-zone flex flex-wrap justify-center gap-2 px-4 py-4">
+    {children}
+  </div>
+);
+
+const Choices = ({ children }: { children?: ReactNode }) => (
+  <div className="game-choices-zone flex flex-wrap justify-center gap-3 px-4 py-4">
+    {children}
+  </div>
+);
+
+export const AnswerGame = Object.assign(AnswerGameRoot, {
+  Question,
+  Answer,
+  Choices,
+});

--- a/src/components/answer-game/AnswerGameProvider.test.tsx
+++ b/src/components/answer-game/AnswerGameProvider.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { AnswerGameProvider } from './AnswerGameProvider';
+import { useAnswerGameContext } from './useAnswerGameContext';
+import { useAnswerGameDispatch } from './useAnswerGameDispatch';
+import type { AnswerGameConfig } from './types';
+
+const gameConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: true,
+};
+
+const StateReader = () => {
+  const state = useAnswerGameContext();
+  return <div data-testid="phase">{state.phase}</div>;
+};
+
+const Dispatcher = () => {
+  const dispatch = useAnswerGameDispatch();
+  return (
+    <button
+      type="button"
+      onClick={() => dispatch({ type: 'COMPLETE_GAME' })}
+    >
+      end
+    </button>
+  );
+};
+
+describe('AnswerGameProvider', () => {
+  it('provides initial state to children', () => {
+    render(
+      <AnswerGameProvider config={gameConfig}>
+        <StateReader />
+      </AnswerGameProvider>,
+    );
+    expect(screen.getByTestId('phase')).toHaveTextContent('playing');
+  });
+
+  it('dispatch updates state', async () => {
+    const user = userEvent.setup();
+    render(
+      <AnswerGameProvider config={gameConfig}>
+        <StateReader />
+        <Dispatcher />
+      </AnswerGameProvider>,
+    );
+    await user.click(screen.getByRole('button', { name: 'end' }));
+    expect(screen.getByTestId('phase')).toHaveTextContent('game-over');
+  });
+
+  it('useAnswerGameContext throws outside provider', () => {
+    const consoleError = console.error;
+    console.error = () => {};
+    expect(() => render(<StateReader />)).toThrow(
+      'useAnswerGameContext must be used inside AnswerGameProvider',
+    );
+    console.error = consoleError;
+  });
+
+  it('useAnswerGameDispatch throws outside provider', () => {
+    const consoleError = console.error;
+    console.error = () => {};
+    expect(() => render(<Dispatcher />)).toThrow(
+      'useAnswerGameDispatch must be used inside AnswerGameProvider',
+    );
+    console.error = consoleError;
+  });
+});

--- a/src/components/answer-game/AnswerGameProvider.tsx
+++ b/src/components/answer-game/AnswerGameProvider.tsx
@@ -1,0 +1,40 @@
+import { createContext, useReducer } from 'react';
+import {
+  answerGameReducer,
+  makeInitialState,
+} from './answer-game-reducer';
+import type {
+  AnswerGameAction,
+  AnswerGameConfig,
+  AnswerGameState,
+} from './types';
+import type { Dispatch, ReactNode } from 'react';
+
+export const AnswerGameStateContext =
+  createContext<AnswerGameState | null>(null);
+export const AnswerGameDispatchContext =
+  createContext<Dispatch<AnswerGameAction> | null>(null);
+
+interface AnswerGameProviderProps {
+  config: AnswerGameConfig;
+  children: ReactNode;
+}
+
+export const AnswerGameProvider = ({
+  config,
+  children,
+}: AnswerGameProviderProps) => {
+  const [state, dispatch] = useReducer(
+    answerGameReducer,
+    config,
+    makeInitialState,
+  );
+
+  return (
+    <AnswerGameStateContext.Provider value={state}>
+      <AnswerGameDispatchContext.Provider value={dispatch}>
+        {children}
+      </AnswerGameDispatchContext.Provider>
+    </AnswerGameStateContext.Provider>
+  );
+};

--- a/src/components/answer-game/EncouragementAnnouncer/EncouragementAnnouncer.stories.tsx
+++ b/src/components/answer-game/EncouragementAnnouncer/EncouragementAnnouncer.stories.tsx
@@ -1,0 +1,18 @@
+import { EncouragementAnnouncer } from './EncouragementAnnouncer';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof EncouragementAnnouncer> = {
+  component: EncouragementAnnouncer,
+  tags: ['autodocs'],
+  argTypes: { onDismiss: { action: 'dismissed' } },
+};
+export default meta;
+
+type Story = StoryObj<typeof EncouragementAnnouncer>;
+
+export const Hidden: Story = {
+  args: { visible: false, message: 'Keep trying!' },
+};
+export const Visible: Story = {
+  args: { visible: true, message: 'Almost! Try again.' },
+};

--- a/src/components/answer-game/EncouragementAnnouncer/EncouragementAnnouncer.tsx
+++ b/src/components/answer-game/EncouragementAnnouncer/EncouragementAnnouncer.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+
+interface EncouragementAnnouncerProps {
+  visible: boolean;
+  message: string;
+  onDismiss: () => void;
+}
+
+export const EncouragementAnnouncer = ({
+  visible,
+  message,
+  onDismiss,
+}: EncouragementAnnouncerProps) => {
+  useEffect(() => {
+    if (!visible) return;
+    const timer = setTimeout(onDismiss, 2000);
+    return () => clearTimeout(timer);
+  }, [visible, onDismiss]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="pointer-events-none fixed bottom-24 left-1/2 flex -translate-x-1/2 flex-col items-center gap-2 rounded-2xl bg-background/95 px-6 py-4 shadow-xl"
+    >
+      <span className="text-5xl" aria-hidden="true">
+        🐨
+      </span>
+      <p className="text-center text-lg font-semibold">{message}</p>
+    </div>
+  );
+};

--- a/src/components/answer-game/GameOverOverlay/GameOverOverlay.stories.tsx
+++ b/src/components/answer-game/GameOverOverlay/GameOverOverlay.stories.tsx
@@ -1,0 +1,18 @@
+import { GameOverOverlay } from './GameOverOverlay';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof GameOverOverlay> = {
+  component: GameOverOverlay,
+  tags: ['autodocs'],
+  argTypes: {
+    onPlayAgain: { action: 'playAgain' },
+    onHome: { action: 'home' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof GameOverOverlay>;
+
+export const FiveStars: Story = { args: { retryCount: 0 } };
+export const ThreeStars: Story = { args: { retryCount: 3 } };
+export const OneStar: Story = { args: { retryCount: 10 } };

--- a/src/components/answer-game/GameOverOverlay/GameOverOverlay.tsx
+++ b/src/components/answer-game/GameOverOverlay/GameOverOverlay.tsx
@@ -1,0 +1,64 @@
+interface GameOverOverlayProps {
+  retryCount: number;
+  onPlayAgain: () => void;
+  onHome: () => void;
+}
+
+function starsFromRetries(retryCount: number): number {
+  if (retryCount === 0) return 5;
+  if (retryCount <= 2) return 4;
+  if (retryCount <= 4) return 3;
+  if (retryCount <= 6) return 2;
+  return 1;
+}
+
+export const GameOverOverlay = ({
+  retryCount,
+  onPlayAgain,
+  onHome,
+}: GameOverOverlayProps) => {
+  const stars = starsFromRetries(retryCount);
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Game complete"
+      className="fixed inset-0 flex flex-col items-center justify-center gap-8 bg-background/95"
+    >
+      <span className="animate-bounce text-8xl" aria-hidden="true">
+        🐨
+      </span>
+
+      <div
+        aria-label={`You scored ${stars} out of 5 stars`}
+        className="flex gap-2"
+      >
+        {Array.from({ length: 5 }, (_, i) => (
+          <span
+            key={i}
+            className={`text-4xl ${i < stars ? 'text-yellow-400' : 'text-muted-foreground'}`}
+          >
+            ★
+          </span>
+        ))}
+      </div>
+
+      <div className="flex gap-4">
+        <button
+          type="button"
+          onClick={onPlayAgain}
+          className="rounded-xl bg-primary px-8 py-4 text-lg font-bold text-primary-foreground shadow-md active:scale-95"
+        >
+          Play again
+        </button>
+        <button
+          type="button"
+          onClick={onHome}
+          className="rounded-xl bg-muted px-8 py-4 text-lg font-bold active:scale-95"
+        >
+          Home
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/answer-game/ScoreAnimation/ScoreAnimation.stories.tsx
+++ b/src/components/answer-game/ScoreAnimation/ScoreAnimation.stories.tsx
@@ -1,0 +1,13 @@
+import { ScoreAnimation } from './ScoreAnimation';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof ScoreAnimation> = {
+  component: ScoreAnimation,
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof ScoreAnimation>;
+
+export const Playing: Story = { args: { visible: false } };
+export const Complete: Story = { args: { visible: true } };

--- a/src/components/answer-game/ScoreAnimation/ScoreAnimation.tsx
+++ b/src/components/answer-game/ScoreAnimation/ScoreAnimation.tsx
@@ -1,0 +1,33 @@
+interface ScoreAnimationProps {
+  visible: boolean;
+}
+
+export const ScoreAnimation = ({ visible }: ScoreAnimationProps) => {
+  if (!visible) return null;
+
+  return (
+    <div
+      aria-live="polite"
+      aria-label="Round complete!"
+      className="pointer-events-none fixed inset-0 flex items-center justify-center"
+    >
+      {Array.from({ length: 12 }, (_, i) => (
+        <span
+          key={i}
+          className="absolute size-3 rounded-full animate-bounce"
+          style={{
+            left: `${10 + ((i * 7) % 80)}%`,
+            top: `${20 + ((i * 13) % 50)}%`,
+            backgroundColor: [
+              '#FF6B6B',
+              '#FFD93D',
+              '#6BCB77',
+              '#4D96FF',
+            ][i % 4],
+            animationDelay: `${i * 50}ms`,
+          }}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/answer-game/answer-game-reducer.test.ts
+++ b/src/components/answer-game/answer-game-reducer.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+import {
+  answerGameReducer,
+  makeInitialState,
+} from './answer-game-reducer';
+import type { AnswerGameConfig, AnswerZone, TileItem } from './types';
+
+const config: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 3,
+  ttsEnabled: true,
+};
+
+const tiles: TileItem[] = [
+  { id: 't1', label: 'C', value: 'C' },
+  { id: 't2', label: 'A', value: 'A' },
+  { id: 't3', label: 'T', value: 'T' },
+];
+
+const zones: AnswerZone[] = [
+  {
+    id: 'z0',
+    index: 0,
+    expectedValue: 'C',
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  },
+  {
+    id: 'z1',
+    index: 1,
+    expectedValue: 'A',
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  },
+  {
+    id: 'z2',
+    index: 2,
+    expectedValue: 'T',
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  },
+];
+
+describe('answerGameReducer', () => {
+  it('INIT_ROUND sets allTiles and bankTileIds', () => {
+    const state = makeInitialState(config);
+    const next = answerGameReducer(state, {
+      type: 'INIT_ROUND',
+      tiles,
+      zones,
+    });
+    expect(next.allTiles).toEqual(tiles);
+    expect(next.bankTileIds).toEqual(['t1', 't2', 't3']);
+    expect(next.zones).toEqual(zones);
+    expect(next.activeSlotIndex).toBe(0);
+  });
+
+  it('PLACE_TILE correct: removes tile from bank and places in zone', () => {
+    const state = answerGameReducer(makeInitialState(config), {
+      type: 'INIT_ROUND',
+      tiles,
+      zones,
+    });
+    const next = answerGameReducer(state, {
+      type: 'PLACE_TILE',
+      tileId: 't1',
+      zoneIndex: 0,
+    });
+    expect(next.bankTileIds).not.toContain('t1');
+    expect(next.zones[0]!.placedTileId).toBe('t1');
+    expect(next.zones[0]!.isWrong).toBe(false);
+    expect(next.retryCount).toBe(0);
+  });
+
+  it('PLACE_TILE wrong: tile stays in bank, zone marked wrong, retryCount incremented', () => {
+    const state = answerGameReducer(makeInitialState(config), {
+      type: 'INIT_ROUND',
+      tiles,
+      zones,
+    });
+    const next = answerGameReducer(state, {
+      type: 'PLACE_TILE',
+      tileId: 't2',
+      zoneIndex: 0,
+    });
+    expect(next.bankTileIds).toContain('t2');
+    expect(next.zones[0]!.isWrong).toBe(true);
+    expect(next.zones[0]!.isLocked).toBe(true);
+    expect(next.retryCount).toBe(1);
+  });
+
+  it('PLACE_TILE correct: phase transitions to round-complete when all zones filled', () => {
+    let state = answerGameReducer(makeInitialState(config), {
+      type: 'INIT_ROUND',
+      tiles,
+      zones,
+    });
+    state = answerGameReducer(state, {
+      type: 'PLACE_TILE',
+      tileId: 't1',
+      zoneIndex: 0,
+    });
+    state = answerGameReducer(state, {
+      type: 'PLACE_TILE',
+      tileId: 't2',
+      zoneIndex: 1,
+    });
+    state = answerGameReducer(state, {
+      type: 'PLACE_TILE',
+      tileId: 't3',
+      zoneIndex: 2,
+    });
+    expect(state.phase).toBe('round-complete');
+  });
+
+  it('REMOVE_TILE returns tile to bank', () => {
+    let state = answerGameReducer(makeInitialState(config), {
+      type: 'INIT_ROUND',
+      tiles,
+      zones,
+    });
+    state = answerGameReducer(state, {
+      type: 'PLACE_TILE',
+      tileId: 't1',
+      zoneIndex: 0,
+    });
+    state = answerGameReducer(state, {
+      type: 'REMOVE_TILE',
+      zoneIndex: 0,
+    });
+    expect(state.bankTileIds).toContain('t1');
+    expect(state.zones[0]!.placedTileId).toBeNull();
+  });
+
+  it('REMOVE_TILE is a no-op when zone is empty', () => {
+    const state = answerGameReducer(makeInitialState(config), {
+      type: 'INIT_ROUND',
+      tiles,
+      zones,
+    });
+    const next = answerGameReducer(state, {
+      type: 'REMOVE_TILE',
+      zoneIndex: 0,
+    });
+    expect(next).toBe(state);
+  });
+
+  it('SWAP_TILES exchanges placed tiles between two occupied zones', () => {
+    let state = answerGameReducer(makeInitialState(config), {
+      type: 'INIT_ROUND',
+      tiles,
+      zones,
+    });
+    state = answerGameReducer(state, {
+      type: 'PLACE_TILE',
+      tileId: 't2',
+      zoneIndex: 0,
+    });
+    state = answerGameReducer(state, {
+      type: 'EJECT_TILE',
+      zoneIndex: 0,
+    });
+    state = answerGameReducer(state, {
+      type: 'PLACE_TILE',
+      tileId: 't1',
+      zoneIndex: 0,
+    });
+    state = answerGameReducer(state, {
+      type: 'PLACE_TILE',
+      tileId: 't2',
+      zoneIndex: 1,
+    });
+    state = answerGameReducer(state, {
+      type: 'SWAP_TILES',
+      fromZoneIndex: 0,
+      toZoneIndex: 1,
+    });
+    expect(state.zones[0]!.placedTileId).toBe('t2');
+    expect(state.zones[1]!.placedTileId).toBe('t1');
+  });
+
+  it('EJECT_TILE clears zone and returns tile to bank', () => {
+    let state = answerGameReducer(makeInitialState(config), {
+      type: 'INIT_ROUND',
+      tiles,
+      zones,
+    });
+    state = answerGameReducer(state, {
+      type: 'PLACE_TILE',
+      tileId: 't2',
+      zoneIndex: 0,
+    });
+    expect(state.zones[0]!.isWrong).toBe(true);
+    state = answerGameReducer(state, {
+      type: 'EJECT_TILE',
+      zoneIndex: 0,
+    });
+    expect(state.zones[0]!.placedTileId).toBeNull();
+    expect(state.zones[0]!.isWrong).toBe(false);
+    expect(state.bankTileIds).toContain('t2');
+  });
+
+  it('ADVANCE_ROUND resets zones and bank, increments roundIndex', () => {
+    let state = answerGameReducer(makeInitialState(config), {
+      type: 'INIT_ROUND',
+      tiles,
+      zones,
+    });
+    state = answerGameReducer(state, {
+      type: 'PLACE_TILE',
+      tileId: 't1',
+      zoneIndex: 0,
+    });
+    const newTiles: TileItem[] = [{ id: 'n1', label: 'D', value: 'D' }];
+    const newZones: AnswerZone[] = [
+      {
+        id: 'nz0',
+        index: 0,
+        expectedValue: 'D',
+        placedTileId: null,
+        isWrong: false,
+        isLocked: false,
+      },
+    ];
+    state = answerGameReducer(state, {
+      type: 'ADVANCE_ROUND',
+      tiles: newTiles,
+      zones: newZones,
+    });
+    expect(state.roundIndex).toBe(1);
+    expect(state.allTiles).toEqual(newTiles);
+    expect(state.bankTileIds).toEqual(['n1']);
+    expect(state.retryCount).toBe(0);
+    expect(state.phase).toBe('playing');
+  });
+
+  it('COMPLETE_GAME sets phase to game-over', () => {
+    const state = makeInitialState(config);
+    const next = answerGameReducer(state, { type: 'COMPLETE_GAME' });
+    expect(next.phase).toBe('game-over');
+  });
+
+  it('SET_DRAG_ACTIVE sets dragActiveTileId', () => {
+    const state = makeInitialState(config);
+    const next = answerGameReducer(state, {
+      type: 'SET_DRAG_ACTIVE',
+      tileId: 't1',
+    });
+    expect(next.dragActiveTileId).toBe('t1');
+    const cleared = answerGameReducer(next, {
+      type: 'SET_DRAG_ACTIVE',
+      tileId: null,
+    });
+    expect(cleared.dragActiveTileId).toBeNull();
+  });
+});

--- a/src/components/answer-game/answer-game-reducer.ts
+++ b/src/components/answer-game/answer-game-reducer.ts
@@ -1,0 +1,210 @@
+import type {
+  AnswerGameAction,
+  AnswerGameConfig,
+  AnswerGameState,
+  AnswerZone,
+  TileItem,
+} from './types';
+
+export function makeInitialState(
+  config: AnswerGameConfig,
+): AnswerGameState {
+  return {
+    config,
+    allTiles: [],
+    bankTileIds: [],
+    zones: [],
+    activeSlotIndex: 0,
+    dragActiveTileId: null,
+    phase: 'playing',
+    roundIndex: 0,
+    retryCount: 0,
+  };
+}
+
+export function answerGameReducer(
+  state: AnswerGameState,
+  action: AnswerGameAction,
+): AnswerGameState {
+  switch (action.type) {
+    case 'INIT_ROUND': {
+      return {
+        ...state,
+        allTiles: action.tiles,
+        bankTileIds: action.tiles.map((t: TileItem) => t.id),
+        zones: action.zones,
+        activeSlotIndex: 0,
+        phase: 'playing',
+        retryCount: 0,
+      };
+    }
+
+    case 'PLACE_TILE': {
+      const tile = state.allTiles.find((t) => t.id === action.tileId);
+      const zone = state.zones[action.zoneIndex];
+      if (!tile || !zone) return state;
+
+      const correct = tile.value === zone.expectedValue;
+
+      if (!correct && state.config.wrongTileBehavior === 'reject') {
+        return { ...state, retryCount: state.retryCount + 1 };
+      }
+
+      if (correct) {
+        const newZone: AnswerZone = {
+          ...zone,
+          placedTileId: action.tileId,
+          isWrong: false,
+          isLocked: false,
+        };
+        const newZones = state.zones.map((z, i) =>
+          i === action.zoneIndex ? newZone : z,
+        );
+        const newBankTileIds = state.bankTileIds.filter(
+          (id) => id !== action.tileId,
+        );
+        const nextActiveSlot = newZones.findIndex(
+          (z, i) => i > action.zoneIndex && z.placedTileId === null,
+        );
+        const allFilledCorrectly = newZones.every(
+          (z) => z.placedTileId !== null && !z.isWrong,
+        );
+        return {
+          ...state,
+          zones: newZones,
+          bankTileIds: newBankTileIds,
+          activeSlotIndex:
+            nextActiveSlot === -1
+              ? state.activeSlotIndex
+              : nextActiveSlot,
+          retryCount: state.retryCount,
+          phase: allFilledCorrectly ? 'round-complete' : 'playing',
+        };
+      }
+
+      const lockManual =
+        state.config.wrongTileBehavior === 'lock-manual';
+      const newZone: AnswerZone = {
+        ...zone,
+        placedTileId: lockManual ? action.tileId : zone.placedTileId,
+        isWrong: true,
+        isLocked: true,
+      };
+      const newZones = state.zones.map((z, i) =>
+        i === action.zoneIndex ? newZone : z,
+      );
+      const newBankTileIds = lockManual
+        ? state.bankTileIds.filter((id) => id !== action.tileId)
+        : state.bankTileIds;
+
+      return {
+        ...state,
+        zones: newZones,
+        bankTileIds: newBankTileIds,
+        activeSlotIndex: state.activeSlotIndex,
+        retryCount: state.retryCount + 1,
+        phase: 'playing',
+      };
+    }
+
+    case 'REMOVE_TILE': {
+      const zone = state.zones[action.zoneIndex];
+      if (!zone?.placedTileId) return state;
+      return {
+        ...state,
+        zones: state.zones.map((z, i) =>
+          i === action.zoneIndex
+            ? {
+                ...z,
+                placedTileId: null,
+                isWrong: false,
+                isLocked: false,
+              }
+            : z,
+        ),
+        bankTileIds: [...state.bankTileIds, zone.placedTileId],
+      };
+    }
+
+    case 'SWAP_TILES': {
+      const fromZone = state.zones[action.fromZoneIndex];
+      const toZone = state.zones[action.toZoneIndex];
+      if (!fromZone || !toZone) return state;
+      return {
+        ...state,
+        zones: state.zones.map((z, i) => {
+          if (i === action.fromZoneIndex)
+            return { ...z, placedTileId: toZone.placedTileId };
+          if (i === action.toZoneIndex)
+            return { ...z, placedTileId: fromZone.placedTileId };
+          return z;
+        }),
+      };
+    }
+
+    case 'EJECT_TILE': {
+      const zone = state.zones[action.zoneIndex];
+      if (!zone) return state;
+
+      if (zone.placedTileId) {
+        return {
+          ...state,
+          zones: state.zones.map((z, i) =>
+            i === action.zoneIndex
+              ? {
+                  ...z,
+                  placedTileId: null,
+                  isWrong: false,
+                  isLocked: false,
+                }
+              : z,
+          ),
+          bankTileIds: [...state.bankTileIds, zone.placedTileId],
+        };
+      }
+
+      if (zone.isWrong || zone.isLocked) {
+        return {
+          ...state,
+          zones: state.zones.map((z, i) =>
+            i === action.zoneIndex
+              ? {
+                  ...z,
+                  placedTileId: null,
+                  isWrong: false,
+                  isLocked: false,
+                }
+              : z,
+          ),
+        };
+      }
+
+      return state;
+    }
+
+    case 'ADVANCE_ROUND': {
+      return {
+        ...state,
+        allTiles: action.tiles,
+        bankTileIds: action.tiles.map((t: TileItem) => t.id),
+        zones: action.zones,
+        activeSlotIndex: 0,
+        phase: 'playing',
+        roundIndex: state.roundIndex + 1,
+        retryCount: 0,
+      };
+    }
+
+    case 'COMPLETE_GAME': {
+      return { ...state, phase: 'game-over' };
+    }
+
+    case 'SET_DRAG_ACTIVE': {
+      return { ...state, dragActiveTileId: action.tileId };
+    }
+
+    default: {
+      return state;
+    }
+  }
+}

--- a/src/components/answer-game/magnetic-snap.test.ts
+++ b/src/components/answer-game/magnetic-snap.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { lerp, magneticOffset } from './magnetic-snap';
+
+describe('lerp', () => {
+  it('returns a at t=0', () => expect(lerp(0, 100, 0)).toBe(0));
+  it('returns b at t=1', () => expect(lerp(0, 100, 1)).toBe(100));
+  it('returns midpoint at t=0.5', () =>
+    expect(lerp(0, 100, 0.5)).toBe(50));
+});
+
+describe('magneticOffset', () => {
+  const zoneCenter = { x: 200, y: 300 };
+
+  it('returns (0, 0) when distance is outside 60 px radius', () => {
+    const result = magneticOffset(61, { x: 100, y: 200 }, zoneCenter);
+    expect(result).toEqual({ x: 0, y: 0 });
+  });
+
+  it('returns (0, 0) at exactly the boundary (60 px)', () => {
+    const result = magneticOffset(60, { x: 100, y: 200 }, zoneCenter);
+    expect(result.x).toBeCloseTo(0);
+    expect(result.y).toBeCloseTo(0);
+  });
+
+  it('applies lerp pull at 30 px distance', () => {
+    const currentPos = { x: 170, y: 300 };
+    const result = magneticOffset(30, currentPos, zoneCenter);
+    const t = (1 - 30 / 60) * 0.3;
+    const expectedX =
+      lerp(currentPos.x, zoneCenter.x, t) - currentPos.x;
+    const expectedY =
+      lerp(currentPos.y, zoneCenter.y, t) - currentPos.y;
+    expect(result.x).toBeCloseTo(expectedX);
+    expect(result.y).toBeCloseTo(expectedY);
+  });
+
+  it('pulls strongly at 0 px distance (on top of zone center)', () => {
+    const currentPos = { x: 200, y: 300 };
+    const result = magneticOffset(0, currentPos, zoneCenter);
+    expect(result.x).toBeCloseTo(0);
+    expect(result.y).toBeCloseTo(0);
+  });
+});

--- a/src/components/answer-game/magnetic-snap.ts
+++ b/src/components/answer-game/magnetic-snap.ts
@@ -1,0 +1,20 @@
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+const MAGNETIC_RADIUS = 60;
+const MAGNETIC_STRENGTH = 0.3;
+
+export function magneticOffset(
+  distance: number,
+  currentPos: { x: number; y: number },
+  zoneCenter: { x: number; y: number },
+): { x: number; y: number } {
+  if (distance >= MAGNETIC_RADIUS) return { x: 0, y: 0 };
+
+  const t = (1 - distance / MAGNETIC_RADIUS) * MAGNETIC_STRENGTH;
+  return {
+    x: lerp(currentPos.x, zoneCenter.x, t) - currentPos.x,
+    y: lerp(currentPos.y, zoneCenter.y, t) - currentPos.y,
+  };
+}

--- a/src/components/answer-game/types.ts
+++ b/src/components/answer-game/types.ts
@@ -1,0 +1,61 @@
+export interface AnswerGameConfig {
+  gameId: string;
+  /** @default 'drag' */
+  inputMethod: 'drag' | 'type' | 'both';
+  /** @default 'lock-auto-eject' */
+  wrongTileBehavior: 'reject' | 'lock-manual' | 'lock-auto-eject';
+  tileBankMode: 'exact' | 'distractors';
+  distractorCount?: number;
+  /** Total number of rounds in this session */
+  totalRounds: number;
+  /** Whether TTS is enabled for this profile */
+  ttsEnabled: boolean;
+}
+
+export interface TileItem {
+  id: string;
+  /** Display label shown on the tile (e.g. "A", "cat", "3") */
+  label: string;
+  /** Semantic value used for evaluation — matches `AnswerZone.expectedValue` */
+  value: string;
+}
+
+export interface AnswerZone {
+  id: string;
+  index: number;
+  /** Correct tile value for this slot; matched against `TileItem.value` */
+  expectedValue: string;
+  placedTileId: string | null;
+  isWrong: boolean;
+  isLocked: boolean;
+}
+
+export type AnswerGamePhase =
+  | 'playing'
+  | 'round-complete'
+  | 'game-over';
+
+export interface AnswerGameState {
+  config: AnswerGameConfig;
+  /** Full tile list for the current round — never mutated mid-round */
+  allTiles: TileItem[];
+  /** IDs of tiles currently visible in the choice bank */
+  bankTileIds: string[];
+  zones: AnswerZone[];
+  /** Index of next slot to fill in auto-next-slot mode */
+  activeSlotIndex: number;
+  dragActiveTileId: string | null;
+  phase: AnswerGamePhase;
+  roundIndex: number;
+  retryCount: number;
+}
+
+export type AnswerGameAction =
+  | { type: 'INIT_ROUND'; tiles: TileItem[]; zones: AnswerZone[] }
+  | { type: 'PLACE_TILE'; tileId: string; zoneIndex: number }
+  | { type: 'REMOVE_TILE'; zoneIndex: number }
+  | { type: 'SWAP_TILES'; fromZoneIndex: number; toZoneIndex: number }
+  | { type: 'EJECT_TILE'; zoneIndex: number }
+  | { type: 'ADVANCE_ROUND'; tiles: TileItem[]; zones: AnswerZone[] }
+  | { type: 'COMPLETE_GAME' }
+  | { type: 'SET_DRAG_ACTIVE'; tileId: string | null };

--- a/src/components/answer-game/useAnswerGameContext.ts
+++ b/src/components/answer-game/useAnswerGameContext.ts
@@ -1,0 +1,13 @@
+import { use } from 'react';
+import { AnswerGameStateContext } from './AnswerGameProvider';
+import type { AnswerGameState } from './types';
+
+export function useAnswerGameContext(): AnswerGameState {
+  const ctx = use(AnswerGameStateContext);
+  if (!ctx) {
+    throw new Error(
+      'useAnswerGameContext must be used inside AnswerGameProvider',
+    );
+  }
+  return ctx;
+}

--- a/src/components/answer-game/useAnswerGameDispatch.ts
+++ b/src/components/answer-game/useAnswerGameDispatch.ts
@@ -1,0 +1,14 @@
+import { use } from 'react';
+import { AnswerGameDispatchContext } from './AnswerGameProvider';
+import type { AnswerGameAction } from './types';
+import type { Dispatch } from 'react';
+
+export function useAnswerGameDispatch(): Dispatch<AnswerGameAction> {
+  const ctx = use(AnswerGameDispatchContext);
+  if (!ctx) {
+    throw new Error(
+      'useAnswerGameDispatch must be used inside AnswerGameProvider',
+    );
+  }
+  return ctx;
+}

--- a/src/components/answer-game/useAutoNextSlot.test.tsx
+++ b/src/components/answer-game/useAutoNextSlot.test.tsx
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AnswerGameProvider } from './AnswerGameProvider';
+import { useAnswerGameContext } from './useAnswerGameContext';
+import { useAnswerGameDispatch } from './useAnswerGameDispatch';
+import { useAutoNextSlot } from './useAutoNextSlot';
+import type { AnswerGameConfig, AnswerZone, TileItem } from './types';
+import type { ReactNode } from 'react';
+
+vi.mock('@/lib/game-event-bus', () => ({
+  getGameEventBus: () => ({ emit: vi.fn(), subscribe: vi.fn() }),
+}));
+
+const gameConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: false,
+};
+
+const tileItems: TileItem[] = [
+  { id: 't1', label: 'C', value: 'C' },
+  { id: 't2', label: 'A', value: 'A' },
+];
+
+const answerZones: AnswerZone[] = [
+  {
+    id: 'z0',
+    index: 0,
+    expectedValue: 'C',
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  },
+  {
+    id: 'z1',
+    index: 1,
+    expectedValue: 'A',
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  },
+];
+
+function useHarness() {
+  const dispatch = useAnswerGameDispatch();
+  const state = useAnswerGameContext();
+  if (state.zones.length === 0)
+    dispatch({
+      type: 'INIT_ROUND',
+      tiles: tileItems,
+      zones: answerZones,
+    });
+  const { placeInNextSlot } = useAutoNextSlot();
+  return { state, placeInNextSlot };
+}
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <AnswerGameProvider config={gameConfig}>
+    {children}
+  </AnswerGameProvider>
+);
+
+describe('useAutoNextSlot', () => {
+  it('places tile in activeSlotIndex zone', () => {
+    const { result } = renderHook(() => useHarness(), {
+      wrapper: Wrapper,
+    });
+    act(() => result.current.placeInNextSlot('t1'));
+    expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+  });
+
+  it('advances activeSlotIndex after correct placement', () => {
+    const { result } = renderHook(() => useHarness(), {
+      wrapper: Wrapper,
+    });
+    expect(result.current.state.activeSlotIndex).toBe(0);
+    act(() => result.current.placeInNextSlot('t1'));
+    expect(result.current.state.activeSlotIndex).toBe(1);
+  });
+});

--- a/src/components/answer-game/useAutoNextSlot.ts
+++ b/src/components/answer-game/useAutoNextSlot.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+import { useAnswerGameContext } from './useAnswerGameContext';
+import { useTileEvaluation } from './useTileEvaluation';
+
+export interface AutoNextSlot {
+  placeInNextSlot: (tileId: string) => void;
+}
+
+export function useAutoNextSlot(): AutoNextSlot {
+  const { activeSlotIndex } = useAnswerGameContext();
+  const { placeTile } = useTileEvaluation();
+
+  const placeInNextSlot = useCallback(
+    (tileId: string) => {
+      placeTile(tileId, activeSlotIndex);
+    },
+    [placeTile, activeSlotIndex],
+  );
+
+  return { placeInNextSlot };
+}

--- a/src/components/answer-game/useFreeSwap.test.tsx
+++ b/src/components/answer-game/useFreeSwap.test.tsx
@@ -1,0 +1,95 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AnswerGameProvider } from './AnswerGameProvider';
+import { useAnswerGameContext } from './useAnswerGameContext';
+import { useAnswerGameDispatch } from './useAnswerGameDispatch';
+import { useFreeSwap } from './useFreeSwap';
+import type { AnswerGameConfig, AnswerZone, TileItem } from './types';
+import type { ReactNode } from 'react';
+
+vi.mock('@/lib/game-event-bus', () => ({
+  getGameEventBus: () => ({ emit: vi.fn(), subscribe: vi.fn() }),
+}));
+
+const gameConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: false,
+};
+
+const tileItems: TileItem[] = [
+  { id: 't1', label: 'C', value: 'C' },
+  { id: 't2', label: 'A', value: 'A' },
+];
+
+const answerZones: AnswerZone[] = [
+  {
+    id: 'z0',
+    index: 0,
+    expectedValue: 'C',
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  },
+  {
+    id: 'z1',
+    index: 1,
+    expectedValue: 'A',
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  },
+];
+
+function useHarness() {
+  const dispatch = useAnswerGameDispatch();
+  const state = useAnswerGameContext();
+  if (state.zones.length === 0)
+    dispatch({
+      type: 'INIT_ROUND',
+      tiles: tileItems,
+      zones: answerZones,
+    });
+  const { swapOrPlace } = useFreeSwap();
+  return { state, dispatch, swapOrPlace };
+}
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <AnswerGameProvider config={gameConfig}>
+    {children}
+  </AnswerGameProvider>
+);
+
+describe('useFreeSwap', () => {
+  it('places tile in empty zone', () => {
+    const { result } = renderHook(() => useHarness(), {
+      wrapper: Wrapper,
+    });
+    act(() => result.current.swapOrPlace('t1', 0));
+    expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+  });
+
+  it('swaps tiles when target zone is occupied', () => {
+    const { result } = renderHook(() => useHarness(), {
+      wrapper: Wrapper,
+    });
+    act(() => {
+      result.current.dispatch({
+        type: 'PLACE_TILE',
+        tileId: 't1',
+        zoneIndex: 0,
+      });
+      result.current.dispatch({
+        type: 'PLACE_TILE',
+        tileId: 't2',
+        zoneIndex: 1,
+      });
+    });
+    act(() => result.current.swapOrPlace('t1', 1));
+    expect(result.current.state.zones[0]?.placedTileId).toBe('t2');
+    expect(result.current.state.zones[1]?.placedTileId).toBe('t1');
+  });
+});

--- a/src/components/answer-game/useFreeSwap.ts
+++ b/src/components/answer-game/useFreeSwap.ts
@@ -1,0 +1,41 @@
+import { useCallback } from 'react';
+import { useAnswerGameContext } from './useAnswerGameContext';
+import { useAnswerGameDispatch } from './useAnswerGameDispatch';
+import { useTileEvaluation } from './useTileEvaluation';
+
+export interface FreeSwap {
+  swapOrPlace: (tileId: string, targetZoneIndex: number) => void;
+}
+
+export function useFreeSwap(): FreeSwap {
+  const { zones } = useAnswerGameContext();
+  const dispatch = useAnswerGameDispatch();
+  const { placeTile } = useTileEvaluation();
+
+  const swapOrPlace = useCallback(
+    (tileId: string, targetZoneIndex: number) => {
+      const targetZone = zones[targetZoneIndex];
+      if (!targetZone) return;
+
+      if (targetZone.placedTileId === null) {
+        placeTile(tileId, targetZoneIndex);
+      } else {
+        const sourceZoneIndex = zones.findIndex(
+          (z) => z.placedTileId === tileId,
+        );
+        if (sourceZoneIndex === -1) {
+          placeTile(tileId, targetZoneIndex);
+        } else {
+          dispatch({
+            type: 'SWAP_TILES',
+            fromZoneIndex: sourceZoneIndex,
+            toZoneIndex: targetZoneIndex,
+          });
+        }
+      }
+    },
+    [zones, dispatch, placeTile],
+  );
+
+  return { swapOrPlace };
+}

--- a/src/components/answer-game/useGameTTS.test.tsx
+++ b/src/components/answer-game/useGameTTS.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AnswerGameProvider } from './AnswerGameProvider';
+import { useGameTTS } from './useGameTTS';
+import type { AnswerGameConfig } from './types';
+import type { ReactNode } from 'react';
+
+import { speak } from '@/lib/speech/SpeechOutput';
+
+vi.mock('@/lib/speech/SpeechOutput', () => ({
+  speak: vi.fn(),
+  cancelSpeech: vi.fn(),
+}));
+
+const ttsConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: true,
+};
+
+const noTtsConfig: AnswerGameConfig = {
+  ...ttsConfig,
+  ttsEnabled: false,
+};
+
+function createWrapper(config: AnswerGameConfig) {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <AnswerGameProvider config={config}>{children}</AnswerGameProvider>
+  );
+  Wrapper.displayName = 'AnswerGameTestWrapper';
+  return Wrapper;
+}
+
+describe('useGameTTS', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('speakTile calls speak() when ttsEnabled', () => {
+    const { result } = renderHook(() => useGameTTS(), {
+      wrapper: createWrapper(ttsConfig),
+    });
+    result.current.speakTile('A');
+    expect(speak).toHaveBeenCalledWith('A');
+  });
+
+  it('speakPrompt calls speak() when ttsEnabled', () => {
+    const { result } = renderHook(() => useGameTTS(), {
+      wrapper: createWrapper(ttsConfig),
+    });
+    result.current.speakPrompt('What is this animal?');
+    expect(speak).toHaveBeenCalledWith('What is this animal?');
+  });
+
+  it('speakTile is a no-op when ttsEnabled is false', () => {
+    const { result } = renderHook(() => useGameTTS(), {
+      wrapper: createWrapper(noTtsConfig),
+    });
+    result.current.speakTile('A');
+    expect(speak).not.toHaveBeenCalled();
+  });
+
+  it('speakPrompt is a no-op when ttsEnabled is false', () => {
+    const { result } = renderHook(() => useGameTTS(), {
+      wrapper: createWrapper(noTtsConfig),
+    });
+    result.current.speakPrompt('Some prompt');
+    expect(speak).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/answer-game/useGameTTS.ts
+++ b/src/components/answer-game/useGameTTS.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import { useAnswerGameContext } from './useAnswerGameContext';
+import { speak } from '@/lib/speech/SpeechOutput';
+
+export interface GameTTS {
+  speakTile: (label: string) => void;
+  speakPrompt: (text: string) => void;
+}
+
+export function useGameTTS(): GameTTS {
+  const { config } = useAnswerGameContext();
+  const { ttsEnabled } = config;
+
+  const speakTile = useCallback(
+    (label: string) => {
+      if (ttsEnabled) speak(label);
+    },
+    [ttsEnabled],
+  );
+
+  const speakPrompt = useCallback(
+    (text: string) => {
+      if (ttsEnabled) speak(text);
+    },
+    [ttsEnabled],
+  );
+
+  return { speakTile, speakPrompt };
+}

--- a/src/components/answer-game/useKeyboardDrag.test.tsx
+++ b/src/components/answer-game/useKeyboardDrag.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AnswerGameProvider } from './AnswerGameProvider';
+import { useKeyboardDrag } from './useKeyboardDrag';
+import type { AnswerGameConfig } from './types';
+
+vi.mock('@/lib/game-event-bus', () => ({
+  getGameEventBus: () => ({ emit: vi.fn(), subscribe: vi.fn() }),
+}));
+
+const gameConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: false,
+};
+
+const KeyboardDragHarness = () => {
+  const { pickedUpTileId, keyboardDragRef } = useKeyboardDrag();
+  return (
+    <div ref={keyboardDragRef} data-testid="container">
+      <div
+        data-tile-id="t1"
+        tabIndex={0}
+        data-testid="tile"
+        role="button"
+        aria-label="Tile A"
+      >
+        A
+      </div>
+      <div data-testid="status">{pickedUpTileId ?? 'none'}</div>
+    </div>
+  );
+};
+
+describe('useKeyboardDrag', () => {
+  it('pressing Space on a tile element picks it up', () => {
+    render(
+      <AnswerGameProvider config={gameConfig}>
+        <KeyboardDragHarness />
+      </AnswerGameProvider>,
+    );
+    const tile = screen.getByTestId('tile');
+    fireEvent.keyDown(tile, { key: ' ', code: 'Space' });
+    expect(screen.getByTestId('status')).toHaveTextContent('t1');
+  });
+
+  it('pressing Escape cancels pickup', () => {
+    render(
+      <AnswerGameProvider config={gameConfig}>
+        <KeyboardDragHarness />
+      </AnswerGameProvider>,
+    );
+    const tile = screen.getByTestId('tile');
+    fireEvent.keyDown(tile, { key: ' ', code: 'Space' });
+    expect(screen.getByTestId('status')).toHaveTextContent('t1');
+    fireEvent.keyDown(tile, { key: 'Escape', code: 'Escape' });
+    expect(screen.getByTestId('status')).toHaveTextContent('none');
+  });
+});

--- a/src/components/answer-game/useKeyboardDrag.ts
+++ b/src/components/answer-game/useKeyboardDrag.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+
+export interface KeyboardDrag {
+  pickedUpTileId: string | null;
+  keyboardDragRef: RefObject<HTMLDivElement | null>;
+}
+
+export function useKeyboardDrag(): KeyboardDrag {
+  const [pickedUpTileId, setPickedUpTileId] = useState<string | null>(
+    null,
+  );
+  const pickedUpRef = useRef<string | null>(null);
+  const keyboardDragRef = useRef<HTMLDivElement | null>(null);
+
+  const syncPickedUp = useCallback((id: string | null) => {
+    pickedUpRef.current = id;
+    setPickedUpTileId(id);
+  }, []);
+
+  useEffect(() => {
+    const node = keyboardDragRef.current;
+    if (!node) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement;
+      if (event.key === ' ' || event.key === 'Enter') {
+        event.preventDefault();
+        const tileId = target.dataset['tileId'];
+        if (tileId && !pickedUpRef.current) {
+          syncPickedUp(tileId);
+          return;
+        }
+        if (pickedUpRef.current) {
+          syncPickedUp(null);
+        }
+      } else if (event.key === 'Escape' && pickedUpRef.current) {
+        syncPickedUp(null);
+      }
+    };
+
+    node.addEventListener('keydown', handleKeyDown);
+    return () => node.removeEventListener('keydown', handleKeyDown);
+  }, [syncPickedUp]);
+
+  return {
+    pickedUpTileId,
+    keyboardDragRef,
+  };
+}

--- a/src/components/answer-game/useTileEvaluation.test.tsx
+++ b/src/components/answer-game/useTileEvaluation.test.tsx
@@ -1,0 +1,132 @@
+import { act, renderHook } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { AnswerGameProvider } from './AnswerGameProvider';
+import { useAnswerGameContext } from './useAnswerGameContext';
+import { useAnswerGameDispatch } from './useAnswerGameDispatch';
+import { useTileEvaluation } from './useTileEvaluation';
+import type { AnswerGameConfig, AnswerZone, TileItem } from './types';
+import type { ReactNode } from 'react';
+
+vi.mock('@/lib/game-event-bus', () => ({
+  getGameEventBus: () => ({ emit: vi.fn(), subscribe: vi.fn() }),
+}));
+
+const baseConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: false,
+};
+
+const tiles: TileItem[] = [
+  { id: 't1', label: 'C', value: 'C' },
+  { id: 't2', label: 'X', value: 'X' },
+];
+
+const zones: AnswerZone[] = [
+  {
+    id: 'z0',
+    index: 0,
+    expectedValue: 'C',
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  },
+];
+
+function createWrapper(config: AnswerGameConfig) {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <AnswerGameProvider config={config}>{children}</AnswerGameProvider>
+  );
+  Wrapper.displayName = 'AnswerGameTestWrapper';
+  return Wrapper;
+}
+
+function useTileEvaluationHarness() {
+  const dispatch = useAnswerGameDispatch();
+  const state = useAnswerGameContext();
+  if (state.zones.length === 0) {
+    dispatch({ type: 'INIT_ROUND', tiles, zones });
+  }
+  const { placeTile } = useTileEvaluation();
+  return { state, placeTile };
+}
+
+function useInitialisedEvaluation(_config: AnswerGameConfig) {
+  const dispatch = useAnswerGameDispatch();
+  const { zones: stateZones } = useAnswerGameContext();
+  if (stateZones.length === 0) {
+    dispatch({ type: 'INIT_ROUND', tiles, zones });
+  }
+  return useTileEvaluation();
+}
+
+describe('useTileEvaluation', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('correct placement: zone not marked wrong', () => {
+    const { result } = renderHook(
+      () => useInitialisedEvaluation(baseConfig),
+      {
+        wrapper: createWrapper(baseConfig),
+      },
+    );
+    act(() => result.current.placeTile('t1', 0));
+    expect(result.current.placeTile).toBeDefined();
+  });
+
+  it('lock-auto-eject: EJECT_TILE fires after 1000ms for wrong tile', () => {
+    const { result } = renderHook(() => useTileEvaluationHarness(), {
+      wrapper: createWrapper(baseConfig),
+    });
+
+    act(() => result.current.placeTile('t2', 0));
+    expect(result.current.state.zones[0]?.isWrong).toBe(true);
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.state.zones[0]?.placedTileId).toBeNull();
+    expect(result.current.state.zones[0]?.isWrong).toBe(false);
+  });
+
+  it('reject: no zone placement, only retryCount incremented', () => {
+    const rejectConfig: AnswerGameConfig = {
+      ...baseConfig,
+      wrongTileBehavior: 'reject',
+    };
+
+    const { result } = renderHook(() => useTileEvaluationHarness(), {
+      wrapper: createWrapper(rejectConfig),
+    });
+
+    act(() => result.current.placeTile('t2', 0));
+    expect(result.current.state.zones[0]?.placedTileId).toBeNull();
+    expect(result.current.state.retryCount).toBe(1);
+  });
+
+  it('lock-manual: wrong tile stays until manually removed', () => {
+    const manualConfig: AnswerGameConfig = {
+      ...baseConfig,
+      wrongTileBehavior: 'lock-manual',
+    };
+
+    const { result } = renderHook(() => useTileEvaluationHarness(), {
+      wrapper: createWrapper(manualConfig),
+    });
+
+    act(() => result.current.placeTile('t2', 0));
+    expect(result.current.state.zones[0]?.isWrong).toBe(true);
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(result.current.state.zones[0]?.placedTileId).toBe('t2');
+  });
+});

--- a/src/components/answer-game/useTileEvaluation.ts
+++ b/src/components/answer-game/useTileEvaluation.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useAnswerGameContext } from './useAnswerGameContext';
+import { useAnswerGameDispatch } from './useAnswerGameDispatch';
+import { getGameEventBus } from '@/lib/game-event-bus';
+
+const AUTO_EJECT_DELAY_MS = 1000;
+
+export interface TileEvaluation {
+  placeTile: (tileId: string, zoneIndex: number) => void;
+}
+
+export function useTileEvaluation(): TileEvaluation {
+  const state = useAnswerGameContext();
+  const dispatch = useAnswerGameDispatch();
+  const ejectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  const clearEjectionTimer = useCallback(() => {
+    if (ejectionTimerRef.current !== null) {
+      clearTimeout(ejectionTimerRef.current);
+      ejectionTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearEjectionTimer(), [clearEjectionTimer]);
+
+  const placeTile = useCallback(
+    (tileId: string, zoneIndex: number) => {
+      clearEjectionTimer();
+
+      const tile = state.allTiles.find((t) => t.id === tileId);
+      const zone = state.zones[zoneIndex];
+      if (!tile || !zone) return;
+
+      const correct = tile.value === zone.expectedValue;
+      dispatch({ type: 'PLACE_TILE', tileId, zoneIndex });
+
+      getGameEventBus().emit({
+        type: 'game:evaluate',
+        gameId: state.config.gameId,
+        sessionId: '',
+        profileId: '',
+        timestamp: Date.now(),
+        roundIndex: state.roundIndex,
+        answer: tileId,
+        correct,
+        nearMiss: false,
+      });
+
+      if (
+        !correct &&
+        state.config.wrongTileBehavior === 'lock-auto-eject'
+      ) {
+        ejectionTimerRef.current = setTimeout(() => {
+          dispatch({ type: 'EJECT_TILE', zoneIndex });
+          ejectionTimerRef.current = null;
+        }, AUTO_EJECT_DELAY_MS);
+      }
+    },
+    [state, dispatch, clearEjectionTimer],
+  );
+
+  return { placeTile };
+}

--- a/src/components/game/GameShell.test.tsx
+++ b/src/components/game/GameShell.test.tsx
@@ -1,5 +1,6 @@
 // src/components/game/GameShell.test.tsx
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   afterEach,
   beforeEach,
@@ -154,5 +155,51 @@ describe('GameShell', () => {
     expect(
       screen.getByRole('button', { name: /exit/i }),
     ).toBeInTheDocument();
+  });
+
+  it('opens exit confirmation dialog when Exit is clicked', async () => {
+    renderShell();
+    await userEvent.click(
+      screen.getByRole('button', { name: /exit/i }),
+    );
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(/want to leave the game/i),
+    ).toBeInTheDocument();
+  });
+
+  it('opens exit confirmation dialog when header Back is clicked', async () => {
+    renderShell();
+    await userEvent.click(
+      screen.getByRole('button', { name: /back/i }),
+    );
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  });
+
+  it('closes dialog when Keep Playing is clicked', async () => {
+    renderShell();
+    await userEvent.click(
+      screen.getByRole('button', { name: /exit/i }),
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: /keep playing/i }),
+    );
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  it('marks session abandoned in DB when Leave Game is clicked', async () => {
+    renderShell();
+    await userEvent.click(
+      screen.getByRole('button', { name: /exit/i }),
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: /leave game/i }),
+    );
+
+    // Session should be abandoned in DB
+    const index = await db.session_history_index
+      .findOne('sess-shell-001')
+      .exec();
+    expect(index?.status).toBe('abandoned');
   });
 });

--- a/src/components/game/GameShell.tsx
+++ b/src/components/game/GameShell.tsx
@@ -1,5 +1,7 @@
 // src/components/game/GameShell.tsx
 import { useNavigate } from '@tanstack/react-router';
+import { LogOut, Pause, RotateCcw } from 'lucide-react';
+import { useState } from 'react';
 import type {
   GameEngineState,
   MoveHandler,
@@ -8,6 +10,17 @@ import type {
   SessionMeta,
 } from '@/lib/game-engine/types';
 import type { JSX, ReactNode } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useRxDB } from '@/db/hooks/useRxDB';
 import {
   GameEngineProvider,
   useGameDispatch,
@@ -26,23 +39,35 @@ export interface GameShellProps {
 
 interface GameShellChromeProps {
   config: ResolvedGameConfig;
+  sessionId: string;
   children: ReactNode;
 }
 
 const GameShellChrome = ({
   config,
+  sessionId,
   children,
 }: GameShellChromeProps): JSX.Element => {
   const state = useGameState();
   const dispatch = useGameDispatch();
   const navigate = useNavigate();
+  const { db } = useRxDB();
+  const [exitOpen, setExitOpen] = useState(false);
   const locale = 'en'; // TODO: use i18n locale in M5
 
   const roundDisplay = state.roundIndex + 1;
   const title = config.title['en'] ?? config.gameId;
 
-  const handleExit = () => {
-    void navigate({ to: '/$locale/dashboard', params: { locale } });
+  const handleConfirmExit = async () => {
+    if (db) {
+      const doc = await db.session_history_index
+        .findOne(sessionId)
+        .exec();
+      if (doc && doc.status === 'in-progress') {
+        await doc.incrementalPatch({ status: 'abandoned' });
+      }
+    }
+    void navigate({ to: '/$locale', params: { locale } });
   };
 
   const handleUndo = () => {
@@ -59,7 +84,7 @@ const GameShellChrome = ({
       <header className="flex items-center justify-between border-b px-4 py-2">
         <button
           className="text-sm text-muted-foreground"
-          onClick={handleExit}
+          onClick={() => setExitOpen(true)}
           aria-label="Back"
           type="button"
         >
@@ -106,25 +131,52 @@ const GameShellChrome = ({
             aria-label="Undo"
             type="button"
           >
-            ⟲ Undo
+            <RotateCcw aria-hidden="true" />
+            Undo
           </button>
         )}
         <button
-          className="rounded px-3 py-1 text-sm hover:bg-muted"
+          className="flex items-center gap-1 rounded px-3 py-1 text-sm hover:bg-muted"
           type="button"
           aria-label="Pause"
         >
-          II Pause
+          <Pause aria-hidden="true" />
+          Pause
         </button>
         <button
-          className="rounded px-3 py-1 text-sm hover:bg-muted"
-          onClick={handleExit}
+          className="flex items-center gap-1 rounded px-3 py-1 text-sm hover:bg-muted"
+          onClick={() => setExitOpen(true)}
           aria-label="Exit"
           type="button"
         >
-          ✕ Exit
+          <LogOut aria-hidden="true" />
+          Exit
         </button>
       </footer>
+
+      {/* Exit confirmation */}
+      <AlertDialog open={exitOpen} onOpenChange={setExitOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Want to leave the game?</AlertDialogTitle>
+            <AlertDialogDescription>
+              That&apos;s okay! You can start a new game from the home
+              screen.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep Playing</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                void handleConfirmExit();
+              }}
+            >
+              Leave Game
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };
@@ -146,6 +198,8 @@ export const GameShell = ({
     meta={meta}
     initialLog={initialLog}
   >
-    <GameShellChrome config={config}>{children}</GameShellChrome>
+    <GameShellChrome config={config} sessionId={sessionId}>
+      {children}
+    </GameShellChrome>
   </GameEngineProvider>
 );

--- a/src/components/questions/AudioButton/AudioButton.stories.tsx
+++ b/src/components/questions/AudioButton/AudioButton.stories.tsx
@@ -1,0 +1,30 @@
+import { AudioButton } from './AudioButton';
+import type { AnswerGameConfig } from '@/components/answer-game/types';
+import type { Meta, StoryObj } from '@storybook/react';
+import { AnswerGameProvider } from '@/components/answer-game/AnswerGameProvider';
+
+const storyConfig: AnswerGameConfig = {
+  gameId: 'storybook',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: true,
+};
+
+const meta: Meta<typeof AudioButton> = {
+  component: AudioButton,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <AnswerGameProvider config={storyConfig}>
+        <Story />
+      </AnswerGameProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof AudioButton>;
+
+export const Default: Story = { args: { prompt: 'cat' } };

--- a/src/components/questions/AudioButton/AudioButton.test.tsx
+++ b/src/components/questions/AudioButton/AudioButton.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AudioButton } from './AudioButton';
+import type { AnswerGameConfig } from '@/components/answer-game/types';
+import { AnswerGameProvider } from '@/components/answer-game/AnswerGameProvider';
+import { speak } from '@/lib/speech/SpeechOutput';
+
+vi.mock('@/lib/speech/SpeechOutput', () => ({
+  speak: vi.fn(),
+  cancelSpeech: vi.fn(),
+}));
+
+const gameConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: true,
+};
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <AnswerGameProvider config={gameConfig}>
+    {children}
+  </AnswerGameProvider>
+);
+
+describe('AudioButton', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders a button with aria-label', () => {
+    render(<AudioButton prompt="cat" />, { wrapper: Wrapper });
+    expect(
+      screen.getByRole('button', { name: 'Hear the question' }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls speak() when clicked', async () => {
+    const user = userEvent.setup();
+    render(<AudioButton prompt="cat" />, { wrapper: Wrapper });
+    await user.click(
+      screen.getByRole('button', { name: 'Hear the question' }),
+    );
+    expect(speak).toHaveBeenCalledWith('cat');
+  });
+});

--- a/src/components/questions/AudioButton/AudioButton.tsx
+++ b/src/components/questions/AudioButton/AudioButton.tsx
@@ -1,0 +1,21 @@
+import { Volume2 } from 'lucide-react';
+import { useGameTTS } from '@/components/answer-game/useGameTTS';
+
+interface AudioButtonProps {
+  prompt: string;
+}
+
+export const AudioButton = ({ prompt }: AudioButtonProps) => {
+  const { speakPrompt } = useGameTTS();
+
+  return (
+    <button
+      type="button"
+      aria-label="Hear the question"
+      className="flex size-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-md active:scale-95"
+      onClick={() => speakPrompt(prompt)}
+    >
+      <Volume2 size={24} aria-hidden="true" />
+    </button>
+  );
+};

--- a/src/components/questions/DotGroupQuestion/DotGroupQuestion.stories.tsx
+++ b/src/components/questions/DotGroupQuestion/DotGroupQuestion.stories.tsx
@@ -1,0 +1,32 @@
+import { DotGroupQuestion } from './DotGroupQuestion';
+import type { AnswerGameConfig } from '@/components/answer-game/types';
+import type { Meta, StoryObj } from '@storybook/react';
+import { AnswerGameProvider } from '@/components/answer-game/AnswerGameProvider';
+
+const storyConfig: AnswerGameConfig = {
+  gameId: 'storybook',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: true,
+};
+
+const meta: Meta<typeof DotGroupQuestion> = {
+  component: DotGroupQuestion,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <AnswerGameProvider config={storyConfig}>
+        <Story />
+      </AnswerGameProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof DotGroupQuestion>;
+
+export const OneDot: Story = { args: { count: 1, prompt: 'one' } };
+export const ThreeDots: Story = { args: { count: 3, prompt: 'three' } };
+export const FiveDots: Story = { args: { count: 5, prompt: 'five' } };

--- a/src/components/questions/DotGroupQuestion/DotGroupQuestion.test.tsx
+++ b/src/components/questions/DotGroupQuestion/DotGroupQuestion.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DotGroupQuestion } from './DotGroupQuestion';
+import type { AnswerGameConfig } from '@/components/answer-game/types';
+import { AnswerGameProvider } from '@/components/answer-game/AnswerGameProvider';
+import { speak } from '@/lib/speech/SpeechOutput';
+
+vi.mock('@/lib/speech/SpeechOutput', () => ({
+  speak: vi.fn(),
+  cancelSpeech: vi.fn(),
+}));
+
+const gameConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: true,
+};
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <AnswerGameProvider config={gameConfig}>
+    {children}
+  </AnswerGameProvider>
+);
+
+describe('DotGroupQuestion', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the correct number of dots', () => {
+    render(<DotGroupQuestion count={3} prompt="three dots" />, {
+      wrapper: Wrapper,
+    });
+    expect(screen.getAllByRole('presentation')).toHaveLength(3);
+  });
+
+  it('has correct aria-label on container', () => {
+    render(<DotGroupQuestion count={3} prompt="three dots" />, {
+      wrapper: Wrapper,
+    });
+    expect(
+      screen.getByRole('button', { name: 'three dots — tap to hear' }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls speak() on click', async () => {
+    const user = userEvent.setup();
+    render(<DotGroupQuestion count={3} prompt="three dots" />, {
+      wrapper: Wrapper,
+    });
+    await user.click(screen.getByRole('button'));
+    expect(speak).toHaveBeenCalledWith('three dots');
+  });
+});

--- a/src/components/questions/DotGroupQuestion/DotGroupQuestion.tsx
+++ b/src/components/questions/DotGroupQuestion/DotGroupQuestion.tsx
@@ -1,0 +1,30 @@
+import { useGameTTS } from '@/components/answer-game/useGameTTS';
+
+interface DotGroupQuestionProps {
+  count: number;
+  prompt: string;
+}
+
+export const DotGroupQuestion = ({
+  count,
+  prompt,
+}: DotGroupQuestionProps) => {
+  const { speakPrompt } = useGameTTS();
+
+  return (
+    <button
+      type="button"
+      aria-label={`${prompt} — tap to hear`}
+      className="flex flex-wrap justify-center gap-3 rounded-xl p-4 focus-visible:outline-2 focus-visible:outline-offset-2"
+      onClick={() => speakPrompt(prompt)}
+    >
+      {Array.from({ length: count }, (_, i) => (
+        <span
+          key={i}
+          role="presentation"
+          className="size-10 rounded-full bg-primary"
+        />
+      ))}
+    </button>
+  );
+};

--- a/src/components/questions/ImageQuestion/ImageQuestion.stories.tsx
+++ b/src/components/questions/ImageQuestion/ImageQuestion.stories.tsx
@@ -1,0 +1,32 @@
+import { ImageQuestion } from './ImageQuestion';
+import type { AnswerGameConfig } from '@/components/answer-game/types';
+import type { Meta, StoryObj } from '@storybook/react';
+import { AnswerGameProvider } from '@/components/answer-game/AnswerGameProvider';
+
+const storyConfig: AnswerGameConfig = {
+  gameId: 'storybook',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: true,
+};
+
+const meta: Meta<typeof ImageQuestion> = {
+  component: ImageQuestion,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <AnswerGameProvider config={storyConfig}>
+        <Story />
+      </AnswerGameProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof ImageQuestion>;
+
+export const Default: Story = {
+  args: { src: 'https://placehold.co/160', prompt: 'cat' },
+};

--- a/src/components/questions/ImageQuestion/ImageQuestion.test.tsx
+++ b/src/components/questions/ImageQuestion/ImageQuestion.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ImageQuestion } from './ImageQuestion';
+import type { AnswerGameConfig } from '@/components/answer-game/types';
+import { AnswerGameProvider } from '@/components/answer-game/AnswerGameProvider';
+import { speak } from '@/lib/speech/SpeechOutput';
+
+vi.mock('@/lib/speech/SpeechOutput', () => ({
+  speak: vi.fn(),
+  cancelSpeech: vi.fn(),
+}));
+
+const gameConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: true,
+};
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <AnswerGameProvider config={gameConfig}>
+    {children}
+  </AnswerGameProvider>
+);
+
+describe('ImageQuestion', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders an image with the given src', () => {
+    render(<ImageQuestion src="/cat.svg" prompt="cat" />, {
+      wrapper: Wrapper,
+    });
+    expect(
+      screen.getByRole('img', { name: /cat/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('has accessible role="button" and correct aria-label', () => {
+    render(<ImageQuestion src="/cat.svg" prompt="cat" />, {
+      wrapper: Wrapper,
+    });
+    expect(
+      screen.getByRole('button', { name: 'cat — tap to hear' }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls speak() when clicked and ttsEnabled', async () => {
+    const user = userEvent.setup();
+    render(<ImageQuestion src="/cat.svg" prompt="cat" />, {
+      wrapper: Wrapper,
+    });
+    await user.click(
+      screen.getByRole('button', { name: 'cat — tap to hear' }),
+    );
+    expect(speak).toHaveBeenCalledWith('cat');
+  });
+});

--- a/src/components/questions/ImageQuestion/ImageQuestion.tsx
+++ b/src/components/questions/ImageQuestion/ImageQuestion.tsx
@@ -1,0 +1,25 @@
+import { useGameTTS } from '@/components/answer-game/useGameTTS';
+
+interface ImageQuestionProps {
+  src: string;
+  prompt: string;
+}
+
+export const ImageQuestion = ({ src, prompt }: ImageQuestionProps) => {
+  const { speakPrompt } = useGameTTS();
+
+  return (
+    <button
+      type="button"
+      aria-label={`${prompt} — tap to hear`}
+      className="rounded-xl focus-visible:outline-2 focus-visible:outline-offset-2"
+      onClick={() => speakPrompt(prompt)}
+    >
+      <img
+        src={src}
+        alt={prompt}
+        className="size-40 rounded-xl object-contain"
+      />
+    </button>
+  );
+};

--- a/src/components/questions/TextQuestion/TextQuestion.stories.tsx
+++ b/src/components/questions/TextQuestion/TextQuestion.stories.tsx
@@ -1,0 +1,34 @@
+import { TextQuestion } from './TextQuestion';
+import type { AnswerGameConfig } from '@/components/answer-game/types';
+import type { Meta, StoryObj } from '@storybook/react';
+import { AnswerGameProvider } from '@/components/answer-game/AnswerGameProvider';
+
+const storyConfig: AnswerGameConfig = {
+  gameId: 'storybook',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: true,
+};
+
+const meta: Meta<typeof TextQuestion> = {
+  component: TextQuestion,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <AnswerGameProvider config={storyConfig}>
+        <Story />
+      </AnswerGameProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof TextQuestion>;
+
+export const Default: Story = { args: { text: 'three' } };
+export const LongWord: Story = { args: { text: 'elephant' } };
+export const SentenceGap: Story = {
+  args: { text: 'The ___ sat on the mat.' },
+};

--- a/src/components/questions/TextQuestion/TextQuestion.test.tsx
+++ b/src/components/questions/TextQuestion/TextQuestion.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TextQuestion } from './TextQuestion';
+import type { AnswerGameConfig } from '@/components/answer-game/types';
+import { AnswerGameProvider } from '@/components/answer-game/AnswerGameProvider';
+import { speak } from '@/lib/speech/SpeechOutput';
+
+vi.mock('@/lib/speech/SpeechOutput', () => ({
+  speak: vi.fn(),
+  cancelSpeech: vi.fn(),
+}));
+
+const gameConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: true,
+};
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <AnswerGameProvider config={gameConfig}>
+    {children}
+  </AnswerGameProvider>
+);
+
+describe('TextQuestion', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the text', () => {
+    render(<TextQuestion text="three" />, { wrapper: Wrapper });
+    expect(screen.getByText('three')).toBeInTheDocument();
+  });
+
+  it('has role="button" and correct aria-label', () => {
+    render(<TextQuestion text="three" />, { wrapper: Wrapper });
+    expect(
+      screen.getByRole('button', { name: 'three — tap to hear' }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls speak() on click', async () => {
+    const user = userEvent.setup();
+    render(<TextQuestion text="three" />, { wrapper: Wrapper });
+    await user.click(screen.getByRole('button'));
+    expect(speak).toHaveBeenCalledWith('three');
+  });
+});

--- a/src/components/questions/TextQuestion/TextQuestion.tsx
+++ b/src/components/questions/TextQuestion/TextQuestion.tsx
@@ -1,0 +1,20 @@
+import { useGameTTS } from '@/components/answer-game/useGameTTS';
+
+interface TextQuestionProps {
+  text: string;
+}
+
+export const TextQuestion = ({ text }: TextQuestionProps) => {
+  const { speakPrompt } = useGameTTS();
+
+  return (
+    <button
+      type="button"
+      aria-label={`${text} — tap to hear`}
+      className="rounded-lg px-6 py-3 text-4xl font-bold focus-visible:outline-2 focus-visible:outline-offset-2"
+      onClick={() => speakPrompt(text)}
+    >
+      {text}
+    </button>
+  );
+};

--- a/src/components/questions/index.ts
+++ b/src/components/questions/index.ts
@@ -1,0 +1,4 @@
+export { ImageQuestion } from './ImageQuestion/ImageQuestion';
+export { AudioButton } from './AudioButton/AudioButton';
+export { TextQuestion } from './TextQuestion/TextQuestion';
+export { DotGroupQuestion } from './DotGroupQuestion/DotGroupQuestion';

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,6 +55,15 @@
   resolved "https://registry.yarnpkg.com/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz#ad5549322dfe9d153d4b4dd6f7ff2ae234b06e24"
   integrity sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==
 
+"@atlaskit/pragmatic-drag-and-drop@^1.7.10":
+  version "1.7.10"
+  resolved "https://registry.yarnpkg.com/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-1.7.10.tgz#4c9173fd3e496b65bc89b9f1ff45da12fb9feb9c"
+  integrity sha512-2oHJbThv26CVxM+N8w1X9iyvnts9f8n5+XdCHyG2DtLtqk97rsvbykUyRV2m2llpH06ZdBycycz/+H7eBgRN4A==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    bind-event-listener "^3.0.0"
+    raf-schd "^4.0.3"
+
 "@axe-core/playwright@^4.11.1":
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/@axe-core/playwright/-/playwright-4.11.1.tgz#d6e2b06ddb1b8ff460ca0f6f0bc96f2f03f6d91b"
@@ -976,7 +985,7 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
-"@babel/runtime@7.29.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.29.2":
+"@babel/runtime@7.29.2", "@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.29.2":
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
@@ -4954,6 +4963,11 @@ binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
+bind-event-listener@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bind-event-listener/-/bind-event-listener-3.0.0.tgz#c90f9a7fcb65cac21045f810c20ef7e647a74921"
+  integrity sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==
 
 body-parser@^2.2.1:
   version "2.2.2"
@@ -10841,6 +10855,11 @@ radix-ui@^1.4.3:
     "@radix-ui/react-use-layout-effect" "1.1.1"
     "@radix-ui/react-use-size" "1.1.1"
     "@radix-ui/react-visually-hidden" "1.2.3"
+
+raf-schd@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
 
 randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Summary

- **AnswerGame primitive**: state machine (`answer-game-reducer`), provider (`AnswerGameProvider`), and composition hooks (`useTileEvaluation`, `useFreeSwap`, `useAutoNextSlot`, `useKeyboardDrag`, `useGameTTS`) for the drag-and-drop answer game
- **Question components**: `AudioButton`, `TextQuestion`, `ImageQuestion`, `DotGroupQuestion` — all with Storybook stories and unit tests
- **Overlay components**: `GameOverOverlay`, `EncouragementAnnouncer`, `ScoreAnimation`
- **Exit confirmation dialog**: clicking Exit (footer) or Back (header) now shows a kid-friendly `AlertDialog` ("Want to leave the game?") instead of navigating immediately
- **Session abandonment fix**: confirmed exit patches `status: 'abandoned'` in IndexedDB before navigating, fixing the bug where `findInProgressSession` kept resuming the old session when a new game config was started
- **Lucide icons**: replaced emoji placeholders with `RotateCcw`, `Pause`, `LogOut` on footer buttons

## Test plan

- [ ] All 173 unit tests pass (`yarn test`)
- [ ] Lint + typecheck clean (`yarn lint && yarn typecheck`)
- [ ] Storybook interaction tests pass (`yarn test:storybook`)
- [ ] E2E smoke + a11y tests pass (`yarn test:e2e`)
- [ ] In-app: click Exit opens dialog; "Keep Playing" dismisses it; "Leave Game" returns to home and the session is no longer resumed on next game start
- [ ] In-app: clicking the header Back arrow also opens the same dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)