### PR TITLE
fix(game): exit confirmation dialog with session abandonment

### DIFF
--- a/src/components/game/GameShell.test.tsx
+++ b/src/components/game/GameShell.test.tsx
@@ -1,5 +1,6 @@
 // src/components/game/GameShell.test.tsx
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   afterEach,
   beforeEach,
@@ -154,5 +155,51 @@ describe('GameShell', () => {
     expect(
       screen.getByRole('button', { name: /exit/i }),
     ).toBeInTheDocument();
+  });
+
+  it('opens exit confirmation dialog when Exit is clicked', async () => {
+    renderShell();
+    await userEvent.click(
+      screen.getByRole('button', { name: /exit/i }),
+    );
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(/want to leave the game/i),
+    ).toBeInTheDocument();
+  });
+
+  it('opens exit confirmation dialog when header Back is clicked', async () => {
+    renderShell();
+    await userEvent.click(
+      screen.getByRole('button', { name: /back/i }),
+    );
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  });
+
+  it('closes dialog when Keep Playing is clicked', async () => {
+    renderShell();
+    await userEvent.click(
+      screen.getByRole('button', { name: /exit/i }),
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: /keep playing/i }),
+    );
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  it('marks session abandoned in DB when Leave Game is clicked', async () => {
+    renderShell();
+    await userEvent.click(
+      screen.getByRole('button', { name: /exit/i }),
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: /leave game/i }),
+    );
+
+    // Session should be abandoned in DB
+    const index = await db.session_history_index
+      .findOne('sess-shell-001')
+      .exec();
+    expect(index?.status).toBe('abandoned');
   });
 });

--- a/src/components/game/GameShell.tsx
+++ b/src/components/game/GameShell.tsx
@@ -1,5 +1,7 @@
 // src/components/game/GameShell.tsx
 import { useNavigate, useParams } from '@tanstack/react-router';
+import { LogOut, Pause, RotateCcw } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type {
   GameEngineState,
@@ -9,6 +11,17 @@ import type {
   SessionMeta,
 } from '@/lib/game-engine/types';
 import type { JSX, ReactNode } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useRxDB } from '@/db/hooks/useRxDB';
 import { useGameRoundProgress } from '@/lib/game-engine/GameRoundContext';
 import {
   GameEngineProvider,
@@ -28,11 +41,13 @@ export interface GameShellProps {
 
 interface GameShellChromeProps {
   config: ResolvedGameConfig;
+  sessionId: string;
   children: ReactNode;
 }
 
 const GameShellChrome = ({
   config,
+  sessionId,
   children,
 }: GameShellChromeProps): JSX.Element => {
   const state = useGameState();
@@ -40,6 +55,8 @@ const GameShellChrome = ({
   const navigate = useNavigate();
   const { t } = useTranslation('games');
   const { locale } = useParams({ from: '/$locale' });
+  const { db } = useRxDB();
+  const [exitOpen, setExitOpen] = useState(false);
 
   const roundOverride = useGameRoundProgress();
   const roundCurrent = roundOverride?.current ?? state.roundIndex + 1;
@@ -47,7 +64,15 @@ const GameShellChrome = ({
   const title =
     config.title[locale] ?? config.title['en'] ?? config.gameId;
 
-  const handleExit = () => {
+  const handleConfirmExit = async () => {
+    if (db) {
+      const doc = await db.session_history_index
+        .findOne(sessionId)
+        .exec();
+      if (doc && doc.status === 'in-progress') {
+        await doc.incrementalPatch({ status: 'abandoned' });
+      }
+    }
     void navigate({ to: '/$locale', params: { locale } });
   };
 
@@ -65,7 +90,7 @@ const GameShellChrome = ({
       <header className="flex items-center justify-between border-b px-4 py-2">
         <button
           className="text-sm text-muted-foreground"
-          onClick={handleExit}
+          onClick={() => setExitOpen(true)}
           aria-label="Back"
           type="button"
         >
@@ -117,25 +142,52 @@ const GameShellChrome = ({
             aria-label="Undo"
             type="button"
           >
-            ⟲ {t('shell.undo')}
+            <RotateCcw aria-hidden="true" />
+            {t('shell.undo')}
           </button>
         )}
         <button
-          className="rounded px-3 py-1 text-sm hover:bg-muted"
+          className="flex items-center gap-1 rounded px-3 py-1 text-sm hover:bg-muted"
           type="button"
           aria-label="Pause"
         >
-          II {t('shell.pause')}
+          <Pause aria-hidden="true" />
+          {t('shell.pause')}
         </button>
         <button
-          className="rounded px-3 py-1 text-sm hover:bg-muted"
-          onClick={handleExit}
+          className="flex items-center gap-1 rounded px-3 py-1 text-sm hover:bg-muted"
+          onClick={() => setExitOpen(true)}
           aria-label="Exit"
           type="button"
         >
-          ✕ {t('shell.exit')}
+          <LogOut aria-hidden="true" />
+          {t('shell.exit')}
         </button>
       </footer>
+
+      {/* Exit confirmation */}
+      <AlertDialog open={exitOpen} onOpenChange={setExitOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Want to leave the game?</AlertDialogTitle>
+            <AlertDialogDescription>
+              That&apos;s okay! You can start a new game from the home
+              screen.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep Playing</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                void handleConfirmExit();
+              }}
+            >
+              Leave Game
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };
@@ -157,6 +209,8 @@ export const GameShell = ({
     meta={meta}
     initialLog={initialLog}
   >
-    <GameShellChrome config={config}>{children}</GameShellChrome>
+    <GameShellChrome config={config} sessionId={sessionId}>
+      {children}
+    </GameShellChrome>
   </GameEngineProvider>
 );


### PR DESCRIPTION
## Summary

- Clicking Exit (footer) or the header Back arrow now opens a kid-friendly `AlertDialog` ("Want to leave the game?") instead of navigating immediately
- Confirmed exit patches `status: 'abandoned'` in IndexedDB before navigating, fixing the bug where `findInProgressSession` kept resuming the old session when starting a new game config
- Replaced emoji placeholders with Lucide icons (`RotateCcw`, `Pause`, `LogOut`) on footer buttons

## Test plan

- [ ] Click Exit → dialog appears; "Keep Playing" dismisses it
- [ ] Click Exit → "Leave Game" → returns to home; session not resumed on next game start
- [ ] Header Back arrow also triggers the same dialog
- [ ] All 396 unit tests pass
- [ ] Storybook + E2E pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)