### PR TITLE
feat: add number words utility

### DIFF
--- a/docs/superpowers/plans/2026-04-10-countable-dots.md
+++ b/docs/superpowers/plans/2026-04-10-countable-dots.md
@@ -1,0 +1,98 @@
+# Countable Dots Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make each dot in `DotGroupQuestion` individually tappable so kids
+can count them one by one, with per-dot numbering and TTS on each tap.
+
+**Tech Stack:** TypeScript, React, Tailwind CSS, Web Speech API (TTS)
+
+**Spec:**
+[docs/superpowers/specs/2026-04-10-match-number-improvements-design.md](../specs/2026-04-10-match-number-improvements-design.md)
+(Section 3 — Countable Dots)
+
+---
+
+## File Map
+
+### New files
+
+_(none)_
+
+### Modified files
+
+- `src/components/questions/DotGroupQuestion/DotGroupQuestion.tsx` — add
+  per-dot tap state, numbering overlay, TTS on tap, auto-reset on count
+  change
+- `src/components/questions/DotGroupQuestion/DotGroupQuestion.test.tsx` —
+  tests for tap-to-count, sequential numbering, reset on count change
+- `src/components/questions/DotGroupQuestion/DotGroupQuestion.stories.tsx` —
+  update stories to demonstrate countable dots
+
+---
+
+## Steps
+
+- [ ] **Step 1 — Add per-dot tap state**
+  - File: `DotGroupQuestion.tsx`
+  - Add `useState<(number | null)[]>` initialised to
+    `Array(count).fill(null)` — tracks assigned count per dot
+  - Add a `useRef<number>` for `nextCount` starting at `1`
+  - Reset both when `count` changes (use `useEffect` with `count` dependency)
+
+- [ ] **Step 2 — Convert dots from `<span>` to `<button>`**
+  - File: `DotGroupQuestion.tsx`
+  - Replace each `<span role="presentation">` dot with a
+    `<button type="button">`
+  - Keep existing styling: `size-10 rounded-full bg-primary`
+  - Add `aria-label` for accessibility (e.g. "Dot 3 of 7")
+  - Add `onClick` handler for the tap logic
+
+- [ ] **Step 3 — Implement tap handler**
+  - File: `DotGroupQuestion.tsx`
+  - On tap of an unnumbered dot (value is `null`):
+    - Assign `nextCount.current` to that dot's position in the state array
+    - Increment `nextCount.current`
+  - Already-tapped dots do nothing on re-tap (guard: if value !== null, return)
+
+- [ ] **Step 4 — Render number overlay on tapped dots**
+  - File: `DotGroupQuestion.tsx`
+  - When a dot has an assigned number, render the number centered on the dot
+  - White text (`text-white`), bold, centered over the primary circle
+  - Use `relative` positioning on the button with an `absolute` number overlay
+  - Font size: `text-sm font-bold`
+
+- [ ] **Step 5 — Add TTS on tap**
+  - File: `DotGroupQuestion.tsx`
+  - On each tap, speak the cardinal word for the assigned number
+    (e.g. "one", "two", "three")
+  - Use the existing `useGameTTS()` hook or `speechSynthesis.speak()` directly
+  - Use `toCardinalText` from `number-words.ts` for locale-aware words
+  - Locale sourced from existing context/params
+
+- [ ] **Step 6 — Auto-reset on count change**
+  - File: `DotGroupQuestion.tsx`
+  - `useEffect` with `[count]` dependency:
+    - Reset state array to `Array(count).fill(null)`
+    - Reset `nextCount.current` to `1`
+  - This handles round transitions
+
+- [ ] **Step 7 — Update tests**
+  - File: `DotGroupQuestion.test.tsx`
+  - Test: tapping a dot assigns sequential numbers (1, 2, 3...)
+  - Test: tapping an already-numbered dot does nothing
+  - Test: state resets when `count` prop changes
+  - Test: dots render as buttons with correct aria-labels
+
+- [ ] **Step 8 — Update stories**
+  - File: `DotGroupQuestion.stories.tsx`
+  - Update existing stories to show interactive countable dots
+  - Add a story with a higher count (e.g. 9 dots) to show wrapping
+
+- [ ] **Step 9 — Verify**
+  - `yarn typecheck` passes
+  - `yarn lint` passes
+  - `yarn test` passes

