### PR TITLE
feat(scripts): prune merged worktrees with optional automation

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# After a merge, if this checkout is on master, fetch origin and remove linked
+# worktrees whose HEAD is already in origin/master. Failures do not block the merge.
+#
+# Disable: SKIP_AUTO_PRUNE_WORKTREES=1
+
+set -euo pipefail
+
+if [[ "${SKIP_AUTO_PRUNE_WORKTREES:-}" == "1" ]]; then
+  exit 0
+fi
+
+if [[ "$(git symbolic-ref -q HEAD 2>/dev/null || true)" != "refs/heads/master" ]]; then
+  exit 0
+fi
+
+REPO=$(git rev-parse --show-toplevel)
+"$REPO/scripts/prune-merged-worktrees-auto.sh" || true

--- a/scripts/prune-merged-worktrees-auto.sh
+++ b/scripts/prune-merged-worktrees-auto.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Fetch the default remote branch, then remove linked worktrees whose HEAD is already
+# contained in that remote-tracking ref (same as prune-merged-worktrees.sh -w).
+#
+# Environment (optional):
+#   PRUNE_WORKTREES_REMOTE   default: origin
+#   PRUNE_WORKTREES_BRANCH   default: master
+#
+# On fetch failure, prints a warning and exits 0 (safe for git hooks).
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REMOTE="${PRUNE_WORKTREES_REMOTE:-origin}"
+BRANCH="${PRUNE_WORKTREES_BRANCH:-master}"
+
+if ! here=$(git rev-parse --show-toplevel 2>/dev/null); then
+  echo "error: not inside a git repository" >&2
+  exit 1
+fi
+here=$(cd "$here" && pwd -P)
+
+gd=$(git -C "$here" rev-parse --git-common-dir)
+if [[ "$gd" != /* ]]; then
+  gd=$(cd "$here/$gd" && pwd -P)
+else
+  gd=$(cd "$gd" && pwd -P)
+fi
+main_root=$(dirname "$gd")
+
+if ! git -C "$main_root" fetch "$REMOTE" "$BRANCH"; then
+  echo "prune-merged-worktrees-auto: fetch ${REMOTE} ${BRANCH} failed; skipping prune" >&2
+  exit 0
+fi
+
+exec "$SCRIPT_DIR/prune-merged-worktrees.sh" -w -t "${REMOTE}/${BRANCH}"

--- a/scripts/prune-merged-worktrees.sh
+++ b/scripts/prune-merged-worktrees.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# List linked worktrees whose HEAD is already contained in master, then optionally remove them.
+# Default: dry-run only. Use -w to run `git worktree remove`.
+#
+# "Merged" means: git merge-base --is-ancestor <worktree-HEAD> master
+# (your local master; run `git fetch origin master` first if you care about remote state).
+#
+# Usage:
+#   ./scripts/prune-merged-worktrees.sh              # dry run vs master
+#   ./scripts/prune-merged-worktrees.sh -w           # remove vs master
+#   ./scripts/prune-merged-worktrees.sh -t origin/master  # compare to ref
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: prune-merged-worktrees.sh [-w] [-t <ref>] [-h]
+
+  Dry run by default: prints linked worktrees whose HEAD is an ancestor of <ref>.
+
+  -t    Merge target ref (default: master). Example: origin/master after fetch.
+  -w    Remove those worktrees (git worktree remove <path>).
+  -h    Show this help.
+
+Must be run from inside the repository (any worktree). Does not remove the primary
+checkout or delete local branches.
+EOF
+}
+
+WRITE=false
+MERGE_TARGET=master
+while getopts "wht:" opt; do
+  case "$opt" in
+    w) WRITE=true ;;
+    t) MERGE_TARGET=$OPTARG ;;
+    h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1)) || true
+if [[ $# -gt 0 ]]; then
+  usage
+  exit 1
+fi
+
+if ! here=$(git rev-parse --show-toplevel 2>/dev/null); then
+  echo "error: not inside a git repository" >&2
+  exit 1
+fi
+here=$(cd "$here" && pwd -P)
+
+gd=$(git -C "$here" rev-parse --git-common-dir)
+if [[ "$gd" != /* ]]; then
+  gd=$(cd "$here/$gd" && pwd -P)
+else
+  gd=$(cd "$gd" && pwd -P)
+fi
+main_root=$(dirname "$gd")
+
+merge_target=$MERGE_TARGET
+if ! git -C "$here" rev-parse --verify "$merge_target" >/dev/null 2>&1; then
+  echo "error: no local ref '$merge_target' (create it, fetch, or pass -t)" >&2
+  exit 1
+fi
+
+declare -a merged_paths
+declare -a merged_heads
+declare -a merged_branches
+
+declare -a sorted_remove_paths
+
+wt_path=""
+wt_head=""
+wt_branch=""
+end_record() {
+  if [[ -z "$wt_path" || -z "$wt_head" ]]; then
+    wt_path=""
+    wt_head=""
+    wt_branch=""
+    return
+  fi
+  local norm
+  norm=$(cd "$wt_path" && pwd -P)
+  if [[ "$norm" == "$main_root" ]]; then
+    wt_path=""
+    wt_head=""
+    wt_branch=""
+    return
+  fi
+  if git -C "$here" merge-base --is-ancestor "$wt_head" "$merge_target" 2>/dev/null; then
+    merged_paths+=("$wt_path")
+    merged_heads+=("$wt_head")
+    merged_branches+=("${wt_branch:-}")
+  fi
+  wt_path=""
+  wt_head=""
+  wt_branch=""
+}
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ -z "$line" ]]; then
+    end_record
+    continue
+  fi
+  case "$line" in
+    worktree\ *)
+      wt_path="${line#worktree }"
+      wt_head=""
+      wt_branch=""
+      ;;
+    HEAD\ *) wt_head="${line#HEAD }" ;;
+    branch\ *) wt_branch="${line#branch }" ;;
+  esac
+done < <(git -C "$here" worktree list --porcelain)
+end_record
+
+if [[ ${#merged_paths[@]} -eq 0 ]]; then
+  echo "No linked worktrees have HEAD contained in '$merge_target'."
+  exit 0
+fi
+
+mode="dry-run"
+if [[ "$WRITE" == true ]]; then
+  mode="remove"
+fi
+
+print_merged_table_and_sort_paths() {
+  declare -a lines=()
+  local i path head branch modified date_fmt branch_display
+
+  for i in "${!merged_paths[@]}"; do
+    path="${merged_paths[$i]}"
+    head="${merged_heads[$i]}"
+    branch="${merged_branches[$i]}"
+    modified=$(stat -f "%m" "$path" 2>/dev/null || stat -c "%Y" "$path" 2>/dev/null || echo 0)
+    date_fmt=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$path" 2>/dev/null \
+      || date -d "@$modified" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "?")
+    if [[ -n "$branch" ]]; then
+      branch_display="${branch#refs/heads/}"
+    else
+      branch_display="detached@${head:0:7}"
+    fi
+    lines+=("${modified}"$'\t'"${date_fmt}"$'\t'"${branch_display}"$'\t'"${path}")
+  done
+
+  local sorted
+  sorted=$(printf '%s\n' "${lines[@]}" | LC_ALL=C sort -t $'\t' -k1,1nr)
+
+  echo "($mode) Linked worktrees whose HEAD is an ancestor of $merge_target (newest mtime first):"
+  echo "$sorted" | awk -F'\t' '
+    BEGIN {
+      printf "%-14s  %-30s  %s\n", "MODIFIED", "BRANCH", "PATH"
+      printf "%-14s  %-30s  %s\n", "──────────────", "──────────────────────────────", "────────────────────────────────"
+    }
+    NF >= 4 { printf "%-14s  %-30s  %s\n", $2, $3, $4 }
+  '
+
+  sorted_remove_paths=()
+  while IFS=$'\t' read -r _epoch _df _bd pth; do
+    [[ -z "$pth" ]] && continue
+    sorted_remove_paths+=("$pth")
+  done <<< "$sorted"
+}
+
+print_merged_table_and_sort_paths
+
+if [[ "$WRITE" != true ]]; then
+  echo
+  echo "Re-run with -w to remove these worktrees."
+  exit 0
+fi
+
+for p in "${sorted_remove_paths[@]}"; do
+  echo "Removing: $p"
+  git -C "$here" worktree remove "$p"
+done
+
+echo "Done. Optional: delete merged local branches with git branch -d <name>"


### PR DESCRIPTION
## Summary

Adds tooling to find linked git worktrees whose `HEAD` is already contained in a merge target (default `master`, or `-t origin/master` after fetch), list them in a table sorted by directory mtime (newest first) with branch and path, and optionally remove them.

## Changes

- **`scripts/prune-merged-worktrees.sh`** — Dry run by default; `-w` removes; `-t <ref>` selects the comparison ref; table columns MODIFIED / BRANCH / PATH (BSD and GNU `stat`).
- **`scripts/prune-merged-worktrees-auto.sh`** — `git fetch` `origin` `master` (override with `PRUNE_WORKTREES_REMOTE` / `PRUNE_WORKTREES_BRANCH`), then prune vs `${REMOTE}/${BRANCH}`. Exits 0 if fetch fails so hooks stay non-fatal.
- **`.husky/post-merge`** — After a merge while checked out on `master`, runs the auto script. Set `SKIP_AUTO_PRUNE_WORKTREES=1` to disable. Failures do not block the merge (`|| true`).

## Usage

```bash
./scripts/prune-merged-worktrees.sh              # dry run vs master
./scripts/prune-merged-worktrees.sh -t origin/master -w
./scripts/prune-merged-worktrees-auto.sh
```

Does not delete local branches; primary checkout is never removed.

Made with [Cursor](https://cursor.com)