### PR TITLE
fix: type issues and keyboard input improvements

### DIFF
--- a/src/components/answer-game/AnswerGameProvider.test.tsx
+++ b/src/components/answer-game/AnswerGameProvider.test.tsx
@@ -73,7 +73,7 @@ describe('AnswerGameProvider', () => {
     console.error = consoleError;
   });
 
-  it('provides null TouchKeyboardContext on non-touch devices', () => {
+  it('provides TouchKeyboardContext focusKeyboard fn for type mode on all devices', () => {
     const FocusReader = () => {
       const focusKeyboard = useTouchKeyboard();
       return (
@@ -86,6 +86,27 @@ describe('AnswerGameProvider', () => {
     render(
       <AnswerGameProvider
         config={{ ...gameConfig, inputMethod: 'type' }}
+      >
+        <FocusReader />
+      </AnswerGameProvider>,
+    );
+
+    expect(screen.getByTestId('has-focus')).toHaveTextContent('fn');
+  });
+
+  it('provides null TouchKeyboardContext for drag mode', () => {
+    const FocusReader = () => {
+      const focusKeyboard = useTouchKeyboard();
+      return (
+        <div data-testid="has-focus">
+          {focusKeyboard === null ? 'null' : 'fn'}
+        </div>
+      );
+    };
+
+    render(
+      <AnswerGameProvider
+        config={{ ...gameConfig, inputMethod: 'drag' }}
       >
         <FocusReader />
       </AnswerGameProvider>,

--- a/src/components/answer-game/AnswerGameProvider.tsx
+++ b/src/components/answer-game/AnswerGameProvider.tsx
@@ -107,22 +107,21 @@ export const AnswerGameProvider = ({
     total: config.totalRounds,
   };
 
-  const usesTouchKeyboard =
-    navigator.maxTouchPoints > 0 && config.inputMethod !== 'drag';
+  const usesTyping = config.inputMethod !== 'drag';
 
   return (
     <GameRoundContext.Provider value={roundProgress}>
       <AnswerGameStateContext.Provider value={state}>
         <AnswerGameDispatchContext.Provider value={dispatch}>
-          {usesTouchKeyboard ? (
+          {usesTyping ? (
             <TouchKeyboardAdapter
               inputMode={config.touchKeyboardInputMode ?? 'text'}
             >
+              <KeyboardInputAdapter />
               {children}
             </TouchKeyboardAdapter>
           ) : (
             <TouchKeyboardContext.Provider value={null}>
-              <KeyboardInputAdapter />
               {children}
             </TouchKeyboardContext.Provider>
           )}

--- a/src/components/answer-game/HiddenKeyboardInput.tsx
+++ b/src/components/answer-game/HiddenKeyboardInput.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { useAnswerGameContext } from './useAnswerGameContext';
 import type { AnswerGameConfig } from './types';
 import type { RefObject } from 'react';
 
@@ -9,22 +11,45 @@ interface HiddenKeyboardInputProps {
 export const HiddenKeyboardInput = ({
   inputRef,
   inputMode,
-}: HiddenKeyboardInputProps) => (
-  <input
-    ref={inputRef}
-    type="text"
-    inputMode={inputMode}
-    data-touch-keyboard="true"
-    aria-hidden="true"
-    tabIndex={-1}
-    style={{
-      position: 'absolute',
-      opacity: 0,
-      pointerEvents: 'none',
-      width: 1,
-      height: 1,
-      top: 0,
-      left: 0,
-    }}
-  />
-);
+}: HiddenKeyboardInputProps) => {
+  const { phase, activeSlotIndex } = useAnswerGameContext();
+
+  // Auto-focus the hidden input on desktop so physical keyboard strokes
+  // are captured without the user needing to tap a slot first. Re-focus
+  // whenever the active slot changes (e.g. after a tile is placed) or
+  // the game phase changes (e.g. returning to 'playing').
+  useEffect(() => {
+    if (phase !== 'playing') return;
+    const el = inputRef.current;
+    if (!el) return;
+    // Only auto-focus when no other interactive element is focused,
+    // so we don't steal focus from drag interactions.
+    if (
+      document.activeElement === document.body ||
+      document.activeElement === null
+    ) {
+      el.focus();
+    }
+  }, [inputRef, activeSlotIndex, phase]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      inputMode={inputMode}
+      autoComplete="off"
+      data-touch-keyboard="true"
+      aria-hidden="true"
+      tabIndex={-1}
+      style={{
+        position: 'absolute',
+        opacity: 0,
+        pointerEvents: 'none',
+        width: 1,
+        height: 1,
+        top: 0,
+        left: 0,
+      }}
+    />
+  );
+};

--- a/src/components/answer-game/Slot/Slot.tsx
+++ b/src/components/answer-game/Slot/Slot.tsx
@@ -128,6 +128,12 @@ export const Slot = ({
                 children(renderProps)
               )}
             </button>
+            {showCursor ? (
+              <span
+                aria-hidden="true"
+                className="pointer-events-none absolute bottom-2 left-1/2 h-0.5 w-7 -translate-x-1/2 rounded-sm bg-destructive animate-blink"
+              />
+            ) : null}
           </>
         )}
       </InnerTag>

--- a/src/components/answer-game/Slot/Slot.tsx
+++ b/src/components/answer-game/Slot/Slot.tsx
@@ -56,6 +56,12 @@ export const Slot = ({
           : isWrong
             ? 'border-destructive bg-destructive/10 text-destructive'
             : 'border-primary bg-primary/10 text-primary',
+    // Focus ring on filled active slot (wrong = destructive, correct = primary)
+    !isEmpty && showCursor && isWrong
+      ? 'ring-2 ring-destructive ring-offset-2'
+      : !isEmpty && showCursor && !isWrong
+        ? 'ring-2 ring-primary ring-offset-2'
+        : '',
   ]
     .filter(Boolean)
     .join(' ');

--- a/src/components/answer-game/Slot/Slot.tsx
+++ b/src/components/answer-game/Slot/Slot.tsx
@@ -30,7 +30,6 @@ export const Slot = ({
     label,
     isEmpty,
     isWrong,
-    isActive,
     showCursor,
     isPreview,
     previewLabel,
@@ -49,18 +48,16 @@ export const Slot = ({
     'relative flex items-center justify-center border-2 transition-all overflow-hidden',
     isPreview
       ? 'border-dashed border-primary'
-      : isEmpty && !isActive
+      : isEmpty
         ? 'border-border'
-        : isEmpty && isActive
-          ? 'border-primary ring-2 ring-primary ring-offset-2'
-          : isWrong
-            ? 'border-destructive bg-destructive/10 text-destructive'
-            : 'border-primary bg-primary/10 text-primary',
-    // Focus ring on filled active slot (wrong = destructive, correct = primary)
-    !isEmpty && showCursor && isWrong
+        : isWrong
+          ? 'border-destructive bg-destructive/10 text-destructive'
+          : 'border-primary bg-primary/10 text-primary',
+    // Focus ring on active slot (driven by showCursor, works in all modes)
+    showCursor && isWrong
       ? 'ring-2 ring-destructive ring-offset-2'
-      : !isEmpty && showCursor && !isWrong
-        ? 'ring-2 ring-primary ring-offset-2'
+      : showCursor
+        ? 'border-primary ring-2 ring-primary ring-offset-2'
         : '',
   ]
     .filter(Boolean)

--- a/src/components/answer-game/Slot/useSlotBehavior.test.tsx
+++ b/src/components/answer-game/Slot/useSlotBehavior.test.tsx
@@ -177,6 +177,22 @@ describe('useSlotBehavior', () => {
     expect(result.current.result.renderProps.showCursor).toBe(true);
   });
 
+  it('shows cursor in free-swap mode when inputMethod is type', () => {
+    const freeSwapTypeConfig: AnswerGameConfig = {
+      ...baseConfig,
+      slotInteraction: 'free-swap',
+      inputMethod: 'type',
+    };
+
+    const { result } = renderHook(() => useHarness(0, emptyZones), {
+      wrapper: createWrapper(freeSwapTypeConfig),
+    });
+
+    // free-swap + type: isActive is false but cursor still shows on activeSlot
+    expect(result.current.result.renderProps.isActive).toBe(false);
+    expect(result.current.result.renderProps.showCursor).toBe(true);
+  });
+
   it('does not show cursor when inputMethod is drag', () => {
     const orderedDragConfig: AnswerGameConfig = {
       ...baseConfig,

--- a/src/components/answer-game/Slot/useSlotBehavior.ts
+++ b/src/components/answer-game/Slot/useSlotBehavior.ts
@@ -73,7 +73,7 @@ export const useSlotBehavior = (
   const isActive = isOrdered && activeSlotIndex === index;
   const showCursor =
     activeSlotIndex === index &&
-    isEmpty &&
+    (isEmpty || isWrong) &&
     config.inputMethod !== 'drag';
   const isBeingDragged = tileId !== null && dragActiveTileId === tileId;
 

--- a/src/components/answer-game/Slot/useSlotBehavior.ts
+++ b/src/components/answer-game/Slot/useSlotBehavior.ts
@@ -72,7 +72,9 @@ export const useSlotBehavior = (
 
   const isActive = isOrdered && activeSlotIndex === index;
   const showCursor =
-    isActive && isEmpty && config.inputMethod !== 'drag';
+    activeSlotIndex === index &&
+    isEmpty &&
+    config.inputMethod !== 'drag';
   const isBeingDragged = tileId !== null && dragActiveTileId === tileId;
 
   // Preview derivation

--- a/src/components/answer-game/answer-game-reducer.test.ts
+++ b/src/components/answer-game/answer-game-reducer.test.ts
@@ -681,7 +681,7 @@ describe('answerGameReducer', () => {
         value: 'Y',
         zoneIndex: 0,
       });
-      expect(next.zones[0].placedTileId).toBe('typed-2');
+      expect(next.zones[0]?.placedTileId).toBe('typed-2');
       // Old virtual tile cleaned up
       expect(
         next.allTiles.find((t) => t.id === 'typed-1'),

--- a/src/components/answer-game/answer-game-reducer.test.ts
+++ b/src/components/answer-game/answer-game-reducer.test.ts
@@ -658,7 +658,7 @@ describe('answerGameReducer', () => {
       expect(state.activeSlotIndex).toBe(1);
     });
 
-    it('does nothing when zone is locked', () => {
+    it('replaces a wrong locked tile when typing over it', () => {
       let state = answerGameReducer(
         makeInitialState(lockManualConfig),
         {
@@ -674,14 +674,21 @@ describe('answerGameReducer', () => {
         value: 'X',
         zoneIndex: 0,
       });
-      // Try to type again on the locked slot
+      // Type again on the locked wrong slot — should replace
       const next = answerGameReducer(state, {
         type: 'TYPE_TILE',
         tileId: 'typed-2',
         value: 'Y',
         zoneIndex: 0,
       });
-      expect(next).toBe(state);
+      expect(next.zones[0].placedTileId).toBe('typed-2');
+      // Old virtual tile cleaned up
+      expect(
+        next.allTiles.find((t) => t.id === 'typed-1'),
+      ).toBeUndefined();
+      expect(
+        next.allTiles.find((t) => t.id === 'typed-2'),
+      ).toBeDefined();
     });
 
     it('with reject behavior: increments retryCount but does not place', () => {

--- a/src/components/answer-game/answer-game-reducer.test.ts
+++ b/src/components/answer-game/answer-game-reducer.test.ts
@@ -602,4 +602,161 @@ describe('answerGameReducer', () => {
     });
     expect(state.dragHoverZoneIndex).toBeNull();
   });
+
+  describe('TYPE_TILE (free-typing virtual tiles)', () => {
+    const lockManualConfig: AnswerGameConfig = {
+      ...config,
+      wrongTileBehavior: 'lock-manual',
+    };
+
+    it('creates a virtual tile and places it as wrong/locked when value does not match', () => {
+      let state = answerGameReducer(
+        makeInitialState(lockManualConfig),
+        {
+          type: 'INIT_ROUND',
+          tiles,
+          zones,
+        },
+      );
+      state = answerGameReducer(state, {
+        type: 'TYPE_TILE',
+        tileId: 'typed-abc',
+        value: 'P',
+        zoneIndex: 0,
+      });
+      expect(state.zones[0]!.placedTileId).toBe('typed-abc');
+      expect(state.zones[0]!.isWrong).toBe(true);
+      expect(state.zones[0]!.isLocked).toBe(true);
+      expect(state.allTiles).toContainEqual({
+        id: 'typed-abc',
+        label: 'P',
+        value: 'P',
+      });
+      // Virtual tile should NOT be in bankTileIds
+      expect(state.bankTileIds).not.toContain('typed-abc');
+      expect(state.retryCount).toBe(1);
+    });
+
+    it('creates a virtual tile as correct when value matches zone', () => {
+      let state = answerGameReducer(
+        makeInitialState(lockManualConfig),
+        {
+          type: 'INIT_ROUND',
+          tiles,
+          zones,
+        },
+      );
+      state = answerGameReducer(state, {
+        type: 'TYPE_TILE',
+        tileId: 'typed-correct',
+        value: 'C',
+        zoneIndex: 0,
+      });
+      expect(state.zones[0]!.placedTileId).toBe('typed-correct');
+      expect(state.zones[0]!.isWrong).toBe(false);
+      expect(state.zones[0]!.isLocked).toBe(false);
+      expect(state.activeSlotIndex).toBe(1);
+    });
+
+    it('does nothing when zone is locked', () => {
+      let state = answerGameReducer(
+        makeInitialState(lockManualConfig),
+        {
+          type: 'INIT_ROUND',
+          tiles,
+          zones,
+        },
+      );
+      // Place a wrong tile first
+      state = answerGameReducer(state, {
+        type: 'TYPE_TILE',
+        tileId: 'typed-1',
+        value: 'X',
+        zoneIndex: 0,
+      });
+      // Try to type again on the locked slot
+      const next = answerGameReducer(state, {
+        type: 'TYPE_TILE',
+        tileId: 'typed-2',
+        value: 'Y',
+        zoneIndex: 0,
+      });
+      expect(next).toBe(state);
+    });
+
+    it('with reject behavior: increments retryCount but does not place', () => {
+      const rejectConfig: AnswerGameConfig = {
+        ...config,
+        wrongTileBehavior: 'reject',
+      };
+      let state = answerGameReducer(makeInitialState(rejectConfig), {
+        type: 'INIT_ROUND',
+        tiles,
+        zones,
+      });
+      state = answerGameReducer(state, {
+        type: 'TYPE_TILE',
+        tileId: 'typed-rej',
+        value: 'Z',
+        zoneIndex: 0,
+      });
+      expect(state.zones[0]!.placedTileId).toBeNull();
+      expect(state.retryCount).toBe(1);
+    });
+
+    it('REMOVE_TILE on virtual tile: removes from allTiles, does NOT add to bank', () => {
+      let state = answerGameReducer(
+        makeInitialState(lockManualConfig),
+        {
+          type: 'INIT_ROUND',
+          tiles,
+          zones,
+        },
+      );
+      state = answerGameReducer(state, {
+        type: 'TYPE_TILE',
+        tileId: 'typed-rm',
+        value: 'X',
+        zoneIndex: 0,
+      });
+      const allTilesBefore = state.allTiles.length;
+      state = answerGameReducer(state, {
+        type: 'REMOVE_TILE',
+        zoneIndex: 0,
+      });
+      expect(state.zones[0]!.placedTileId).toBeNull();
+      expect(state.allTiles.length).toBe(allTilesBefore - 1);
+      expect(
+        state.allTiles.find((t) => t.id === 'typed-rm'),
+      ).toBeUndefined();
+      expect(state.bankTileIds).not.toContain('typed-rm');
+    });
+
+    it('EJECT_TILE on virtual tile: removes from allTiles, does NOT add to bank', () => {
+      const autoEjectConfig: AnswerGameConfig = {
+        ...config,
+        wrongTileBehavior: 'lock-auto-eject',
+      };
+      let state = answerGameReducer(makeInitialState(autoEjectConfig), {
+        type: 'INIT_ROUND',
+        tiles,
+        zones,
+      });
+      state = answerGameReducer(state, {
+        type: 'TYPE_TILE',
+        tileId: 'typed-ej',
+        value: 'X',
+        zoneIndex: 0,
+      });
+      state = answerGameReducer(state, {
+        type: 'EJECT_TILE',
+        zoneIndex: 0,
+      });
+      expect(state.zones[0]!.placedTileId).toBeNull();
+      expect(
+        state.allTiles.find((t) => t.id === 'typed-ej'),
+      ).toBeUndefined();
+      expect(state.bankTileIds).not.toContain('typed-ej');
+    });
+  });
 });

--- a/src/components/answer-game/answer-game-reducer.ts
+++ b/src/components/answer-game/answer-game-reducer.ts
@@ -27,6 +27,34 @@ export function makeInitialState(
   };
 }
 
+/**
+ * Find the best next activeSlotIndex after a placement or removal.
+ * Priority: first empty slot after `afterIndex`, then first empty slot
+ * anywhere, then first wrong slot anywhere. Returns `fallback` when every
+ * slot is correctly filled.
+ */
+function findNextActiveSlot(
+  zones: AnswerZone[],
+  afterIndex: number,
+  fallback: number,
+): number {
+  // 1. First empty slot after the current action
+  const nextEmpty = zones.findIndex(
+    (z, i) => i > afterIndex && z.placedTileId === null,
+  );
+  if (nextEmpty !== -1) return nextEmpty;
+
+  // 2. First empty slot anywhere (wraps around)
+  const anyEmpty = zones.findIndex((z) => z.placedTileId === null);
+  if (anyEmpty !== -1) return anyEmpty;
+
+  // 3. First wrong slot anywhere (so user can retype)
+  const anyWrong = zones.findIndex((z) => z.isWrong);
+  if (anyWrong !== -1) return anyWrong;
+
+  return fallback;
+}
+
 function resolveCompletionPhase(
   state: AnswerGameState,
 ): AnswerGamePhase {
@@ -109,9 +137,6 @@ export function answerGameReducer(
             : state.zones.map((z, i) =>
                 i === action.zoneIndex ? newZone : z,
               );
-        const nextActiveSlot = newZones.findIndex(
-          (z, i) => i > action.zoneIndex && z.placedTileId === null,
-        );
         const allFilledCorrectly = newZones.every(
           (z) => z.placedTileId !== null && !z.isWrong,
         );
@@ -121,10 +146,11 @@ export function answerGameReducer(
           dragActiveTileId,
           zones: newZones,
           bankTileIds: newBankTileIds,
-          activeSlotIndex:
-            nextActiveSlot === -1
-              ? state.activeSlotIndex
-              : nextActiveSlot,
+          activeSlotIndex: findNextActiveSlot(
+            newZones,
+            action.zoneIndex,
+            state.activeSlotIndex,
+          ),
           retryCount: state.retryCount,
           phase: allFilledCorrectly
             ? resolveCompletionPhase(state)
@@ -177,7 +203,10 @@ export function answerGameReducer(
 
     case 'TYPE_TILE': {
       const zone = state.zones[action.zoneIndex];
-      if (!zone || zone.isLocked) return state;
+      if (!zone) return state;
+      // Allow typing over wrong locked tiles to replace them;
+      // only block correctly-locked tiles (shouldn't exist, but be safe).
+      if (zone.isLocked && !zone.isWrong) return state;
 
       const virtualTile: TileItem = {
         id: action.tileId,
@@ -194,7 +223,19 @@ export function answerGameReducer(
         };
       }
 
-      const newAllTiles = [...state.allTiles, virtualTile];
+      // Clean up the previous wrong virtual tile being replaced
+      const previousId = zone.placedTileId;
+      const prevIsVirtual = previousId?.startsWith('typed-');
+      const baseTiles = prevIsVirtual
+        ? state.allTiles.filter((t) => t.id !== previousId)
+        : state.allTiles;
+      // If replacing a real (non-virtual) tile, return it to the bank
+      let baseBankTileIds = state.bankTileIds;
+      if (previousId && !prevIsVirtual) {
+        baseBankTileIds = [...baseBankTileIds, previousId];
+      }
+
+      const newAllTiles = [...baseTiles, virtualTile];
       const newZone: AnswerZone = {
         ...zone,
         placedTileId: action.tileId,
@@ -206,20 +247,19 @@ export function answerGameReducer(
       );
 
       if (correct) {
-        const nextActiveSlot = newZones.findIndex(
-          (z, i) => i > action.zoneIndex && z.placedTileId === null,
-        );
         const allFilledCorrectly = newZones.every(
           (z) => z.placedTileId !== null && !z.isWrong,
         );
         return {
           ...state,
           allTiles: newAllTiles,
+          bankTileIds: baseBankTileIds,
           zones: newZones,
-          activeSlotIndex:
-            nextActiveSlot === -1
-              ? state.activeSlotIndex
-              : nextActiveSlot,
+          activeSlotIndex: findNextActiveSlot(
+            newZones,
+            action.zoneIndex,
+            state.activeSlotIndex,
+          ),
           phase: allFilledCorrectly
             ? resolveCompletionPhase(state)
             : 'playing',
@@ -229,6 +269,7 @@ export function answerGameReducer(
       return {
         ...state,
         allTiles: newAllTiles,
+        bankTileIds: baseBankTileIds,
         zones: newZones,
         activeSlotIndex: state.activeSlotIndex,
         retryCount: state.retryCount + 1,
@@ -265,6 +306,8 @@ export function answerGameReducer(
         bankTileIds: isVirtual
           ? state.bankTileIds
           : [...state.bankTileIds, removedTileId],
+        // Move cursor to the cleared slot so the user can retype
+        activeSlotIndex: action.zoneIndex,
       };
     }
 
@@ -370,6 +413,8 @@ export function answerGameReducer(
           bankTileIds: isVirtual
             ? state.bankTileIds
             : [...state.bankTileIds, ejectedTileId],
+          // Move cursor to the ejected slot
+          activeSlotIndex: action.zoneIndex,
         };
       }
 
@@ -385,6 +430,8 @@ export function answerGameReducer(
               }
             : z,
         ),
+        // Move cursor to the ejected slot
+        activeSlotIndex: action.zoneIndex,
       };
     }
 
@@ -464,6 +511,14 @@ export function answerGameReducer(
         dragActiveTileId: null,
         dragHoverBankTileId: null,
       };
+    }
+
+    case 'SET_ACTIVE_SLOT': {
+      const clamped = Math.max(
+        0,
+        Math.min(action.zoneIndex, state.zones.length - 1),
+      );
+      return { ...state, activeSlotIndex: clamped };
     }
 
     default: {

--- a/src/components/answer-game/answer-game-reducer.ts
+++ b/src/components/answer-game/answer-game-reducer.ts
@@ -80,22 +80,35 @@ export function answerGameReducer(
 
       if (correct) {
         const previousId = zone.placedTileId;
+        const prevIsVirtual = previousId?.startsWith('typed-');
         let newBankTileIds = state.bankTileIds.filter(
           (id) => id !== action.tileId,
         );
-        if (previousId !== null && previousId !== action.tileId) {
-          // Bank tile dropped on an occupied slot: previous occupant returns to bank.
+        if (
+          previousId !== null &&
+          previousId !== action.tileId && // Virtual tiles are discarded; real tiles return to the bank.
+          !prevIsVirtual
+        ) {
           newBankTileIds = [...newBankTileIds, previousId];
         }
+        // Remove displaced virtual tile from allTiles
+        const newAllTiles = prevIsVirtual
+          ? state.allTiles.filter((t) => t.id !== previousId)
+          : state.allTiles;
         const newZone: AnswerZone = {
           ...zone,
           placedTileId: action.tileId,
           isWrong: false,
           isLocked: false,
         };
-        const newZones = state.zones.map((z, i) =>
-          i === action.zoneIndex ? newZone : z,
-        );
+        const newZones =
+          newAllTiles === state.allTiles
+            ? state.zones.map((z, i) =>
+                i === action.zoneIndex ? newZone : z,
+              )
+            : state.zones.map((z, i) =>
+                i === action.zoneIndex ? newZone : z,
+              );
         const nextActiveSlot = newZones.findIndex(
           (z, i) => i > action.zoneIndex && z.placedTileId === null,
         );
@@ -104,6 +117,7 @@ export function answerGameReducer(
         );
         return {
           ...state,
+          allTiles: newAllTiles,
           dragActiveTileId,
           zones: newZones,
           bankTileIds: newBankTileIds,
@@ -121,6 +135,8 @@ export function answerGameReducer(
       const shouldLock =
         state.config.wrongTileBehavior === 'lock-manual' ||
         state.config.wrongTileBehavior === 'lock-auto-eject';
+      const previousId = zone.placedTileId;
+      const prevIsVirtual = previousId?.startsWith('typed-');
       const newZone: AnswerZone = {
         ...zone,
         placedTileId: shouldLock ? action.tileId : zone.placedTileId,
@@ -135,14 +151,21 @@ export function answerGameReducer(
         : state.bankTileIds;
       if (
         shouldLock &&
-        zone.placedTileId &&
-        zone.placedTileId !== action.tileId
+        previousId &&
+        previousId !== action.tileId && // Virtual tiles are discarded; real tiles return to the bank.
+        !prevIsVirtual
       ) {
-        newBankTileIds = [...newBankTileIds, zone.placedTileId];
+        newBankTileIds = [...newBankTileIds, previousId];
       }
+      // Remove displaced virtual tile from allTiles
+      const newAllTiles =
+        shouldLock && prevIsVirtual
+          ? state.allTiles.filter((t) => t.id !== previousId)
+          : state.allTiles;
 
       return {
         ...state,
+        allTiles: newAllTiles,
         dragActiveTileId,
         zones: newZones,
         bankTileIds: newBankTileIds,

--- a/src/components/answer-game/answer-game-reducer.ts
+++ b/src/components/answer-game/answer-game-reducer.ts
@@ -152,16 +152,83 @@ export function answerGameReducer(
       };
     }
 
+    case 'TYPE_TILE': {
+      const zone = state.zones[action.zoneIndex];
+      if (!zone || zone.isLocked) return state;
+
+      const virtualTile: TileItem = {
+        id: action.tileId,
+        label: action.value,
+        value: action.value,
+      };
+      const correct =
+        action.value.toLowerCase() === zone.expectedValue.toLowerCase();
+
+      if (!correct && state.config.wrongTileBehavior === 'reject') {
+        return {
+          ...state,
+          retryCount: state.retryCount + 1,
+        };
+      }
+
+      const newAllTiles = [...state.allTiles, virtualTile];
+      const newZone: AnswerZone = {
+        ...zone,
+        placedTileId: action.tileId,
+        isWrong: !correct,
+        isLocked: !correct,
+      };
+      const newZones = state.zones.map((z, i) =>
+        i === action.zoneIndex ? newZone : z,
+      );
+
+      if (correct) {
+        const nextActiveSlot = newZones.findIndex(
+          (z, i) => i > action.zoneIndex && z.placedTileId === null,
+        );
+        const allFilledCorrectly = newZones.every(
+          (z) => z.placedTileId !== null && !z.isWrong,
+        );
+        return {
+          ...state,
+          allTiles: newAllTiles,
+          zones: newZones,
+          activeSlotIndex:
+            nextActiveSlot === -1
+              ? state.activeSlotIndex
+              : nextActiveSlot,
+          phase: allFilledCorrectly
+            ? resolveCompletionPhase(state)
+            : 'playing',
+        };
+      }
+
+      return {
+        ...state,
+        allTiles: newAllTiles,
+        zones: newZones,
+        activeSlotIndex: state.activeSlotIndex,
+        retryCount: state.retryCount + 1,
+        phase: 'playing',
+      };
+    }
+
     case 'REMOVE_TILE': {
       const zone = state.zones[action.zoneIndex];
       if (!zone?.placedTileId) return state;
       const removedTileId = zone.placedTileId;
+      // Virtual tiles (created by TYPE_TILE) are removed from allTiles
+      // and NOT returned to the bank.
+      const isVirtual = removedTileId.startsWith('typed-');
       return {
         ...state,
         dragActiveTileId:
           state.dragActiveTileId === removedTileId
             ? null
             : state.dragActiveTileId,
+        allTiles: isVirtual
+          ? state.allTiles.filter((t) => t.id !== removedTileId)
+          : state.allTiles,
         zones: state.zones.map((z, i) =>
           i === action.zoneIndex
             ? {
@@ -172,7 +239,9 @@ export function answerGameReducer(
               }
             : z,
         ),
-        bankTileIds: [...state.bankTileIds, removedTileId],
+        bankTileIds: isVirtual
+          ? state.bankTileIds
+          : [...state.bankTileIds, removedTileId],
       };
     }
 
@@ -253,6 +322,7 @@ export function answerGameReducer(
 
       if (zone.placedTileId) {
         const ejectedTileId = zone.placedTileId;
+        const isVirtual = ejectedTileId.startsWith('typed-');
         return {
           ...state,
           // If the ejected tile was mid-drag, clear drag state so the bank
@@ -261,6 +331,9 @@ export function answerGameReducer(
             state.dragActiveTileId === ejectedTileId
               ? null
               : state.dragActiveTileId,
+          allTiles: isVirtual
+            ? state.allTiles.filter((t) => t.id !== ejectedTileId)
+            : state.allTiles,
           zones: state.zones.map((z, i) =>
             i === action.zoneIndex
               ? {
@@ -271,7 +344,9 @@ export function answerGameReducer(
                 }
               : z,
           ),
-          bankTileIds: [...state.bankTileIds, ejectedTileId],
+          bankTileIds: isVirtual
+            ? state.bankTileIds
+            : [...state.bankTileIds, ejectedTileId],
         };
       }
 

--- a/src/components/answer-game/types.ts
+++ b/src/components/answer-game/types.ts
@@ -88,6 +88,12 @@ export interface AnswerGameState {
 export type AnswerGameAction =
   | { type: 'INIT_ROUND'; tiles: TileItem[]; zones: AnswerZone[] }
   | { type: 'PLACE_TILE'; tileId: string; zoneIndex: number }
+  | {
+      type: 'TYPE_TILE';
+      tileId: string;
+      value: string;
+      zoneIndex: number;
+    }
   | { type: 'REMOVE_TILE'; zoneIndex: number }
   | { type: 'SWAP_TILES'; fromZoneIndex: number; toZoneIndex: number }
   | { type: 'EJECT_TILE'; zoneIndex: number }

--- a/src/components/answer-game/types.ts
+++ b/src/components/answer-game/types.ts
@@ -103,7 +103,8 @@ export type AnswerGameAction =
   | { type: 'SET_DRAG_ACTIVE'; tileId: string | null }
   | { type: 'SET_DRAG_HOVER'; zoneIndex: number | null }
   | { type: 'SET_DRAG_HOVER_BANK'; tileId: string | null }
-  | { type: 'SWAP_SLOT_BANK'; zoneIndex: number; bankTileId: string };
+  | { type: 'SWAP_SLOT_BANK'; zoneIndex: number; bankTileId: string }
+  | { type: 'SET_ACTIVE_SLOT'; zoneIndex: number };
 
 /**
  * Snapshot of AnswerGameState persisted to session_history_index.draftState.

--- a/src/components/answer-game/useKeyboardInput.test.tsx
+++ b/src/components/answer-game/useKeyboardInput.test.tsx
@@ -180,4 +180,56 @@ describe('useKeyboardInput', () => {
 
     unmount();
   });
+
+  it('dispatches REMOVE_TILE on Backspace for the most recently filled slot', () => {
+    const filledConfig = makeConfig('type');
+    const filledZones: AnswerZone[] = [
+      {
+        id: 'z0',
+        index: 0,
+        expectedValue: 'c',
+        placedTileId: 't1',
+        isWrong: true,
+        isLocked: true,
+      },
+    ];
+    const initialState = {
+      allTiles: makeTileItems(),
+      bankTileIds: [] as string[],
+      zones: filledZones,
+      activeSlotIndex: 0,
+      phase: 'playing' as const,
+      roundIndex: 0,
+      retryCount: 1,
+      levelIndex: 0,
+    };
+    const FilledWrapper = ({ children }: { children: ReactNode }) => (
+      <AnswerGameProvider
+        config={filledConfig}
+        initialState={initialState}
+      >
+        {children}
+      </AnswerGameProvider>
+    );
+
+    const { unmount } = renderHook(() => useKeyboardInput(), {
+      wrapper: FilledWrapper,
+    });
+
+    act(() => {
+      globalThis.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Backspace',
+          bubbles: true,
+        }),
+      );
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'REMOVE_TILE',
+      zoneIndex: 0,
+    });
+
+    unmount();
+  });
 });

--- a/src/components/answer-game/useKeyboardInput.test.tsx
+++ b/src/components/answer-game/useKeyboardInput.test.tsx
@@ -181,6 +181,55 @@ describe('useKeyboardInput', () => {
     unmount();
   });
 
+  it('does NOT remove a correctly-placed tile on Backspace', () => {
+    const filledConfig = makeConfig('type');
+    const correctZones: AnswerZone[] = [
+      {
+        id: 'z0',
+        index: 0,
+        expectedValue: 'c',
+        placedTileId: 't1',
+        isWrong: false,
+        isLocked: false,
+      },
+    ];
+    const initialState = {
+      allTiles: makeTileItems(),
+      bankTileIds: [] as string[],
+      zones: correctZones,
+      activeSlotIndex: 0,
+      phase: 'playing' as const,
+      roundIndex: 0,
+      retryCount: 0,
+      levelIndex: 0,
+    };
+    const CorrectWrapper = ({ children }: { children: ReactNode }) => (
+      <AnswerGameProvider
+        config={filledConfig}
+        initialState={initialState}
+      >
+        {children}
+      </AnswerGameProvider>
+    );
+
+    const { unmount } = renderHook(() => useKeyboardInput(), {
+      wrapper: CorrectWrapper,
+    });
+
+    act(() => {
+      globalThis.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Backspace',
+          bubbles: true,
+        }),
+      );
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
   it('dispatches REMOVE_TILE on Backspace for the most recently filled slot', () => {
     const filledConfig = makeConfig('type');
     const filledZones: AnswerZone[] = [

--- a/src/components/answer-game/useKeyboardInput.test.tsx
+++ b/src/components/answer-game/useKeyboardInput.test.tsx
@@ -81,7 +81,27 @@ describe('useKeyboardInput', () => {
     unmount();
   });
 
-  it('does nothing when config.inputMethod is not "type"', () => {
+  it('dispatches PLACE_TILE in both mode (keyboard fallback)', () => {
+    const { unmount } = renderHook(() => useKeyboardInput(), {
+      wrapper: makeWrapper('both'),
+    });
+
+    act(() => {
+      globalThis.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'c', bubbles: true }),
+      );
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'PLACE_TILE',
+      tileId: 't1',
+      zoneIndex: 0,
+    });
+
+    unmount();
+  });
+
+  it('does nothing when config.inputMethod is drag', () => {
     const { unmount } = renderHook(() => useKeyboardInput(), {
       wrapper: makeWrapper('drag'),
     });
@@ -133,7 +153,7 @@ describe('useKeyboardInput', () => {
     unmount();
   });
 
-  it('fires when target is the data-touch-keyboard input', () => {
+  it('skips when target is an HTMLInputElement to avoid double-placement with hidden input', () => {
     const { unmount } = renderHook(() => useKeyboardInput(), {
       wrapper: makeWrapper('type'),
     });
@@ -150,11 +170,7 @@ describe('useKeyboardInput', () => {
       globalThis.dispatchEvent(event);
     });
 
-    expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'PLACE_TILE',
-      tileId: 't1',
-      zoneIndex: 0,
-    });
+    expect(mockDispatch).not.toHaveBeenCalled();
 
     unmount();
   });

--- a/src/components/answer-game/useKeyboardInput.test.tsx
+++ b/src/components/answer-game/useKeyboardInput.test.tsx
@@ -117,7 +117,7 @@ describe('useKeyboardInput', () => {
     unmount();
   });
 
-  it('does nothing when no bank tile matches the pressed key', () => {
+  it('dispatches TYPE_TILE when no bank tile matches the pressed key', () => {
     const { unmount } = renderHook(() => useKeyboardInput(), {
       wrapper: makeWrapper('type'),
     });
@@ -128,7 +128,13 @@ describe('useKeyboardInput', () => {
       );
     });
 
-    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'TYPE_TILE',
+        value: 'x',
+        zoneIndex: 0,
+      }),
+    );
 
     unmount();
   });

--- a/src/components/answer-game/useKeyboardInput.ts
+++ b/src/components/answer-game/useKeyboardInput.ts
@@ -19,10 +19,22 @@ export const useKeyboardInput = (): void => {
       if (
         event.target instanceof HTMLInputElement &&
         event.key !== 'Backspace' &&
-        event.key !== 'Delete'
+        event.key !== 'Delete' &&
+        event.key !== 'Tab'
       )
         return;
       if (event.target instanceof HTMLTextAreaElement) return;
+
+      // Tab / Shift+Tab: navigate between slots
+      if (event.key === 'Tab') {
+        event.preventDefault();
+        const delta = event.shiftKey ? -1 : 1;
+        const next = state.activeSlotIndex + delta;
+        if (next >= 0 && next < state.zones.length) {
+          dispatch({ type: 'SET_ACTIVE_SLOT', zoneIndex: next });
+        }
+        return;
+      }
 
       // Backspace / Delete: eject the most recently filled *wrong* slot
       if (event.key === 'Backspace' || event.key === 'Delete') {

--- a/src/components/answer-game/useKeyboardInput.ts
+++ b/src/components/answer-game/useKeyboardInput.ts
@@ -4,7 +4,7 @@ import { useTileEvaluation } from './useTileEvaluation';
 
 export const useKeyboardInput = (): void => {
   const state = useAnswerGameContext();
-  const { placeTile } = useTileEvaluation();
+  const { placeTile, typeTile } = useTileEvaluation();
 
   useEffect(() => {
     if (state.config.inputMethod === 'drag') return;
@@ -23,9 +23,12 @@ export const useKeyboardInput = (): void => {
           state.bankTileIds.includes(t.id) &&
           t.value.toLowerCase() === char,
       );
-      if (!matchingTile) return;
 
-      placeTile(matchingTile.id, state.activeSlotIndex);
+      if (matchingTile) {
+        placeTile(matchingTile.id, state.activeSlotIndex);
+      } else {
+        typeTile(char, state.activeSlotIndex);
+      }
     };
 
     globalThis.addEventListener('keydown', handleKeyDown);
@@ -37,5 +40,6 @@ export const useKeyboardInput = (): void => {
     state.bankTileIds,
     state.activeSlotIndex,
     placeTile,
+    typeTile,
   ]);
 };

--- a/src/components/answer-game/useKeyboardInput.ts
+++ b/src/components/answer-game/useKeyboardInput.ts
@@ -20,15 +20,16 @@ export const useKeyboardInput = (): void => {
         event.target instanceof HTMLInputElement &&
         event.key !== 'Backspace' &&
         event.key !== 'Delete' &&
-        event.key !== 'Tab'
+        event.key !== 'ArrowLeft' &&
+        event.key !== 'ArrowRight'
       )
         return;
       if (event.target instanceof HTMLTextAreaElement) return;
 
-      // Tab / Shift+Tab: navigate between slots
-      if (event.key === 'Tab') {
-        event.preventDefault();
-        const delta = event.shiftKey ? -1 : 1;
+      // Arrow keys: navigate between slots (WCAG — Tab moves between
+      // widgets, arrows navigate within a widget)
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+        const delta = event.key === 'ArrowLeft' ? -1 : 1;
         const next = state.activeSlotIndex + delta;
         if (next >= 0 && next < state.zones.length) {
           dispatch({ type: 'SET_ACTIVE_SLOT', zoneIndex: next });

--- a/src/components/answer-game/useKeyboardInput.ts
+++ b/src/components/answer-game/useKeyboardInput.ts
@@ -20,18 +20,18 @@ export const useKeyboardInput = (): void => {
         event.target instanceof HTMLInputElement &&
         event.key !== 'Backspace' &&
         event.key !== 'Delete' &&
-        event.key !== 'Tab'
+        event.key !== 'ArrowLeft' &&
+        event.key !== 'ArrowRight'
       )
         return;
       if (event.target instanceof HTMLTextAreaElement) return;
 
-      // Tab / Shift+Tab: navigate between slots like input fields.
-      // At the boundaries, let focus escape to the rest of the page.
-      if (event.key === 'Tab') {
-        const delta = event.shiftKey ? -1 : 1;
+      // Arrow keys: navigate between slots (WCAG — Tab moves between
+      // widgets, arrows navigate within a widget)
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+        const delta = event.key === 'ArrowLeft' ? -1 : 1;
         const next = state.activeSlotIndex + delta;
         if (next >= 0 && next < state.zones.length) {
-          event.preventDefault();
           dispatch({ type: 'SET_ACTIVE_SLOT', zoneIndex: next });
         }
         return;

--- a/src/components/answer-game/useKeyboardInput.ts
+++ b/src/components/answer-game/useKeyboardInput.ts
@@ -25,12 +25,13 @@ export const useKeyboardInput = (): void => {
         return;
       if (event.target instanceof HTMLTextAreaElement) return;
 
-      // Tab / Shift+Tab: navigate between slots like input fields
+      // Tab / Shift+Tab: navigate between slots like input fields.
+      // At the boundaries, let focus escape to the rest of the page.
       if (event.key === 'Tab') {
-        event.preventDefault();
         const delta = event.shiftKey ? -1 : 1;
         const next = state.activeSlotIndex + delta;
         if (next >= 0 && next < state.zones.length) {
+          event.preventDefault();
           dispatch({ type: 'SET_ACTIVE_SLOT', zoneIndex: next });
         }
         return;

--- a/src/components/answer-game/useKeyboardInput.ts
+++ b/src/components/answer-game/useKeyboardInput.ts
@@ -12,9 +12,16 @@ export const useKeyboardInput = (): void => {
     if (state.config.inputMethod === 'drag') return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      // Skip all input/textarea targets — the hidden keyboard input
-      // (useTouchKeyboardInput) handles those to avoid double-placement.
-      if (event.target instanceof HTMLInputElement) return;
+      // Skip input/textarea targets for character keys — the hidden
+      // keyboard input (useTouchKeyboardInput) handles those to avoid
+      // double-placement. Backspace/Delete are allowed through because
+      // an empty hidden input won't fire an input event for them.
+      if (
+        event.target instanceof HTMLInputElement &&
+        event.key !== 'Backspace' &&
+        event.key !== 'Delete'
+      )
+        return;
       if (event.target instanceof HTMLTextAreaElement) return;
 
       // Backspace / Delete: eject the most recently filled slot

--- a/src/components/answer-game/useKeyboardInput.ts
+++ b/src/components/answer-game/useKeyboardInput.ts
@@ -1,20 +1,18 @@
 import { useEffect } from 'react';
 import { useAnswerGameContext } from './useAnswerGameContext';
-import { useAnswerGameDispatch } from './useAnswerGameDispatch';
+import { useTileEvaluation } from './useTileEvaluation';
 
 export const useKeyboardInput = (): void => {
   const state = useAnswerGameContext();
-  const dispatch = useAnswerGameDispatch();
+  const { placeTile } = useTileEvaluation();
 
   useEffect(() => {
-    if (state.config.inputMethod !== 'type') return;
+    if (state.config.inputMethod === 'drag') return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (
-        event.target instanceof HTMLInputElement &&
-        !event.target.dataset['touchKeyboard']
-      )
-        return;
+      // Skip all input/textarea targets — the hidden keyboard input
+      // (useTouchKeyboardInput) handles those to avoid double-placement.
+      if (event.target instanceof HTMLInputElement) return;
       if (event.target instanceof HTMLTextAreaElement) return;
 
       const char = event.key.toLowerCase();
@@ -27,11 +25,7 @@ export const useKeyboardInput = (): void => {
       );
       if (!matchingTile) return;
 
-      dispatch({
-        type: 'PLACE_TILE',
-        tileId: matchingTile.id,
-        zoneIndex: state.activeSlotIndex,
-      });
+      placeTile(matchingTile.id, state.activeSlotIndex);
     };
 
     globalThis.addEventListener('keydown', handleKeyDown);
@@ -42,6 +36,6 @@ export const useKeyboardInput = (): void => {
     state.allTiles,
     state.bankTileIds,
     state.activeSlotIndex,
-    dispatch,
+    placeTile,
   ]);
 };

--- a/src/components/answer-game/useKeyboardInput.ts
+++ b/src/components/answer-game/useKeyboardInput.ts
@@ -24,11 +24,12 @@ export const useKeyboardInput = (): void => {
         return;
       if (event.target instanceof HTMLTextAreaElement) return;
 
-      // Backspace / Delete: eject the most recently filled slot
+      // Backspace / Delete: eject the most recently filled *wrong* slot
       if (event.key === 'Backspace' || event.key === 'Delete') {
-        // Search backwards from activeSlotIndex for a filled slot
+        // Search backwards from activeSlotIndex for a wrong/locked slot
         for (let i = state.activeSlotIndex; i >= 0; i--) {
-          if (state.zones[i]?.placedTileId) {
+          const zone = state.zones[i];
+          if (zone?.placedTileId && (zone.isWrong || zone.isLocked)) {
             dispatch({ type: 'REMOVE_TILE', zoneIndex: i });
             return;
           }

--- a/src/components/answer-game/useKeyboardInput.ts
+++ b/src/components/answer-game/useKeyboardInput.ts
@@ -1,9 +1,11 @@
 import { useEffect } from 'react';
 import { useAnswerGameContext } from './useAnswerGameContext';
+import { useAnswerGameDispatch } from './useAnswerGameDispatch';
 import { useTileEvaluation } from './useTileEvaluation';
 
 export const useKeyboardInput = (): void => {
   const state = useAnswerGameContext();
+  const dispatch = useAnswerGameDispatch();
   const { placeTile, typeTile } = useTileEvaluation();
 
   useEffect(() => {
@@ -14,6 +16,18 @@ export const useKeyboardInput = (): void => {
       // (useTouchKeyboardInput) handles those to avoid double-placement.
       if (event.target instanceof HTMLInputElement) return;
       if (event.target instanceof HTMLTextAreaElement) return;
+
+      // Backspace / Delete: eject the most recently filled slot
+      if (event.key === 'Backspace' || event.key === 'Delete') {
+        // Search backwards from activeSlotIndex for a filled slot
+        for (let i = state.activeSlotIndex; i >= 0; i--) {
+          if (state.zones[i]?.placedTileId) {
+            dispatch({ type: 'REMOVE_TILE', zoneIndex: i });
+            return;
+          }
+        }
+        return;
+      }
 
       const char = event.key.toLowerCase();
       if (char.length !== 1) return;
@@ -38,7 +52,9 @@ export const useKeyboardInput = (): void => {
     state.config.inputMethod,
     state.allTiles,
     state.bankTileIds,
+    state.zones,
     state.activeSlotIndex,
+    dispatch,
     placeTile,
     typeTile,
   ]);

--- a/src/components/answer-game/useKeyboardInput.ts
+++ b/src/components/answer-game/useKeyboardInput.ts
@@ -20,16 +20,15 @@ export const useKeyboardInput = (): void => {
         event.target instanceof HTMLInputElement &&
         event.key !== 'Backspace' &&
         event.key !== 'Delete' &&
-        event.key !== 'ArrowLeft' &&
-        event.key !== 'ArrowRight'
+        event.key !== 'Tab'
       )
         return;
       if (event.target instanceof HTMLTextAreaElement) return;
 
-      // Arrow keys: navigate between slots (WCAG — Tab moves between
-      // widgets, arrows navigate within a widget)
-      if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
-        const delta = event.key === 'ArrowLeft' ? -1 : 1;
+      // Tab / Shift+Tab: navigate between slots like input fields
+      if (event.key === 'Tab') {
+        event.preventDefault();
+        const delta = event.shiftKey ? -1 : 1;
         const next = state.activeSlotIndex + delta;
         if (next >= 0 && next < state.zones.length) {
           dispatch({ type: 'SET_ACTIVE_SLOT', zoneIndex: next });

--- a/src/components/answer-game/useTileEvaluation.ts
+++ b/src/components/answer-game/useTileEvaluation.ts
@@ -1,3 +1,4 @@
+import { nanoid } from 'nanoid';
 import { useCallback } from 'react';
 import { useAnswerGameContext } from './useAnswerGameContext';
 import { useAnswerGameDispatch } from './useAnswerGameDispatch';
@@ -6,6 +7,12 @@ import { getGameEventBus } from '@/lib/game-event-bus';
 
 export interface TileEvaluation {
   placeTile: (tileId: string, zoneIndex: number) => void;
+  /**
+   * Place a free-typed value into a slot. Creates a virtual tile when
+   * no matching bank tile exists. Used with lock-manual / lock-auto-eject
+   * so the user sees immediate wrong-tile feedback for any keystroke.
+   */
+  typeTile: (value: string, zoneIndex: number) => void;
 }
 
 export function useTileEvaluation(): TileEvaluation {
@@ -37,5 +44,35 @@ export function useTileEvaluation(): TileEvaluation {
     [state, dispatch],
   );
 
-  return { placeTile };
+  const typeTile = useCallback(
+    (value: string, zoneIndex: number) => {
+      const zone = state.zones[zoneIndex];
+      if (!zone) return;
+
+      const correct =
+        value.toLowerCase() === zone.expectedValue.toLowerCase();
+      playSound(correct ? 'correct' : 'wrong', 0.8);
+      dispatch({
+        type: 'TYPE_TILE',
+        tileId: `typed-${nanoid()}`,
+        value,
+        zoneIndex,
+      });
+
+      getGameEventBus().emit({
+        type: 'game:evaluate',
+        gameId: state.config.gameId,
+        sessionId: '',
+        profileId: '',
+        timestamp: Date.now(),
+        roundIndex: state.roundIndex,
+        answer: value,
+        correct,
+        nearMiss: false,
+      });
+    },
+    [state, dispatch],
+  );
+
+  return { placeTile, typeTile };
 }

--- a/src/components/answer-game/useTouchKeyboardInput.test.tsx
+++ b/src/components/answer-game/useTouchKeyboardInput.test.tsx
@@ -112,7 +112,7 @@ describe('useTouchKeyboardInput', () => {
     expect(input.value).toBe('');
   });
 
-  it('does nothing when no bank tile matches the typed character', () => {
+  it('dispatches TYPE_TILE when no bank tile matches the typed character', () => {
     render(<TestHarness />, { wrapper: makeWrapper(config) });
     const input = screen.getByTestId('hidden');
 
@@ -121,7 +121,13 @@ describe('useTouchKeyboardInput', () => {
       nativeEvent: { data: 'z' },
     });
 
-    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'TYPE_TILE',
+        value: 'z',
+        zoneIndex: 0,
+      }),
+    );
   });
 
   it('is case-insensitive — uppercase input matches lowercase tile value', () => {
@@ -252,7 +258,7 @@ describe('useTouchKeyboardInput — numeric debounce', () => {
     expect(input.value).toBe('');
   });
 
-  it('does not dispatch when no tile matches the debounced value', () => {
+  it('dispatches TYPE_TILE when no tile matches the debounced numeric value', () => {
     render(<TestHarness />, { wrapper: makeWrapper(numericConfig) });
     const input = screen.getByTestId<HTMLInputElement>('hidden');
 
@@ -260,6 +266,12 @@ describe('useTouchKeyboardInput — numeric debounce', () => {
     fireEvent.input(input);
     vi.advanceTimersByTime(400);
 
-    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'TYPE_TILE',
+        value: '99',
+        zoneIndex: 0,
+      }),
+    );
   });
 });

--- a/src/components/answer-game/useTouchKeyboardInput.test.tsx
+++ b/src/components/answer-game/useTouchKeyboardInput.test.tsx
@@ -1,5 +1,12 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { AnswerGameProvider } from './AnswerGameProvider';
 import { useTouchKeyboardInput } from './useTouchKeyboardInput';
 import type { AnswerGameConfig, AnswerZone, TileItem } from './types';
@@ -60,17 +67,25 @@ const TestHarness = () => {
   return <input ref={hiddenInputRef} data-testid="hidden" />;
 };
 
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <AnswerGameProvider config={config}>{children}</AnswerGameProvider>
-);
+const makeWrapper = (cfg: AnswerGameConfig) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <AnswerGameProvider config={cfg}>{children}</AnswerGameProvider>
+  );
+  return Wrapper;
+};
 
 describe('useTouchKeyboardInput', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     mockDispatch.mockClear();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('dispatches PLACE_TILE when a matching key is typed into the hidden input', () => {
-    render(<TestHarness />, { wrapper });
+    render(<TestHarness />, { wrapper: makeWrapper(config) });
     const input = screen.getByTestId('hidden');
 
     fireEvent.input(input, {
@@ -86,7 +101,7 @@ describe('useTouchKeyboardInput', () => {
   });
 
   it('clears the input value after each key', () => {
-    render(<TestHarness />, { wrapper });
+    render(<TestHarness />, { wrapper: makeWrapper(config) });
     const input = screen.getByTestId<HTMLInputElement>('hidden');
 
     fireEvent.input(input, {
@@ -98,7 +113,7 @@ describe('useTouchKeyboardInput', () => {
   });
 
   it('does nothing when no bank tile matches the typed character', () => {
-    render(<TestHarness />, { wrapper });
+    render(<TestHarness />, { wrapper: makeWrapper(config) });
     const input = screen.getByTestId('hidden');
 
     fireEvent.input(input, {
@@ -110,7 +125,7 @@ describe('useTouchKeyboardInput', () => {
   });
 
   it('is case-insensitive — uppercase input matches lowercase tile value', () => {
-    render(<TestHarness />, { wrapper });
+    render(<TestHarness />, { wrapper: makeWrapper(config) });
     const input = screen.getByTestId('hidden');
 
     fireEvent.input(input, {
@@ -123,5 +138,128 @@ describe('useTouchKeyboardInput', () => {
       tileId: 't1',
       zoneIndex: 0,
     });
+  });
+});
+
+describe('useTouchKeyboardInput — numeric debounce', () => {
+  const numericTiles: TileItem[] = [
+    { id: 'n1', label: '3', value: '3' },
+    { id: 'n2', label: '12', value: '12' },
+    { id: 'n3', label: '7', value: '7' },
+  ];
+
+  const numericZones: AnswerZone[] = [
+    {
+      id: 'z0',
+      index: 0,
+      expectedValue: '3',
+      placedTileId: null,
+      isWrong: false,
+      isLocked: false,
+    },
+    {
+      id: 'z1',
+      index: 1,
+      expectedValue: '7',
+      placedTileId: null,
+      isWrong: false,
+      isLocked: false,
+    },
+    {
+      id: 'z2',
+      index: 2,
+      expectedValue: '12',
+      placedTileId: null,
+      isWrong: false,
+      isLocked: false,
+    },
+  ];
+
+  const numericConfig: AnswerGameConfig = {
+    gameId: 'sort',
+    inputMethod: 'type',
+    wrongTileBehavior: 'lock-manual',
+    tileBankMode: 'exact',
+    totalRounds: 1,
+    ttsEnabled: false,
+    touchKeyboardInputMode: 'numeric',
+    initialTiles: numericTiles,
+    initialZones: numericZones,
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockDispatch.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces numeric input and matches multi-digit numbers', () => {
+    render(<TestHarness />, { wrapper: makeWrapper(numericConfig) });
+    const input = screen.getByTestId<HTMLInputElement>('hidden');
+
+    // Simulate typing "1" then "2" in quick succession
+    input.value = '1';
+    fireEvent.input(input);
+
+    // No dispatch yet — waiting for debounce
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    input.value = '12';
+    fireEvent.input(input);
+
+    // Still waiting
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    // Advance past the debounce timeout (400ms)
+    vi.advanceTimersByTime(400);
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'PLACE_TILE',
+      tileId: 'n2',
+      zoneIndex: 0,
+    });
+  });
+
+  it('matches single-digit numbers after debounce', () => {
+    render(<TestHarness />, { wrapper: makeWrapper(numericConfig) });
+    const input = screen.getByTestId<HTMLInputElement>('hidden');
+
+    input.value = '3';
+    fireEvent.input(input);
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(400);
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'PLACE_TILE',
+      tileId: 'n1',
+      zoneIndex: 0,
+    });
+  });
+
+  it('clears input after debounce fires', () => {
+    render(<TestHarness />, { wrapper: makeWrapper(numericConfig) });
+    const input = screen.getByTestId<HTMLInputElement>('hidden');
+
+    input.value = '7';
+    fireEvent.input(input);
+    vi.advanceTimersByTime(400);
+
+    expect(input.value).toBe('');
+  });
+
+  it('does not dispatch when no tile matches the debounced value', () => {
+    render(<TestHarness />, { wrapper: makeWrapper(numericConfig) });
+    const input = screen.getByTestId<HTMLInputElement>('hidden');
+
+    input.value = '99';
+    fireEvent.input(input);
+    vi.advanceTimersByTime(400);
+
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/components/answer-game/useTouchKeyboardInput.ts
+++ b/src/components/answer-game/useTouchKeyboardInput.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useAnswerGameContext } from './useAnswerGameContext';
-import { useAnswerGameDispatch } from './useAnswerGameDispatch';
+import { useTileEvaluation } from './useTileEvaluation';
 import type { RefObject } from 'react';
 
 export interface TouchKeyboardInput {
@@ -8,22 +8,24 @@ export interface TouchKeyboardInput {
   focusKeyboard: () => void;
 }
 
+const NUMERIC_DEBOUNCE_MS = 400;
+
 export const useTouchKeyboardInput = (): TouchKeyboardInput => {
   const hiddenInputRef = useRef<HTMLInputElement | null>(null);
   const state = useAnswerGameContext();
-  const dispatch = useAnswerGameDispatch();
+  const { placeTile } = useTileEvaluation();
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   useEffect(() => {
     const input = hiddenInputRef.current;
     if (!input) return;
 
-    const handleInput = (event: Event) => {
-      const inputEvent = event as InputEvent;
-      const raw =
-        inputEvent.data ?? (event.target as HTMLInputElement).value;
-      if (!raw) return;
-      const data = raw.toLowerCase();
+    const isNumeric = state.config.touchKeyboardInputMode === 'numeric';
 
+    const tryMatchAndPlace = (value: string) => {
+      const data = value.toLowerCase();
       const matchingTile = state.allTiles.find(
         (t) =>
           state.bankTileIds.includes(t.id) &&
@@ -31,23 +33,51 @@ export const useTouchKeyboardInput = (): TouchKeyboardInput => {
       );
 
       if (matchingTile) {
-        dispatch({
-          type: 'PLACE_TILE',
-          tileId: matchingTile.id,
-          zoneIndex: state.activeSlotIndex,
-        });
+        placeTile(matchingTile.id, state.activeSlotIndex);
       }
 
       input.value = '';
     };
 
+    const handleInput = (event: Event) => {
+      const inputEvent = event as InputEvent;
+
+      if (isNumeric) {
+        // For numeric input, accumulate digits and debounce so multi-digit
+        // numbers (e.g. "12") can be typed before matching.
+        if (debounceTimerRef.current !== null) {
+          clearTimeout(debounceTimerRef.current);
+        }
+        debounceTimerRef.current = setTimeout(() => {
+          debounceTimerRef.current = null;
+          const accumulated = input.value;
+          if (accumulated) {
+            tryMatchAndPlace(accumulated);
+          }
+        }, NUMERIC_DEBOUNCE_MS);
+      } else {
+        // For text input, match character-by-character (original behaviour).
+        const raw =
+          inputEvent.data ?? (event.target as HTMLInputElement).value;
+        if (!raw) return;
+        tryMatchAndPlace(raw);
+      }
+    };
+
     input.addEventListener('input', handleInput);
-    return () => input.removeEventListener('input', handleInput);
+    return () => {
+      input.removeEventListener('input', handleInput);
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+    };
   }, [
+    state.config.touchKeyboardInputMode,
     state.allTiles,
     state.bankTileIds,
     state.activeSlotIndex,
-    dispatch,
+    placeTile,
   ]);
 
   const focusKeyboard = useCallback(() => {

--- a/src/components/answer-game/useTouchKeyboardInput.ts
+++ b/src/components/answer-game/useTouchKeyboardInput.ts
@@ -47,10 +47,11 @@ export const useTouchKeyboardInput = (): TouchKeyboardInput => {
       const inputEvent = event as InputEvent;
 
       // Backspace / Delete inside the hidden input: eject the most
-      // recently filled slot, mirroring physical keyboard behaviour.
+      // recently filled *wrong* slot, mirroring physical keyboard behaviour.
       if (inputEvent.inputType === 'deleteContentBackward') {
         for (let i = state.activeSlotIndex; i >= 0; i--) {
-          if (state.zones[i]?.placedTileId) {
+          const zone = state.zones[i];
+          if (zone?.placedTileId && (zone.isWrong || zone.isLocked)) {
             dispatch({ type: 'REMOVE_TILE', zoneIndex: i });
             return;
           }

--- a/src/components/answer-game/useTouchKeyboardInput.ts
+++ b/src/components/answer-game/useTouchKeyboardInput.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useAnswerGameContext } from './useAnswerGameContext';
+import { useAnswerGameDispatch } from './useAnswerGameDispatch';
 import { useTileEvaluation } from './useTileEvaluation';
 import type { RefObject } from 'react';
 
@@ -13,6 +14,7 @@ const NUMERIC_DEBOUNCE_MS = 400;
 export const useTouchKeyboardInput = (): TouchKeyboardInput => {
   const hiddenInputRef = useRef<HTMLInputElement | null>(null);
   const state = useAnswerGameContext();
+  const dispatch = useAnswerGameDispatch();
   const { placeTile, typeTile } = useTileEvaluation();
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -43,6 +45,18 @@ export const useTouchKeyboardInput = (): TouchKeyboardInput => {
 
     const handleInput = (event: Event) => {
       const inputEvent = event as InputEvent;
+
+      // Backspace / Delete inside the hidden input: eject the most
+      // recently filled slot, mirroring physical keyboard behaviour.
+      if (inputEvent.inputType === 'deleteContentBackward') {
+        for (let i = state.activeSlotIndex; i >= 0; i--) {
+          if (state.zones[i]?.placedTileId) {
+            dispatch({ type: 'REMOVE_TILE', zoneIndex: i });
+            return;
+          }
+        }
+        return;
+      }
 
       if (isNumeric) {
         // For numeric input, accumulate digits and debounce so multi-digit
@@ -78,7 +92,9 @@ export const useTouchKeyboardInput = (): TouchKeyboardInput => {
     state.config.touchKeyboardInputMode,
     state.allTiles,
     state.bankTileIds,
+    state.zones,
     state.activeSlotIndex,
+    dispatch,
     placeTile,
     typeTile,
   ]);

--- a/src/components/answer-game/useTouchKeyboardInput.ts
+++ b/src/components/answer-game/useTouchKeyboardInput.ts
@@ -13,7 +13,7 @@ const NUMERIC_DEBOUNCE_MS = 400;
 export const useTouchKeyboardInput = (): TouchKeyboardInput => {
   const hiddenInputRef = useRef<HTMLInputElement | null>(null);
   const state = useAnswerGameContext();
-  const { placeTile } = useTileEvaluation();
+  const { placeTile, typeTile } = useTileEvaluation();
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -34,6 +34,8 @@ export const useTouchKeyboardInput = (): TouchKeyboardInput => {
 
       if (matchingTile) {
         placeTile(matchingTile.id, state.activeSlotIndex);
+      } else {
+        typeTile(data, state.activeSlotIndex);
       }
 
       input.value = '';
@@ -78,6 +80,7 @@ export const useTouchKeyboardInput = (): TouchKeyboardInput => {
     state.bankTileIds,
     state.activeSlotIndex,
     placeTile,
+    typeTile,
   ]);
 
   const focusKeyboard = useCallback(() => {

--- a/src/games/number-match/NumeralTileBank/NumeralTileBank.tsx
+++ b/src/games/number-match/NumeralTileBank/NumeralTileBank.tsx
@@ -142,79 +142,81 @@ export const NumeralTileBank = ({
       data-tile-bank=""
       className="flex flex-wrap justify-center gap-3"
     >
-      {allTiles.map((tile) => {
-        const inBank = bankTileIds.includes(tile.id);
-        const isDragging = tile.id === dragActiveTileId;
-        const isHoverTarget =
-          tile.id === dragHoverBankTileId ||
-          (!dragHoverBankTileId &&
-            isDragOver &&
-            !inBank &&
-            tile.id === dragActiveTileId);
-        const numericValue = Number.parseInt(tile.value, 10);
-        const isDomino = getIsDomino(tileStyle, numericValue);
-        const holeSizeClass = isDomino ? 'h-[72px] w-32' : 'size-20';
+      {allTiles
+        .filter((t) => !t.id.startsWith('typed-'))
+        .map((tile) => {
+          const inBank = bankTileIds.includes(tile.id);
+          const isDragging = tile.id === dragActiveTileId;
+          const isHoverTarget =
+            tile.id === dragHoverBankTileId ||
+            (!dragHoverBankTileId &&
+              isDragOver &&
+              !inBank &&
+              tile.id === dragActiveTileId);
+          const numericValue = Number.parseInt(tile.value, 10);
+          const isDomino = getIsDomino(tileStyle, numericValue);
+          const holeSizeClass = isDomino ? 'h-[72px] w-32' : 'size-20';
 
-        if (inBank) {
-          return (
-            <div
-              key={tile.id}
-              className={[
-                'relative rounded-2xl transition-all',
-                holeSizeClass,
-              ]
-                .filter(Boolean)
-                .join(' ')}
-            >
+          if (inBank) {
+            return (
               <div
-                data-tile-bank-hole={tile.id}
+                key={tile.id}
                 className={[
-                  'rounded-2xl bg-muted/60 shadow-inner',
+                  'relative rounded-2xl transition-all',
                   holeSizeClass,
                 ]
                   .filter(Boolean)
                   .join(' ')}
-                aria-hidden="true"
-              />
-              <div
-                className={`absolute inset-0${isDragging ? ' opacity-30 pointer-events-none' : ''}`}
-                aria-hidden={isDragging || undefined}
               >
-                <NumeralTile tile={tile} tileStyle={tileStyle} />
-              </div>
-              {isHoverTarget && (
                 <div
-                  className="pointer-events-none absolute inset-0 rounded-2xl border-2 border-dashed border-primary"
+                  data-tile-bank-hole={tile.id}
+                  className={[
+                    'rounded-2xl bg-muted/60 shadow-inner',
+                    holeSizeClass,
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
                   aria-hidden="true"
                 />
+                <div
+                  className={`absolute inset-0${isDragging ? ' opacity-30 pointer-events-none' : ''}`}
+                  aria-hidden={isDragging || undefined}
+                >
+                  <NumeralTile tile={tile} tileStyle={tileStyle} />
+                </div>
+                {isHoverTarget && (
+                  <div
+                    className="pointer-events-none absolute inset-0 rounded-2xl border-2 border-dashed border-primary"
+                    aria-hidden="true"
+                  />
+                )}
+              </div>
+            );
+          }
+
+          return (
+            <div
+              key={tile.id}
+              data-tile-bank-hole={tile.id}
+              className={[
+                'relative rounded-2xl bg-muted/60 shadow-inner transition-all',
+                holeSizeClass,
+                isHoverTarget
+                  ? 'border-2 border-dashed border-primary'
+                  : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+              aria-hidden="true"
+            >
+              {isHoverTarget && (
+                <span className="absolute inset-0 flex items-center justify-center text-2xl font-bold opacity-50">
+                  {tile.label}
+                </span>
               )}
             </div>
           );
-        }
-
-        return (
-          <div
-            key={tile.id}
-            data-tile-bank-hole={tile.id}
-            className={[
-              'relative rounded-2xl bg-muted/60 shadow-inner transition-all',
-              holeSizeClass,
-              isHoverTarget
-                ? 'border-2 border-dashed border-primary'
-                : '',
-            ]
-              .filter(Boolean)
-              .join(' ')}
-            aria-hidden="true"
-          >
-            {isHoverTarget && (
-              <span className="absolute inset-0 flex items-center justify-center text-2xl font-bold opacity-50">
-                {tile.label}
-              </span>
-            )}
-          </div>
-        );
-      })}
+        })}
     </div>
   );
 };

--- a/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.tsx
+++ b/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.tsx
@@ -47,58 +47,60 @@ export const SortNumbersTileBank = () => {
       data-tile-bank=""
       className="flex flex-wrap justify-center gap-3"
     >
-      {allTiles.map((tile) => {
-        const inBank = bankTileIds.includes(tile.id);
-        const isDragging = tile.id === dragActiveTileId;
-        const isHoverTarget =
-          tile.id === dragHoverBankTileId ||
-          (!dragHoverBankTileId &&
-            isDragOver &&
-            !inBank &&
-            tile.id === dragActiveTileId);
+      {allTiles
+        .filter((t) => !t.id.startsWith('typed-'))
+        .map((tile) => {
+          const inBank = bankTileIds.includes(tile.id);
+          const isDragging = tile.id === dragActiveTileId;
+          const isHoverTarget =
+            tile.id === dragHoverBankTileId ||
+            (!dragHoverBankTileId &&
+              isDragOver &&
+              !inBank &&
+              tile.id === dragActiveTileId);
 
-        if (inBank) {
+          if (inBank) {
+            return (
+              <div
+                key={tile.id}
+                className="relative size-14 rounded-xl transition-all"
+              >
+                <div
+                  data-tile-bank-hole={tile.id}
+                  className="size-14 rounded-xl bg-muted/60 shadow-inner"
+                  aria-hidden="true"
+                />
+                <div
+                  className={`absolute inset-0${isDragging ? ' opacity-30 pointer-events-none' : ''}`}
+                  aria-hidden={isDragging || undefined}
+                >
+                  <NumberTile tile={tile} />
+                </div>
+                {isHoverTarget && (
+                  <div
+                    className="pointer-events-none absolute inset-0 rounded-xl border-2 border-dashed border-primary"
+                    aria-hidden="true"
+                  />
+                )}
+              </div>
+            );
+          }
+
           return (
             <div
               key={tile.id}
-              className="relative size-14 rounded-xl transition-all"
+              data-tile-bank-hole={tile.id}
+              className={`relative size-14 rounded-xl bg-muted/60 shadow-inner transition-all${isHoverTarget ? ' border-2 border-dashed border-primary' : ''}`}
+              aria-hidden="true"
             >
-              <div
-                data-tile-bank-hole={tile.id}
-                className="size-14 rounded-xl bg-muted/60 shadow-inner"
-                aria-hidden="true"
-              />
-              <div
-                className={`absolute inset-0${isDragging ? ' opacity-30 pointer-events-none' : ''}`}
-                aria-hidden={isDragging || undefined}
-              >
-                <NumberTile tile={tile} />
-              </div>
               {isHoverTarget && (
-                <div
-                  className="pointer-events-none absolute inset-0 rounded-xl border-2 border-dashed border-primary"
-                  aria-hidden="true"
-                />
+                <span className="absolute inset-0 flex items-center justify-center text-2xl font-bold opacity-50">
+                  {tile.label}
+                </span>
               )}
             </div>
           );
-        }
-
-        return (
-          <div
-            key={tile.id}
-            data-tile-bank-hole={tile.id}
-            className={`relative size-14 rounded-xl bg-muted/60 shadow-inner transition-all${isHoverTarget ? ' border-2 border-dashed border-primary' : ''}`}
-            aria-hidden="true"
-          >
-            {isHoverTarget && (
-              <span className="absolute inset-0 flex items-center justify-center text-2xl font-bold opacity-50">
-                {tile.label}
-              </span>
-            )}
-          </div>
-        );
-      })}
+        })}
     </div>
   );
 };

--- a/src/games/word-spell/LetterTileBank/LetterTileBank.tsx
+++ b/src/games/word-spell/LetterTileBank/LetterTileBank.tsx
@@ -59,61 +59,63 @@ export const LetterTileBank = () => {
       data-tile-bank=""
       className="flex flex-wrap justify-center gap-3"
     >
-      {allTiles.map((tile) => {
-        const inBank = bankTileIds.includes(tile.id);
-        const isDragging = tile.id === dragActiveTileId;
-        // Occupied bank tile being hovered by a slot tile (HTML5 + touch), OR
-        // slot tile being dragged back over its own bank hole (HTML5 only —
-        // the hole div is not a registered drop target, so we use isDragOver).
-        const isHoverTarget =
-          tile.id === dragHoverBankTileId ||
-          (!dragHoverBankTileId &&
-            isDragOver &&
-            !inBank &&
-            tile.id === dragActiveTileId);
+      {allTiles
+        .filter((t) => !t.id.startsWith('typed-'))
+        .map((tile) => {
+          const inBank = bankTileIds.includes(tile.id);
+          const isDragging = tile.id === dragActiveTileId;
+          // Occupied bank tile being hovered by a slot tile (HTML5 + touch), OR
+          // slot tile being dragged back over its own bank hole (HTML5 only —
+          // the hole div is not a registered drop target, so we use isDragOver).
+          const isHoverTarget =
+            tile.id === dragHoverBankTileId ||
+            (!dragHoverBankTileId &&
+              isDragOver &&
+              !inBank &&
+              tile.id === dragActiveTileId);
 
-        if (inBank) {
+          if (inBank) {
+            return (
+              <div
+                key={tile.id}
+                className="relative size-14 rounded-xl transition-all"
+              >
+                <div
+                  data-tile-bank-hole={tile.id}
+                  className="size-14 rounded-xl bg-muted/60 shadow-inner"
+                  aria-hidden="true"
+                />
+                <div
+                  className={`absolute inset-0${isDragging ? ' opacity-30 pointer-events-none' : ''}`}
+                  aria-hidden={isDragging || undefined}
+                >
+                  <LetterTile tile={tile} />
+                </div>
+                {isHoverTarget && (
+                  <div
+                    className="pointer-events-none absolute inset-0 rounded-xl border-2 border-dashed border-primary"
+                    aria-hidden="true"
+                  />
+                )}
+              </div>
+            );
+          }
+
           return (
             <div
               key={tile.id}
-              className="relative size-14 rounded-xl transition-all"
+              data-tile-bank-hole={tile.id}
+              className={`relative size-14 rounded-xl bg-muted/60 shadow-inner transition-all${isHoverTarget ? ' border-2 border-dashed border-primary' : ''}`}
+              aria-hidden="true"
             >
-              <div
-                data-tile-bank-hole={tile.id}
-                className="size-14 rounded-xl bg-muted/60 shadow-inner"
-                aria-hidden="true"
-              />
-              <div
-                className={`absolute inset-0${isDragging ? ' opacity-30 pointer-events-none' : ''}`}
-                aria-hidden={isDragging || undefined}
-              >
-                <LetterTile tile={tile} />
-              </div>
               {isHoverTarget && (
-                <div
-                  className="pointer-events-none absolute inset-0 rounded-xl border-2 border-dashed border-primary"
-                  aria-hidden="true"
-                />
+                <span className="absolute inset-0 flex items-center justify-center text-2xl font-bold opacity-50">
+                  {tile.label}
+                </span>
               )}
             </div>
           );
-        }
-
-        return (
-          <div
-            key={tile.id}
-            data-tile-bank-hole={tile.id}
-            className={`relative size-14 rounded-xl bg-muted/60 shadow-inner transition-all${isHoverTarget ? ' border-2 border-dashed border-primary' : ''}`}
-            aria-hidden="true"
-          >
-            {isHoverTarget && (
-              <span className="absolute inset-0 flex items-center justify-center text-2xl font-bold opacity-50">
-                {tile.label}
-              </span>
-            )}
-          </div>
-        );
-      })}
+        })}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- Keyboard input overhaul: free-typing with `TYPE_TILE` for lock-manual/lock-auto-eject modes, Backspace/Delete ejects tiles, slot navigation with arrow keys
- Slot UX: blinking cursor on wrong tiles, focus ring on active filled slots, Tab escapes slots at boundaries
- Tile bank: exclude virtual typed tiles from rendering
- Fix TS2532: add optional chaining in test for `zones[0]`

## Test plan

- [x] TypeScript typecheck passes
- [x] ESLint + Knip lint passes
- [x] Unit tests pass (Vitest)
- [x] Storybook interaction tests pass
- [x] Visual regression tests pass
- [x] E2E tests pass (Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)