--- a/docs/superpowers/plans/2026-04-10-domino-tile-overhaul.md
+++ b/docs/superpowers/plans/2026-04-10-domino-tile-overhaul.md
@@ -1,0 +1,107 @@
+# Domino Tile Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify all `dots`-style tiles into a single vertical domino shape,
+replace the current `DiceFace`/`DominoTile` split with a single `DominoTile`
+component, update the `DOMINO_SPLIT` map for young-reader-friendly splits,
+and remove `allDice` branching logic.
+
+**Tech Stack:** TypeScript, React, Tailwind CSS
+
+**Spec:**
+[docs/superpowers/specs/2026-04-10-match-number-improvements-design.md](../specs/2026-04-10-match-number-improvements-design.md)
+(Section 1 — Domino Tile Overhaul)
+
+---
+
+## File Map
+
+### New files
+
+_(none)_
+
+### Modified files
+
+- `src/games/number-match/NumeralTileBank/NumeralTileBank.tsx` — rewrite
+  `DominoTile` as a vertical layout, make `DiceFace` internal-only, update
+  `DOMINO_SPLIT` map, unify tile sizing, remove `getIsDomino` branching
+- `src/games/number-match/NumberMatch/NumberMatch.tsx` — remove `allDice`
+  branching, unify slot sizing for dots mode, update slot render callback to
+  always use `DominoTile`
+
+---
+
+## Steps
+
+- [ ] **Step 1 — Update `DOMINO_SPLIT` map**
+  - File: `NumeralTileBank.tsx`
+  - Replace the existing `DOMINO_SPLIT` with the new young-reader-friendly map
+    (top/bottom, smaller value on top):
+
+    | Value | Top | Bottom |
+    | ----- | --- | ------ |
+    | 1     | 1   | 0      |
+    | 2     | 2   | 0      |
+    | 3     | 3   | 0      |
+    | 4     | 4   | 0      |
+    | 5     | 5   | 0      |
+    | 6     | 6   | 0      |
+    | 7     | 2   | 5      |
+    | 8     | 4   | 4      |
+    | 9     | 4   | 5      |
+    | 10    | 5   | 5      |
+    | 11    | 5   | 6      |
+    | 12    | 6   | 6      |
+
+  - Keys 1-6 now have a bottom value of `0` (blank half)
+
+- [ ] **Step 2 — Rewrite `DominoTile` to vertical orientation**
+  - File: `NumeralTileBank.tsx`
+  - Change layout from horizontal (`flex items-center`) to vertical
+    (`flex flex-col items-center`)
+  - Render top `DiceFace`, then a horizontal divider line, then bottom
+    `DiceFace`
+  - Divider: `<span className="h-px w-11 shrink-0 bg-current opacity-30" />`
+  - Padding: `py-3` between pip grids and divider
+  - Bottom value of `0` renders a blank half (empty `DiceFace` or empty space)
+  - All tiles: `w-[72px] h-[136px]` (tall rectangle)
+
+- [ ] **Step 3 — Make `DiceFace` internal, stop exporting it**
+  - File: `NumeralTileBank.tsx`
+  - Remove `DiceFace` from named exports
+  - `DiceFace` stays as a private helper inside the file (renders one half of
+    a domino)
+  - Handle value `0` in `DiceFace` — render an empty 3x3 grid (no pips)
+
+- [ ] **Step 4 — Remove `getIsDomino` helper and `allDice` branching in
+      `NumeralTileBank`**
+  - File: `NumeralTileBank.tsx`
+  - Delete the `getIsDomino` function
+  - When `tileStyle === 'dots'`, always use the same domino dimensions
+    (`w-[72px] h-[136px]`) for tiles and holes regardless of value
+  - Remove conditional sizing (`isDomino ? 'h-[72px] w-32' : 'size-20'`)
+  - All tiles in dots mode render via `DominoTile`
+
+- [ ] **Step 5 — Remove `allDice` branching in `NumberMatch.tsx`**
+  - File: `NumberMatch.tsx`
+  - Remove the `allDice` computed boolean and its slot class logic
+  - When dots mode is active, all slots use portrait dimensions:
+    `w-[72px] h-[136px] rounded-2xl`
+  - Update slot render callback to always use `<DominoTile value={n} />`
+    instead of branching on `n <= 6` vs `n > 6`
+
+- [ ] **Step 6 — Update imports**
+  - File: `NumberMatch.tsx`
+  - Remove `DiceFace` import (no longer exported)
+  - Keep `DominoTile` import
+
+- [ ] **Step 7 — Verify**
+  - `yarn typecheck` passes
+  - `yarn lint` passes
+  - `yarn test` passes (existing tests in
+    `NumeralTileBank.test.tsx` and `NumberMatch.test.tsx`)
+  - Storybook stories render correctly with uniform vertical tiles

--- a/docs/superpowers/plans/2026-04-10-hover-preview-fix.md
+++ b/docs/superpowers/plans/2026-04-10-hover-preview-fix.md
@@ -1,0 +1,85 @@
+# Hover Preview Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix hover previews in slots and bank holes so they render a domino
+face (when in dots+group mode) or the correct text label instead of always
+showing plain text.
+
+**Tech Stack:** TypeScript, React, Tailwind CSS
+
+**Spec:**
+[docs/superpowers/specs/2026-04-10-match-number-improvements-design.md](../specs/2026-04-10-match-number-improvements-design.md)
+(Section 4 — Hover Preview Fix)
+
+**Dependency:** Requires the Domino Tile Overhaul
+([2026-04-10-domino-tile-overhaul.md](./2026-04-10-domino-tile-overhaul.md))
+and Mode Bug Fix + New Modes
+([2026-04-10-mode-bugfix-new-modes.md](./2026-04-10-mode-bugfix-new-modes.md))
+to be implemented first, since this plan builds on `tilesShowGroup` and the
+new `DominoTile` component.
+
+---
+
+## File Map
+
+### New files
+
+_(none)_
+
+### Modified files
+
+- `src/games/number-match/NumberMatch/NumberMatch.tsx` — update slot render
+  callback to render domino or text for `previewLabel`
+- `src/games/number-match/NumeralTileBank/NumeralTileBank.tsx` — update bank
+  hole hover preview to render domino or text
+
+---
+
+## Steps
+
+- [ ] **Step 1 — Update slot preview rendering in `NumberMatch.tsx`**
+  - File: `NumberMatch.tsx`
+  - In the `Slot` render callback, handle the `previewLabel` case:
+    - When `isPreview && previewLabel !== null`:
+      - If `tilesShowGroup && tileStyle === 'dots'`: parse `previewLabel` as
+        number, render `<DominoTile value={n} />` at `opacity-50`
+      - Otherwise: render `<span>{previewLabel}</span>` at `opacity-50`
+  - This requires the `Slot` render callback to receive `previewLabel` and
+    `isPreview` in its render props (check `SlotRenderProps` — these are
+    already available: `label`, `previewLabel`, `isPreview`)
+
+- [ ] **Step 2 — Update bank hole hover preview in `NumeralTileBank.tsx`**
+  - File: `NumeralTileBank.tsx`
+  - When a bank hole is the hover target (`isHoverTarget`), the empty hole
+    currently renders `tile.label` as plain text
+  - Update to check `tilesShowGroup && tileStyle === 'dots'`:
+    - If true: render `<DominoTile value={n} />` at `opacity-50` inside the
+      hole
+    - If false: render `<span>{tile.label}</span>` at `opacity-50` (current
+      behavior)
+
+- [ ] **Step 3 — Verify preview sizing**
+  - Slot preview: domino preview should fit within the portrait slot
+    (`w-[72px] h-[136px]`)
+  - Bank hole preview: domino preview should fit within the bank hole
+    dimensions
+  - Word tile previews: text should fit within `min-w-[80px] h-[80px]` holes
+  - Both previews use `opacity-50` for the semi-transparent effect
+
+- [ ] **Step 4 — Test in Storybook**
+  - Verify in `NumberMatch` stories:
+    - `NumeralToGroup` mode: dragging a domino tile over a slot shows a
+      semi-transparent domino preview
+    - `GroupToNumeral` mode: dragging a numeral tile shows plain text preview
+    - Word modes: dragging a word tile shows the word text as preview
+  - Verify in `NumeralTileBank` stories:
+    - Returning a tile to bank shows correct preview in the hole
+
+- [ ] **Step 5 — Verify**
+  - `yarn typecheck` passes
+  - `yarn lint` passes
+  - `yarn test` passes

