### PR TITLE
fix(ci): VR workflow checkout ref broke PR runs

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -26,8 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.ref_name }}
+          # On workflow_dispatch we need the branch (not a PR merge ref) so the
+          # "Commit updated snapshots" step can push back. On pull_request we
+          # let checkout use its default merge-ref behaviour.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || '' }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

- PR #37's workflow permissions fix unconditionally set `ref: github.ref_name` on checkout, which resolves to `<pr>/merge` (a virtual merge ref) on `pull_request` events.
- All VR checks on open PRs were failing at the checkout step with `git fetch refs/heads/<pr>/merge` retries before erroring out.
- Gates the ref override to `workflow_dispatch` only, restoring default merge-ref behaviour for PR runs while keeping baseline push-back working for dispatch.

## Test plan

- [x] CI runs on this PR — VR checkout step should succeed (not fetch a non-existent branch)
- [ ] VR test comparison completes on this PR (no diff expected — workflow-only change)