--- a/docs/superpowers/plans/2026-04-10-mode-bugfix-new-modes.md
+++ b/docs/superpowers/plans/2026-04-10-mode-bugfix-new-modes.md
@@ -1,0 +1,145 @@
+# Mode Bug Fix + New Modes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the `group-to-numeral` rendering bug, introduce the
+`tilesShowGroup` gate, expand the mode type to 8 variants, add word/ordinal
+tile rendering, and update slot/bank sizing to match.
+
+**Tech Stack:** TypeScript, React, Tailwind CSS
+
+**Spec:**
+[docs/superpowers/specs/2026-04-10-match-number-improvements-design.md](../specs/2026-04-10-match-number-improvements-design.md)
+(Section 2 — Mode Bug Fix + New Modes, excluding the number-words utility)
+
+**Dependency:** The `number-words.ts` utility must be implemented first (see
+[2026-04-10-number-words-utility.md](./2026-04-10-number-words-utility.md)).
+
+---
+
+## File Map
+
+### New files
+
+_(none)_
+
+### Modified files
+
+- `src/games/number-match/types.ts` — expand `NumberMatchMode` to 8 variants,
+  update `NumberMatchConfig` field
+- `src/games/number-match/build-numeral-round.ts` — generate display labels
+  for word/ordinal modes using the number-words utility
+- `src/games/number-match/NumberMatch/NumberMatch.tsx` — add `tilesShowGroup`
+  gate, update slot dimensions, update rendering logic for word tiles
+- `src/games/number-match/NumeralTileBank/NumeralTileBank.tsx` — accept
+  `tilesShowGroup` prop, gate domino rendering, update NumeralTile to render
+  word tiles
+- `src/games/number-match/NumberMatch/NumberMatch.stories.tsx` — add stories
+  for all 8 modes
+- `src/games/number-match/NumeralTileBank/NumeralTileBank.stories.tsx` —
+  update stories for new tile types
+
+---
+
+## Steps
+
+- [ ] **Step 1 — Expand `NumberMatchMode` type**
+  - File: `types.ts`
+  - Replace the current mode union with all 8 variants:
+
+    ```typescript
+    type NumberMatchMode =
+      | 'numeral-to-group'
+      | 'group-to-numeral'
+      | 'cardinal-number-to-text'
+      | 'cardinal-text-to-number'
+      | 'ordinal-number-to-text'
+      | 'ordinal-text-to-number'
+      | 'cardinal-to-ordinal'
+      | 'ordinal-to-cardinal';
+    ```
+
+  - Remove old `'numeral-to-word'` and `'word-to-numeral'` variants
+
+- [ ] **Step 2 — Add `tilesShowGroup` gate in `NumberMatch.tsx`**
+  - File: `NumberMatch.tsx`
+  - Derive `tilesShowGroup`:
+    `const tilesShowGroup = config.mode === 'numeral-to-group';`
+  - Pass `tilesShowGroup` as a prop to `NumeralTileBank`
+  - Domino rendering only applies when
+    `tilesShowGroup && config.tileStyle === 'dots'`
+
+- [ ] **Step 3 — Update slot dimensions**
+  - File: `NumberMatch.tsx`
+  - Slot sizing logic:
+    - `tilesShowGroup && tileStyle === 'dots'` -> portrait
+      `w-[72px] h-[136px] rounded-2xl`
+    - All other modes -> square `size-20 rounded-2xl`
+
+- [ ] **Step 4 — Update slot render callback**
+  - File: `NumberMatch.tsx`
+  - When `tilesShowGroup && tileStyle === 'dots'` -> render
+    `<DominoTile value={n} />`
+  - When mode is a word/ordinal mode -> render text label from tile
+  - Otherwise -> render plain numeral text
+
+- [ ] **Step 5 — Update question rendering for new modes**
+  - File: `NumberMatch.tsx`
+  - `group-to-numeral` -> `<DotGroupQuestion>`
+  - `numeral-to-group` -> `<TextQuestion>` (shows numeral)
+  - Cardinal/ordinal modes -> `<TextQuestion>` showing the appropriate
+    question text:
+    - `cardinal-number-to-text`: show numeral (e.g. "7")
+    - `cardinal-text-to-number`: show cardinal word (e.g. "seven")
+    - `ordinal-number-to-text`: show ordinal number (e.g. "7th")
+    - `ordinal-text-to-number`: show ordinal word (e.g. "seventh")
+    - `cardinal-to-ordinal`: show cardinal word (e.g. "seven")
+    - `ordinal-to-cardinal`: show ordinal word (e.g. "seventh")
+  - Use `toCardinalText`, `toOrdinalText`, `toOrdinalNumber` from
+    `number-words.ts` for conversions
+  - Locale from `useParams({ from: '/$locale' })`
+
+- [ ] **Step 6 — Accept `tilesShowGroup` prop in `NumeralTileBank`**
+  - File: `NumeralTileBank.tsx`
+  - Add `tilesShowGroup: boolean` to props
+  - Gate domino rendering: only render `DominoTile` when
+    `tilesShowGroup && tileStyle === 'dots'`
+  - When `!tilesShowGroup`: render plain text tile (numeral or word)
+  - Tile sizing: portrait for dots+group, square otherwise
+
+- [ ] **Step 7 — Add word tile UI in `NumeralTile`**
+  - File: `NumeralTileBank.tsx`
+  - Word tiles: square with `min-w-[80px] h-[80px]`
+  - Font size scales down for longer words (e.g. `text-sm` for > 6 chars)
+  - Long words with hyphens break across two lines (`hyphens-auto`)
+  - Slots and bank holes use matching `min-w-[80px]`
+
+- [ ] **Step 8 — Update `build-numeral-round.ts` for word labels**
+  - File: `build-numeral-round.ts`
+  - Accept `mode` and `locale` parameters
+  - Generate tile labels based on mode:
+    - `numeral-to-group` / `group-to-numeral`: numeric labels (current)
+    - `cardinal-number-to-text`: answer tiles show cardinal words
+    - `cardinal-text-to-number`: answer tiles show numerals
+    - `ordinal-number-to-text`: answer tiles show ordinal words
+    - `ordinal-text-to-number`: answer tiles show numerals with ordinal suffix
+    - `cardinal-to-ordinal`: answer tiles show ordinal words
+    - `ordinal-to-cardinal`: answer tiles show cardinal words
+  - Matching always compares underlying numeric `value`, not text
+
+- [ ] **Step 9 — Update stories**
+  - File: `NumberMatch.stories.tsx`
+  - Add stories for all 8 modes: `NumeralToGroup`, `GroupToNumeral`,
+    `CardinalNumberToText`, `CardinalTextToNumber`, `OrdinalNumberToText`,
+    `OrdinalTextToNumber`, `CardinalToOrdinal`, `OrdinalToCardinal`
+  - File: `NumeralTileBank.stories.tsx`
+  - Add story for word-style tiles
+
+- [ ] **Step 10 — Verify**
+  - `yarn typecheck` passes
+  - `yarn lint` passes
+  - `yarn test` passes
+  - All 8 mode stories render correctly in Storybook

--- a/docs/superpowers/plans/2026-04-10-orchestration-prompt.md
+++ b/docs/superpowers/plans/2026-04-10-orchestration-prompt.md
@@ -1,0 +1,205 @@
+# Match Number Improvements — Orchestration Prompt
+
+Use this prompt in a new Claude Code session to execute the implementation
+plans. Copy everything below the `---` line.
+
+---
+
+## Task
+
+Implement the MatchNumber game improvements across 5 plans, using parallel
+sub-agents where dependencies allow. Each agent works in its own git worktree
+branched from `match-number-improvements` and raises a PR back into
+`match-number-improvements` when done.
+
+## Source branch
+
+All worktrees branch from `match-number-improvements` (NOT `master`). PRs
+target `match-number-improvements`.
+
+## Plans location
+
+All plans live in `docs/superpowers/plans/` and follow the checkbox step
+format. Each agent must follow its plan exactly — tick off each step as it
+completes.
+
+## Dependency graph
+
+```text
+Wave 1 (parallel, no dependencies):
+  ├── Agent A: 2026-04-10-number-words-utility.md     → branch: feat/number-words-utility
+  └── Agent B: 2026-04-10-domino-tile-overhaul.md      → branch: feat/domino-tile-overhaul
+
+  ⏳ Merge both Wave 1 PRs before starting Wave 2
+
+Wave 2 (parallel, depends on Wave 1 merges):
+  ├── Agent C: 2026-04-10-countable-dots.md             → branch: feat/countable-dots
+  └── Agent D: 2026-04-10-mode-bugfix-new-modes.md      → branch: feat/mode-bugfix-new-modes
+
+  ⏳ Merge both Wave 2 PRs before starting Wave 3
+
+Wave 3 (single agent, depends on Wave 2 merges):
+  └── Agent E: 2026-04-10-hover-preview-fix.md          → branch: feat/hover-preview-fix
+```
+
+## Agent instructions (applies to every agent)
+
+Each agent must:
+
+1. Create a worktree from the current state of `match-number-improvements`:
+
+   ```bash
+   cd /Users/leocaseiro/Sites/base-skill
+   git worktree add ./worktrees/<branch-name> -b <branch-name> match-number-improvements
+   cd ./worktrees/<branch-name>
+   yarn install
+   ```
+
+2. Read its assigned plan from `docs/superpowers/plans/`.
+3. Implement each step, ticking off checkboxes as it goes.
+4. After all steps pass, run the verification gate:
+
+   ```bash
+   yarn typecheck && yarn lint && yarn test
+   ```
+
+5. Commit with a descriptive message (no `--amend`).
+6. Push the branch and create a PR targeting `match-number-improvements`:
+
+   ```bash
+   git push -u origin <branch-name>
+   gh pr create --base match-number-improvements \
+     --title "<short title>" \
+     --body "$(cat <<'EOF'
+   ## Summary
+   <what this PR does, 1-3 bullets>
+
+   ## Plan
+   Implements `docs/superpowers/plans/<plan-file>.md`
+
+   ## Verification
+   - [ ] `yarn typecheck` passes
+   - [ ] `yarn lint` passes
+   - [ ] `yarn test` passes
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"
+   ```
+
+7. Do NOT merge the PR — leave it for review.
+
+## Execution flow
+
+### Wave 1 — dispatch agents A and B in parallel
+
+Dispatch two sub-agents simultaneously using the Agent tool with
+`isolation: "worktree"`. Both are independent and can run at the same time.
+
+**Agent A prompt:**
+
+> You are implementing the Number Words Utility for the MatchNumber game.
+>
+> Working directory: `/Users/leocaseiro/Sites/base-skill`
+>
+> 1. Create a worktree: `git worktree add ./worktrees/feat/number-words-utility -b feat/number-words-utility match-number-improvements`
+> 2. `cd ./worktrees/feat/number-words-utility && yarn install`
+> 3. Read and follow every step in `docs/superpowers/plans/2026-04-10-number-words-utility.md`
+> 4. Run `yarn typecheck && yarn lint && yarn test` — all must pass
+> 5. Commit, push, and create a PR targeting `match-number-improvements`
+> 6. Do NOT merge the PR
+>
+> Follow the plan exactly. Use named exports only (no default exports).
+> Analyse `eslint.config.js` for code style (const arrow functions, not
+> function declarations).
+
+**Agent B prompt:**
+
+> You are implementing the Domino Tile Overhaul for the MatchNumber game.
+>
+> Working directory: `/Users/leocaseiro/Sites/base-skill`
+>
+> 1. Create a worktree: `git worktree add ./worktrees/feat/domino-tile-overhaul -b feat/domino-tile-overhaul match-number-improvements`
+> 2. `cd ./worktrees/feat/domino-tile-overhaul && yarn install`
+> 3. Read and follow every step in `docs/superpowers/plans/2026-04-10-domino-tile-overhaul.md`
+> 4. Run `yarn typecheck && yarn lint && yarn test` — all must pass
+> 5. Commit, push, and create a PR targeting `match-number-improvements`
+> 6. Do NOT merge the PR
+>
+> Follow the plan exactly. Use named exports only (no default exports).
+> Analyse `eslint.config.js` for code style (const arrow functions, not
+> function declarations).
+
+**After both PRs are reviewed and merged**, proceed to Wave 2.
+
+### Wave 2 — dispatch agents C and D in parallel
+
+After Wave 1 merges are on `match-number-improvements`, dispatch two more
+sub-agents simultaneously.
+
+**Agent C prompt:**
+
+> You are implementing Countable Dots for the MatchNumber game.
+>
+> Working directory: `/Users/leocaseiro/Sites/base-skill`
+>
+> 1. Create a worktree: `git worktree add ./worktrees/feat/countable-dots -b feat/countable-dots match-number-improvements`
+> 2. `cd ./worktrees/feat/countable-dots && yarn install`
+> 3. Read and follow every step in `docs/superpowers/plans/2026-04-10-countable-dots.md`
+> 4. The `number-words.ts` utility is already merged — import `toCardinalText` from it
+> 5. Run `yarn typecheck && yarn lint && yarn test` — all must pass
+> 6. Commit, push, and create a PR targeting `match-number-improvements`
+> 7. Do NOT merge the PR
+>
+> Follow the plan exactly. Use named exports only (no default exports).
+> Analyse `eslint.config.js` for code style (const arrow functions, not
+> function declarations).
+
+**Agent D prompt:**
+
+> You are implementing Mode Bug Fix + New Modes for the MatchNumber game.
+>
+> Working directory: `/Users/leocaseiro/Sites/base-skill`
+>
+> 1. Create a worktree: `git worktree add ./worktrees/feat/mode-bugfix-new-modes -b feat/mode-bugfix-new-modes match-number-improvements`
+> 2. `cd ./worktrees/feat/mode-bugfix-new-modes && yarn install`
+> 3. Read and follow every step in `docs/superpowers/plans/2026-04-10-mode-bugfix-new-modes.md`
+> 4. Both the `number-words.ts` utility and Domino Tile Overhaul are already merged — build on them
+> 5. Run `yarn typecheck && yarn lint && yarn test` — all must pass
+> 6. Commit, push, and create a PR targeting `match-number-improvements`
+> 7. Do NOT merge the PR
+>
+> Follow the plan exactly. Use named exports only (no default exports).
+> Analyse `eslint.config.js` for code style (const arrow functions, not
+> function declarations).
+
+**After both PRs are reviewed and merged**, proceed to Wave 3.
+
+### Wave 3 — dispatch agent E
+
+**Agent E prompt:**
+
+> You are implementing the Hover Preview Fix for the MatchNumber game.
+>
+> Working directory: `/Users/leocaseiro/Sites/base-skill`
+>
+> 1. Create a worktree: `git worktree add ./worktrees/feat/hover-preview-fix -b feat/hover-preview-fix match-number-improvements`
+> 2. `cd ./worktrees/feat/hover-preview-fix && yarn install`
+> 3. Read and follow every step in `docs/superpowers/plans/2026-04-10-hover-preview-fix.md`
+> 4. The Domino Overhaul and Mode Bug Fix are already merged — `tilesShowGroup` and the new `DominoTile` are available
+> 5. Run `yarn typecheck && yarn lint && yarn test` — all must pass
+> 6. Commit, push, and create a PR targeting `match-number-improvements`
+> 7. Do NOT merge the PR
+>
+> Follow the plan exactly. Use named exports only (no default exports).
+> Analyse `eslint.config.js` for code style (const arrow functions, not
+> function declarations).
+
+## Between waves
+
+After each wave's PRs are created:
+
+1. Review the PRs (or ask the user to review)
+2. Merge them into `match-number-improvements`
+3. Clean up worktrees: `git worktree remove ./worktrees/feat/<name>`
+4. Then dispatch the next wave

--- a/docs/superpowers/specs/2026-04-10-match-number-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-10-match-number-improvements-design.md
@@ -81,7 +81,7 @@ This boolean gates rendering in three places:
 
 **8 game modes:**
 
-| Mode                      | Question  | Answer    | n2words      |
+| Mode                      | Question  | Answer    | Conversion   |
 | ------------------------- | --------- | --------- | ------------ |
 | `numeral-to-group`        | 7         | Domino    | —            |
 | `group-to-numeral`        | Dots      | 7         | —            |
@@ -193,5 +193,4 @@ Both reuse the existing `DominoTile` / `DiceFace` components.
 ## Out of Scope
 
 - `objects` and `fingers` tile styles — kept as stubs
-- Numeric ordinal format ("7th") — pending `n2words` upstream contribution
 - Drag preview ghost image (the floating tile during drag) — separate concern

--- a/docs/superpowers/specs/2026-04-10-match-number-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-10-match-number-improvements-design.md
@@ -1,0 +1,197 @@
+# MatchNumber Game Improvements Design
+
+## Overview
+
+Five improvements to the MatchNumber game targeting young readers and fixing
+existing mode bugs.
+
+## 1. Domino Tile Overhaul (Uniform Size + Vertical Orientation + Simpler Splits)
+
+### Problem
+
+- Dice tiles (1–6) are square 80×80, domino tiles (7–12) are wide rectangles
+  128×72 — inconsistent sizing
+- Dominoes render horizontally (left/right halves) — unnatural for a domino
+- Splits are not optimised for young readers (e.g. 10 = 6+4 instead of 5+5)
+- Pips are too close to the divider line
+
+### Solution
+
+Unify all `dots`-style tiles into a single vertical domino shape.
+
+**New `DOMINO_SPLIT` map (top/bottom, smaller value on top):**
+
+| Value | Top | Bottom |
+| ----- | --- | ------ |
+| 1     | 1   | 0      |
+| 2     | 2   | 0      |
+| 3     | 3   | 0      |
+| 4     | 4   | 0      |
+| 5     | 5   | 0      |
+| 6     | 6   | 0      |
+| 7     | 2   | 5      |
+| 8     | 4   | 4      |
+| 9     | 4   | 5      |
+| 10    | 5   | 5      |
+| 11    | 5   | 6      |
+| 12    | 6   | 6      |
+
+A bottom value of `0` means blank half (no pips).
+
+**Component changes:**
+
+- Replace separate `DiceFace`/`DominoTile` exports with a single `DominoTile`
+  component that always renders vertically
+- `DiceFace` becomes internal-only (renders one half of the domino)
+- All tiles: `w-[72px] h-[136px]` (tall rectangle)
+- Horizontal divider line, shorter than tile width (`w-11`), `opacity-30`
+- Generous padding (`py-3`) between pip grids and divider
+- Remove `allDice` branching logic in `NumberMatch.tsx` and
+  `NumeralTileBank.tsx` — when `tileStyle === 'dots'`, every tile/slot/hole
+  uses the same domino dimensions
+
+## 2. Mode Bug Fix + New Modes
+
+### Problem
+
+- `group-to-numeral`: tiles render as dominoes instead of plain numerals
+- `numeral-to-word` / `word-to-numeral`: tiles show plain numbers, no word
+  conversion exists
+- `tileStyle` options `objects` and `fingers` are stubs (fall through to numeral
+  text) — keep them as stubs for future work
+
+### Solution
+
+**Rendering gate:** Introduce a derived boolean `tilesShowGroup` that is `true`
+only when `mode === 'numeral-to-group'`. Domino rendering only applies when
+`tilesShowGroup && tileStyle === 'dots'`.
+
+This boolean gates rendering in three places:
+
+1. `NumeralTile` component
+2. `Slot` render callback in `NumberMatch.tsx`
+3. Bank hole hover preview
+
+`NumeralTileBank` receives a new prop `tilesShowGroup: boolean`.
+
+**Slot dimensions:**
+
+- `tilesShowGroup && tileStyle === 'dots'` → portrait `w-[72px] h-[136px]`
+- All other modes → square `size-20`
+
+**8 game modes:**
+
+| Mode                      | Question  | Answer    | n2words      |
+| ------------------------- | --------- | --------- | ------------ |
+| `numeral-to-group`        | 7         | Domino    | —            |
+| `group-to-numeral`        | Dots      | 7         | —            |
+| `cardinal-number-to-text` | 7         | "seven"   | `toCardinal` |
+| `cardinal-text-to-number` | "seven"   | 7         | `toCardinal` |
+| `ordinal-number-to-text`  | 7         | "seventh" | `toOrdinal`  |
+| `ordinal-text-to-number`  | "seventh" | 7         | `toOrdinal`  |
+| `cardinal-to-ordinal`     | "seven"   | "seventh" | both         |
+| `ordinal-to-cardinal`     | "seventh" | "seven"   | both         |
+
+**Dependency:** `n2words` — tree-shakeable per-locale imports, i18n, zero deps.
+Provides `toCardinal` and `toOrdinal` per locale.
+
+**Data flow:** Rounds are always generated with numeric values. At render time,
+`n2words` converts to display strings based on the mode. Matching logic always
+compares the underlying numeric `value`, never text strings.
+
+**Locale:** Sourced from the existing `useParams({ from: '/$locale' })` router
+param. Map the app locale to `n2words` locale import (e.g. `en` → `en-AU`,
+`pt` → `pt-PT`).
+
+**Word tile UI:**
+
+- Square tiles with `min-width: 80px`, height 80px
+- Font size scales down for longer words
+- Long words break at hyphens across two lines
+- Slots and bank holes match using `min-width`
+
+### Types update
+
+```typescript
+type NumberMatchMode =
+  | 'numeral-to-group'
+  | 'group-to-numeral'
+  | 'cardinal-number-to-text'
+  | 'cardinal-text-to-number'
+  | 'ordinal-number-to-text'
+  | 'ordinal-text-to-number'
+  | 'cardinal-to-ordinal'
+  | 'ordinal-to-cardinal';
+```
+
+## 3. Countable Dots on DotGroupQuestion
+
+### Problem
+
+Young kids need to count dots but have no way to track which dots they have
+already counted.
+
+### Solution
+
+Each dot in `DotGroupQuestion` becomes individually tappable:
+
+- Tap an unnumbered dot → assigns the next increment (1, 2, 3...)
+- The number appears centered on the dot
+- Each tap triggers TTS speaking the cardinal word ("one", "two", "three"...)
+- Already-tapped dots do nothing on re-tap (no toggle)
+- Counts auto-reset when `count` changes (next round)
+- Order does not matter — kids can tap dots in any sequence
+- TTS for the whole question area stays on the existing `AudioButton`
+
+**State:** Local `useState` inside `DotGroupQuestion` — array of
+`(number | null)` per dot, tracking assigned count values. A `nextCount` ref
+tracks the next number to assign.
+
+**Rendering:** Each dot changes from a plain `<span>` to a `<button>`. When
+tapped, the dot shows a white number centered on the primary-colored circle.
+
+## 4. Hover Preview Fix
+
+### Problem
+
+When dragging a tile over a slot or bank hole, the preview shows plain text
+label (e.g. "7") instead of the domino face.
+
+### Solution
+
+The hover preview renders the same visual as the tile:
+
+- Domino face when `tilesShowGroup && tileStyle === 'dots'`
+- Plain text otherwise
+
+Affected locations:
+
+1. **Slot preview** — the `Slot` render callback uses `previewLabel` to render
+   a domino or text
+2. **Bank hole preview** — the empty hole in `NumeralTileBank` renders domino or
+   text during hover
+
+Both reuse the existing `DominoTile` / `DiceFace` components.
+
+## Files Affected
+
+- `src/games/number-match/types.ts` — mode type expansion, config field options
+- `src/games/number-match/NumberMatch/NumberMatch.tsx` — rendering logic,
+  slot sizing, mode gating
+- `src/games/number-match/NumeralTileBank/NumeralTileBank.tsx` — domino
+  overhaul, tile rendering, hover preview, `tilesShowGroup` prop
+- `src/games/number-match/build-numeral-round.ts` — label generation for
+  word/ordinal modes
+- `src/components/questions/DotGroupQuestion/DotGroupQuestion.tsx` — countable
+  dots, per-dot tap, TTS
+- `src/games/number-match/NumberMatch/NumberMatch.stories.tsx` — new stories
+  for all modes
+- `src/games/number-match/NumeralTileBank/NumeralTileBank.stories.tsx` — updated
+  stories
+- `package.json` — add `n2words` dependency
+
+## Out of Scope
+
+- `objects` and `fingers` tile styles — kept as stubs
+- Numeric ordinal format ("7th") — pending `n2words` upstream contribution
+- Drag preview ghost image (the floating tile during drag) — separate concern

--- a/docs/superpowers/specs/2026-04-10-match-number-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-10-match-number-improvements-design.md
@@ -87,21 +87,33 @@ This boolean gates rendering in three places:
 | `group-to-numeral`        | Dots      | 7         | —            |
 | `cardinal-number-to-text` | 7         | "seven"   | `toCardinal` |
 | `cardinal-text-to-number` | "seven"   | 7         | `toCardinal` |
-| `ordinal-number-to-text`  | 7         | "seventh" | `toOrdinal`  |
-| `ordinal-text-to-number`  | "seventh" | 7         | `toOrdinal`  |
+| `ordinal-number-to-text`  | "7th"     | "seventh" | `toOrdinal`  |
+| `ordinal-text-to-number`  | "seventh" | "7th"     | `toOrdinal`  |
 | `cardinal-to-ordinal`     | "seven"   | "seventh" | both         |
 | `ordinal-to-cardinal`     | "seventh" | "seven"   | both         |
 
-**Dependency:** `n2words` — tree-shakeable per-locale imports, i18n, zero deps.
-Provides `toCardinal` and `toOrdinal` per locale.
+**Dependency:** `n2words` (only) — tree-shakeable per-locale imports, i18n, zero
+deps. Provides `toCardinal` and `toOrdinal` per locale. No additional ordinal
+suffix packages needed — the numeric ordinal format ("7th" / "7º") is trivial
+inline logic.
+
+**Utility module:** `src/games/number-match/number-words.ts`
+
+- `toCardinalText(n, locale)` → `"seven"` / `"sete"` — wraps
+  `n2words/<locale>.toCardinal`
+- `toOrdinalText(n, locale)` → `"seventh"` / `"sétimo"` — wraps
+  `n2words/<locale>.toOrdinal`
+- `toOrdinalNumber(n, locale)` → `"7th"` / `"7º"` — inline suffix logic
+  (English: 1st/2nd/3rd/Nth; Portuguese: always `º`)
+- Locale map: `'en'` → `n2words/en-AU`, `'pt-BR'` → `n2words/pt-PT`
 
 **Data flow:** Rounds are always generated with numeric values. At render time,
-`n2words` converts to display strings based on the mode. Matching logic always
+the utility converts to display strings based on the mode. Matching logic always
 compares the underlying numeric `value`, never text strings.
 
 **Locale:** Sourced from the existing `useParams({ from: '/$locale' })` router
-param. Map the app locale to `n2words` locale import (e.g. `en` → `en-AU`,
-`pt` → `pt-PT`).
+param (`'en'` | `'pt-BR'`). The utility maps app locales to `n2words` locale
+imports.
 
 **Word tile UI:**
 
@@ -180,6 +192,9 @@ Both reuse the existing `DominoTile` / `DiceFace` components.
   slot sizing, mode gating
 - `src/games/number-match/NumeralTileBank/NumeralTileBank.tsx` — domino
   overhaul, tile rendering, hover preview, `tilesShowGroup` prop
+- `src/games/number-match/number-words.ts` — number↔text conversion utility
+  wrapping `n2words`
+- `src/games/number-match/number-words.test.ts` — unit tests for the utility
 - `src/games/number-match/build-numeral-round.ts` — label generation for
   word/ordinal modes
 - `src/components/questions/DotGroupQuestion/DotGroupQuestion.tsx` — countable

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-unicorn": "^64.0.0",
     "i18next": "^26.0.3",
     "lucide-react": "^0.545.0",
+    "n2words": "^4.0.0",
     "nanoid": "^5.1.7",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",

--- a/src/games/number-match/number-words.test.ts
+++ b/src/games/number-match/number-words.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+  toCardinalText,
+  toOrdinalNumber,
+  toOrdinalText,
+} from './number-words';
+
+describe('toCardinalText', () => {
+  describe('English (en)', () => {
+    it.each([
+      [1, 'one'],
+      [2, 'two'],
+      [3, 'three'],
+      [4, 'four'],
+      [5, 'five'],
+      [6, 'six'],
+      [7, 'seven'],
+      [8, 'eight'],
+      [9, 'nine'],
+      [10, 'ten'],
+      [11, 'eleven'],
+      [12, 'twelve'],
+    ] as const)('toCardinalText(%i, "en") → "%s"', (n, expected) => {
+      expect(toCardinalText(n, 'en')).toBe(expected);
+    });
+  });
+
+  describe('Portuguese (pt-BR)', () => {
+    it.each([
+      [1, 'um'],
+      [2, 'dois'],
+      [3, 'três'],
+      [5, 'cinco'],
+      [7, 'sete'],
+      [10, 'dez'],
+      [12, 'doze'],
+    ] as const)('toCardinalText(%i, "pt-BR") → "%s"', (n, expected) => {
+      expect(toCardinalText(n, 'pt-BR')).toBe(expected);
+    });
+  });
+});
+
+describe('toOrdinalText', () => {
+  describe('English (en)', () => {
+    it.each([
+      [1, 'first'],
+      [2, 'second'],
+      [3, 'third'],
+      [4, 'fourth'],
+      [5, 'fifth'],
+      [7, 'seventh'],
+      [10, 'tenth'],
+      [11, 'eleventh'],
+      [12, 'twelfth'],
+    ] as const)('toOrdinalText(%i, "en") → "%s"', (n, expected) => {
+      expect(toOrdinalText(n, 'en')).toBe(expected);
+    });
+  });
+
+  describe('Portuguese (pt-BR)', () => {
+    it.each([
+      [1, 'primeiro'],
+      [2, 'segundo'],
+      [3, 'terceiro'],
+      [5, 'quinto'],
+      [7, 'sétimo'],
+      [10, 'décimo'],
+      [12, 'décimo segundo'],
+    ] as const)('toOrdinalText(%i, "pt-BR") → "%s"', (n, expected) => {
+      expect(toOrdinalText(n, 'pt-BR')).toBe(expected);
+    });
+  });
+});
+
+describe('toOrdinalNumber', () => {
+  describe('English (en)', () => {
+    it.each([
+      [1, '1st'],
+      [2, '2nd'],
+      [3, '3rd'],
+      [4, '4th'],
+      [5, '5th'],
+      [7, '7th'],
+      [10, '10th'],
+      [11, '11th'],
+      [12, '12th'],
+      [13, '13th'],
+      [21, '21st'],
+      [22, '22nd'],
+      [23, '23rd'],
+      [100, '100th'],
+      [101, '101st'],
+      [111, '111th'],
+      [112, '112th'],
+      [113, '113th'],
+    ] as const)('toOrdinalNumber(%i, "en") → "%s"', (n, expected) => {
+      expect(toOrdinalNumber(n, 'en')).toBe(expected);
+    });
+  });
+
+  describe('Portuguese (pt-BR)', () => {
+    it.each([
+      [1, '1º'],
+      [2, '2º'],
+      [3, '3º'],
+      [7, '7º'],
+      [10, '10º'],
+      [12, '12º'],
+      [100, '100º'],
+    ] as const)(
+      'toOrdinalNumber(%i, "pt-BR") → "%s"',
+      (n, expected) => {
+        expect(toOrdinalNumber(n, 'pt-BR')).toBe(expected);
+      },
+    );
+  });
+});

--- a/src/games/number-match/number-words.ts
+++ b/src/games/number-match/number-words.ts
@@ -1,0 +1,88 @@
+import {
+  toCardinal as enCardinal,
+  toOrdinal as enOrdinal,
+} from 'n2words/en-AU';
+import {
+  toCardinal as ptCardinal,
+  toOrdinal as ptOrdinal,
+} from 'n2words/pt-PT';
+
+/**
+ * Supported app locales for number-word conversion.
+ * Maps to the n2words locale modules (en → en-AU, pt-BR → pt-PT).
+ */
+type NumberWordsLocale = 'en' | 'pt-BR';
+
+const cardinalByLocale: Record<
+  NumberWordsLocale,
+  (n: number) => string
+> = {
+  en: (n) => enCardinal(n),
+  'pt-BR': (n) => ptCardinal(n),
+};
+
+const ordinalByLocale: Record<
+  NumberWordsLocale,
+  (n: number) => string
+> = {
+  en: (n) => enOrdinal(n),
+  'pt-BR': (n) => ptOrdinal(n),
+};
+
+/**
+ * Convert a number to its cardinal word representation.
+ *
+ * @example toCardinalText(7, 'en')     // "seven"
+ * @example toCardinalText(7, 'pt-BR')  // "sete"
+ */
+export const toCardinalText = (
+  n: number,
+  locale: NumberWordsLocale,
+): string => cardinalByLocale[locale](n);
+
+/**
+ * Convert a number to its ordinal word representation.
+ *
+ * @example toOrdinalText(7, 'en')     // "seventh"
+ * @example toOrdinalText(7, 'pt-BR')  // "sétimo"
+ */
+export const toOrdinalText = (
+  n: number,
+  locale: NumberWordsLocale,
+): string => ordinalByLocale[locale](n);
+
+/**
+ * Convert a number to its numeric ordinal form (e.g. "7th", "7º").
+ *
+ * English: 1st, 2nd, 3rd, 4th … 11th, 12th, 13th … 21st, 22nd, 23rd …
+ * Portuguese: always appends "º" (e.g. "1º", "7º").
+ *
+ * @example toOrdinalNumber(7, 'en')     // "7th"
+ * @example toOrdinalNumber(1, 'en')     // "1st"
+ * @example toOrdinalNumber(7, 'pt-BR')  // "7º"
+ */
+export const toOrdinalNumber = (
+  n: number,
+  locale: NumberWordsLocale,
+): string => {
+  if (locale === 'pt-BR') return `${n}º`;
+
+  // English ordinal suffix
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
+
+  switch (n % 10) {
+    case 1: {
+      return `${n}st`;
+    }
+    case 2: {
+      return `${n}nd`;
+    }
+    case 3: {
+      return `${n}rd`;
+    }
+    default: {
+      return `${n}th`;
+    }
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10007,6 +10007,11 @@ mute-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-2.0.0.tgz#a5446fc0c512b71c83c44d908d5c7b7b4c493b2b"
   integrity sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==
 
+n2words@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/n2words/-/n2words-4.0.0.tgz#eb5b836fb7d948c85ff32e9a8ed922b1fa6fe545"
+  integrity sha512-y0TJuqz5IaDYAjhmiqKGM4C20/fNeOuPGIE+AM5v5mMO9G/lYJ9tee45NYR7lwF9bquwP6WW6YVxh3XTwq4xPg==
+
 nanoid@^3.3.11:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"


### PR DESCRIPTION
## Summary
- Adds `number-words.ts` utility with three exported functions: `toCardinalText`, `toOrdinalText`, and `toOrdinalNumber`
- Wraps `n2words` package (en-AU for English, pt-PT for Portuguese) with app locale mapping (`'en'` / `'pt-BR'`)
- Includes 60 unit tests covering both locales, edge cases (11th/12th/13th, 21st/22nd/23rd), and Portuguese ordinal suffix

## Plan
Implements `docs/superpowers/plans/2026-04-10-number-words-utility.md`

## Verification
- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [x] `yarn test` passes (80 files, 545 tests)
- SKIP_STORYBOOK=1 SKIP_VR=1 SKIP_E2E=1 — no UI changes in this utility-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)