### PR TITLE
docs(plan): PR previews and auto version bump

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,13 @@ jobs:
             echo "bumped=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          case "$BUMP" in
+            major|minor|patch) ;;
+            *)
+              echo "Unexpected bump value: $BUMP" >&2
+              exit 1
+              ;;
+          esac
           yarn version --"$BUMP" --no-git-tag-version
           NEW_VERSION=$(node -p "require('./package.json').version")
           echo "New version: $NEW_VERSION"
@@ -83,11 +90,15 @@ jobs:
 
       - name: Stamp version.json
         run: |
-          echo '{
+          ACTUAL_SHA=$(git rev-parse HEAD)
+          BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          cat > dist/client/version.json <<EOF
+          {
             "version": "${{ steps.version.outputs.version }}",
-            "buildSha": "${{ github.sha }}",
-            "buildDate": "${{ github.event.head_commit.timestamp }}"
-          }' > dist/client/version.json
+            "buildSha": "${ACTUAL_SHA}",
+            "buildDate": "${BUILD_DATE}"
+          }
+          EOF
 
       - name: Deploy to gh-pages branch
         uses: JamesIves/github-pages-deploy-action@v4
@@ -110,4 +121,5 @@ jobs:
           git add package.json
           git commit -m "chore(release): v${NEW_VERSION}"
           git tag "v${NEW_VERSION}"
+          git pull --rebase origin master
           git push origin master --follow-tags

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,12 +90,13 @@ jobs:
 
       - name: Stamp version.json
         run: |
-          ACTUAL_SHA=$(git rev-parse HEAD)
+          set -euo pipefail
+          BUILD_SHA=$(git rev-parse HEAD)
           BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           cat > dist/client/version.json <<EOF
           {
             "version": "${{ steps.version.outputs.version }}",
-            "buildSha": "${ACTUAL_SHA}",
+            "buildSha": "${BUILD_SHA}",
             "buildDate": "${BUILD_DATE}"
           }
           EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches: [master]
   workflow_dispatch:
 
@@ -11,19 +12,22 @@ concurrency:
   cancel-in-progress: false # never cancel an in-flight deploy
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
+  pull-requests: read
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     outputs:
       version: ${{ steps.version.outputs.version }}
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0
 
       - uses: actions/setup-node@v6
         with:
@@ -32,6 +36,26 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+
+      - name: Determine and apply version bump
+        id: bump
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BUMP=$(bash scripts/determine-bump.sh "$PR_NUMBER")
+          echo "Detected bump type: $BUMP"
+          if [[ "$BUMP" == "skip" ]]; then
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          yarn version --"$BUMP" --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "New version: $NEW_VERSION"
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Read package version
         id: version
@@ -65,23 +89,25 @@ jobs:
             "buildDate": "${{ github.event.head_commit.timestamp }}"
           }' > dist/client/version.json
 
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v6
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+      - name: Deploy to gh-pages branch
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: dist/client/
+          branch: gh-pages
+          folder: dist/client
+          clean: true
+          clean-exclude: |
+            pr/**
+          commit-message: 'deploy: production ${{ steps.version.outputs.version }}'
 
-  deploy:
-    name: Deploy
-    runs-on: ubuntu-latest
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Commit and tag version bump
+        if: steps.bump.outputs.bumped == 'true' && github.actor != 'github-actions[bot]'
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore(release): v${NEW_VERSION}"
+          git tag "v${NEW_VERSION}"
+          git push origin master --follow-tags

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,3 +1,5 @@
+# Builds and deploys a live preview for each PR to GitHub Pages.
+# Only works for PRs from the base repo; fork PRs lack write permissions and secrets.
 name: PR Preview
 
 on:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,109 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [master]
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    name: Build and deploy preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Compute version and base paths
+        id: version
+        run: |
+          set -euo pipefail
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          VERSION="${BASE_VERSION}-pr.${PR_NUMBER}"
+          APP_BASE="/base-skill/pr/${PR_NUMBER}/app/"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "app_base=${APP_BASE}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Build app
+        env:
+          APP_BASE_URL: ${{ steps.version.outputs.app_base }}
+          VITE_APP_VERSION: ${{ steps.version.outputs.version }}
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+          VITE_ONEDRIVE_CLIENT_ID: ${{ secrets.VITE_ONEDRIVE_CLIENT_ID }}
+          VITE_CF_WORKER_URL: ${{ secrets.VITE_CF_WORKER_URL }}
+          VITE_ANALYTICS_PROVIDER: ${{ vars.VITE_ANALYTICS_PROVIDER }}
+        run: yarn build
+
+      - name: Copy shell to index.html
+        run: cp dist/client/_shell.html dist/client/index.html
+
+      - name: SPA fallback for history routing
+        run: cp dist/client/index.html dist/client/404.html
+
+      - name: Stamp version.json
+        run: |
+          set -euo pipefail
+          BUILD_SHA=$(git rev-parse HEAD)
+          BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          cat > dist/client/version.json <<EOF
+          {
+            "version": "${{ steps.version.outputs.version }}",
+            "buildSha": "${BUILD_SHA}",
+            "buildDate": "${BUILD_DATE}"
+          }
+          EOF
+
+      - name: Build Storybook
+        run: yarn build-storybook --output-dir storybook-static
+
+      - name: Stage preview directory
+        run: |
+          set -euo pipefail
+          rm -rf preview-staging
+          mkdir -p preview-staging/app preview-staging/storybook
+          cp -r dist/client/. preview-staging/app/
+          cp -r storybook-static/. preview-staging/storybook/
+
+      - name: Deploy preview to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: preview-staging
+          target-folder: pr/${{ steps.version.outputs.pr_number }}
+          clean: true
+          commit-message: 'deploy: PR #${{ steps.version.outputs.pr_number }} preview (${{ steps.version.outputs.version }})'
+
+      - name: Comment PR with preview URLs
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: |
+            ## Preview deployed
+
+            | Target    | URL                                                                                          |
+            | --------- | -------------------------------------------------------------------------------------------- |
+            | App       | https://leocaseiro.github.io/base-skill/pr/${{ steps.version.outputs.pr_number }}/app/       |
+            | Storybook | https://leocaseiro.github.io/base-skill/pr/${{ steps.version.outputs.pr_number }}/storybook/ |
+
+            **Version:** `${{ steps.version.outputs.version }}`
+            **Commit:** `${{ github.event.pull_request.head.sha }}`
+
+            Previews are kept forever — no cleanup on close.

--- a/docs/superpowers/plans/2026-04-10-pr-previews-and-auto-bump-plan.md
+++ b/docs/superpowers/plans/2026-04-10-pr-previews-and-auto-bump-plan.md
@@ -1,0 +1,400 @@
+# PR Previews and Auto-Version-Bump Plan
+
+## Context
+
+BaseSkill currently deploys production builds to GitHub Pages on every push to
+`master` via `.github/workflows/deploy.yml`, using the modern Pages API
+(`actions/deploy-pages`). Only one version of the site is live at any time — the
+latest build on `master`.
+
+This plan adds two things:
+
+1. **PR preview deploys** — every open PR publishes a live preview of the app and
+   Storybook under `https://leocaseiro.github.io/base-skill/pr/<number>/app/` and
+   `.../pr/<number>/storybook/`. Previews persist forever (no cleanup on close)
+   so history is preserved.
+
+2. **Automatic version bumping** — when a PR merges to `master`, the workflow
+   inspects the PR's commit messages, picks a semver bump, updates
+   `package.json`, tags the commit, and deploys.
+
+Because GitHub Pages only serves from one source, and per-PR subdirectories
+require pushing to a long-lived `gh-pages` branch, the existing `deploy.yml`
+must migrate off the Pages API and onto a branch-push model using
+`JamesIves/github-pages-deploy-action`. Both production and previews will live
+on the same `gh-pages` branch.
+
+### Manual Setup Required (one-time)
+
+Before the new workflows will publish anything, the user must change the
+GitHub Pages source in repo settings:
+
+- Go to **Settings → Pages → Source**
+- Change from **GitHub Actions** to **Deploy from a branch**
+- Select branch **`gh-pages`** and folder **`/ (root)`**
+
+This is a one-time manual step and will be documented in the PR description.
+
+## Scope
+
+### In scope
+
+- `scripts/determine-bump.sh` — analyses PR commit messages, outputs bump type
+- `.github/workflows/pr-preview.yml` — per-PR previews (new)
+- `.github/workflows/deploy.yml` — migrated to `gh-pages` branch, adds bump + tag (modified)
+- `vite.config.ts` — prefer `VITE_APP_VERSION` env var over `package.json` version at build time
+- PR comment with preview URLs (bot-managed, single comment per PR, updated on subsequent pushes)
+
+### Out of scope
+
+- Cleanup workflow for closed PRs (user explicitly wants history retained)
+- Service worker gating on PR builds (user accepted the first-load edge case)
+- IndexedDB namespacing (user declined despite the schema-conflict risk)
+- Override mechanism for bump type (auto-detection from commits is the source of truth)
+- Conventional commit enforcement (existing style is close enough; default is patch)
+- PR creation helper / skill (may be added later)
+
+### Explicit non-goals
+
+- PR previews are not expected to share service workers, local storage, or
+  IndexedDB with the production build; cross-contamination is a known tradeoff
+  the user has accepted.
+- The workflow must not introduce any manual steps at PR time — labels,
+  commit-message discipline, and post-merge actions are all automatic.
+
+## Bump Rules
+
+`scripts/determine-bump.sh` reads the PR number from argv and uses
+`gh pr view` to fetch all commit messages (headline + body). It then applies
+these rules in order:
+
+| Priority | Pattern                                                             | Bump  |
+| -------- | ------------------------------------------------------------------- | ----- |
+| 1        | Commit contains `BREAKING CHANGE` (body) OR `<type>!:` (header)     | major |
+| 2        | Any commit header matches `^feat(\(.+\))?:`                         | minor |
+| 3        | Any commit header matches `^(fix\|perf\|refactor\|style)(\(.+\))?:` | patch |
+| 4        | Only `^(docs\|ci\|chore\|test\|build)(\(.+\))?:` commits            | skip  |
+| 5        | Anything else (unclassifiable commits)                              | patch |
+
+Output: prints exactly one of `major`, `minor`, `patch`, or `skip` to stdout.
+Exit code `0` on success, non-zero on failure (e.g., `gh` not authenticated).
+
+The script takes one required positional argument: the PR number. In the
+workflow it will be called as `scripts/determine-bump.sh "$PR_NUMBER"`. A local
+mode is also needed for testability: if `PR_COMMITS_FILE` env var is set,
+the script reads commit messages from that file instead of calling `gh`.
+This allows the bundled shell test suite to exercise every rule.
+
+## Version Strings
+
+- **Production builds** (master): `0.1.0`, `0.2.0`, `1.0.0`, etc. — unchanged,
+  read from `package.json`.
+- **PR preview builds**: `${BASE_VERSION}-pr.${PR_NUMBER}` where `BASE_VERSION`
+  is the current `package.json` version on the PR branch. Example: `0.1.0-pr.42`.
+
+The PR version is stable across commits on the same PR: multiple pushes to the
+same PR always produce the same `-pr.N` suffix (e.g., `0.1.0-pr.42`). The
+changing commit SHA is captured in `version.json#buildSha` instead. This means
+the `pr/42/` directory is overwritten in place on every push.
+
+## Deploy Layout on `gh-pages`
+
+```text
+gh-pages/
+├── index.html              ← production app (master)
+├── assets/                 ← production assets
+├── docs/                   ← production storybook
+├── version.json            ← production version metadata
+├── 404.html                ← SPA history-routing fallback
+└── pr/
+    ├── 42/
+    │   ├── app/
+    │   │   ├── index.html
+    │   │   ├── assets/
+    │   │   └── version.json   (version "0.1.0-pr.42")
+    │   └── storybook/
+    │       └── index.html
+    └── 57/
+        └── ...
+```
+
+## Tasks
+
+### Task 1: `determine-bump.sh` with shell tests
+
+**Files:**
+
+- `scripts/determine-bump.sh` (new, executable)
+- `scripts/determine-bump.test.sh` (new, executable)
+
+**Requirements:**
+
+- Bash script, uses `set -euo pipefail`
+- Takes PR number as `$1`
+- If env var `PR_COMMITS_FILE` is set, reads newline-separated commit messages
+  from that file (one commit per line, headline only acceptable; multi-line
+  bodies separated by a literal `---` sentinel line)
+- Otherwise, calls
+  `gh pr view "$PR_NUMBER" --json commits --jq '.commits[] | (.messageHeadline + "\n" + .messageBody)'`
+- Applies the rules from the table above
+- Prints one of `major|minor|patch|skip` and exits 0
+- On `gh` failure or missing argument, prints an error to stderr and exits 1
+
+**Test script must cover:**
+
+- `feat:` in one commit → `minor`
+- `fix:` only → `patch`
+- `style:` only → `patch` (user specifically said style is not skip)
+- `docs:` only → `skip`
+- `chore:` + `ci:` + `test:` → `skip`
+- `docs:` + `fix:` → `patch` (fix beats docs)
+- `fix:` + `feat:` → `minor` (feat beats fix)
+- `feat!:` → `major`
+- `fix:` with `BREAKING CHANGE:` in body → `major`
+- Commit with no conventional prefix → `patch` (safe default)
+- Scoped prefixes (`fix(auth):`, `feat(ui):`) recognized
+- Mixed case (`FEAT:`, `Fix:`) NOT matched — enforce lowercase
+- Empty commit list → `patch` (defensive default)
+
+The test script should use a temp directory per case, write a `PR_COMMITS_FILE`,
+invoke `determine-bump.sh` with any PR number (since the file bypasses `gh`),
+and assert the output matches expected. Exit 0 on all-pass, non-zero otherwise.
+
+**Wiring:**
+
+- Add a `test:scripts` package.json script that runs `bash scripts/determine-bump.test.sh`
+- Do NOT add it to the pre-push hook (keep the hook lean); it's fine as a
+  manual check or a future CI job
+
+### Task 2: `vite.config.ts` version env support
+
+**File:** `vite.config.ts`
+
+**Change:** Line 99-101 currently reads:
+
+```ts
+define: {
+  'import.meta.env.VITE_APP_VERSION': JSON.stringify(version),
+},
+```
+
+Change to:
+
+```ts
+define: {
+  'import.meta.env.VITE_APP_VERSION': JSON.stringify(
+    process.env['VITE_APP_VERSION'] ?? version,
+  ),
+},
+```
+
+That's the only source change needed. `APP_BASE_URL` is already wired at
+`vite.config.ts:15`.
+
+**Verification:**
+
+- `yarn build` with no env var should stamp the `package.json` version (unchanged behavior)
+- `VITE_APP_VERSION=0.1.0-pr.42 yarn build` should stamp `0.1.0-pr.42`
+- `yarn typecheck` passes
+- `yarn lint` passes
+
+### Task 3: Migrate `deploy.yml` and add bump + tag logic
+
+**File:** `.github/workflows/deploy.yml`
+
+**Changes:**
+
+1. **Trigger:** Change from `push: branches: [master]` to
+
+   ```yaml
+   on:
+     pull_request:
+       types: [closed]
+       branches: [master]
+     workflow_dispatch:
+   ```
+
+2. **Job gating:** Add job-level `if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'` so closed-without-merge PRs don't deploy.
+
+3. **Permissions:** Replace the Pages permissions with:
+
+   ```yaml
+   permissions:
+     contents: write
+     pull-requests: read
+   ```
+
+4. **Checkout:** Use `ref: master` and `fetch-depth: 0` so we have full history and the master HEAD, not the PR merge commit.
+
+5. **Bump step:** After install, add a step that:
+   - Reads the PR number from `${{ github.event.pull_request.number }}` (or skips when dispatched manually)
+   - Runs `scripts/determine-bump.sh "$PR_NUMBER"` → captures `BUMP`
+   - If `BUMP == skip`, sets an output `bumped=false` and continues to build using the existing `package.json` version
+   - Otherwise: `yarn version --$BUMP --no-git-tag-version`, captures the new version from `package.json`, sets output `bumped=true` and `new_version`
+
+6. **Build steps:** unchanged, but the build will naturally pick up the new version because `vite.config.ts` reads from `package.json` by default. No need to inject `VITE_APP_VERSION` here.
+
+7. **Replace Pages API deploy with branch push:**
+   - Remove `actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages` steps
+   - Remove the separate `deploy` job
+   - Add `JamesIves/github-pages-deploy-action@v4` step that pushes `dist/client/` to the root of the `gh-pages` branch with `clean: true` but `clean-exclude: ['pr/**']` so PR previews are preserved
+
+8. **Commit and tag pushback:** If `bumped == true`, add a step that:
+   - Configures git user as `github-actions[bot]`
+   - `git add package.json`
+   - `git commit -m "chore(release): v${NEW_VERSION}"`
+   - `git tag "v${NEW_VERSION}"`
+   - `git push origin master --follow-tags`
+   - Uses `github.actor != 'github-actions[bot]'` as a belt-and-suspenders guard (though the `pull_request: closed` trigger makes a loop effectively impossible)
+
+**Important note on `clean-exclude`:** with a glob of `pr/**`, when we deploy
+production to the `gh-pages` branch root we wipe old production files but
+leave everything under `pr/` untouched. The JamesIves action supports this
+natively.
+
+**Verification:**
+
+- `yarn lint` passes on the YAML (yamllint is not configured; rely on GitHub Actions syntax)
+- Workflow file parses (no structural errors)
+- Full end-to-end verification requires an actual PR merge, which will happen when this feature itself merges
+
+### Task 4: `pr-preview.yml`
+
+**File:** `.github/workflows/pr-preview.yml` (new)
+
+**Structure:**
+
+```yaml
+name: PR Preview
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [master]
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Compute version
+        id: version
+        run: |
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          echo "version=${BASE_VERSION}-pr.${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "pr_base=/base-skill/pr/${PR_NUMBER}/app/" >> "$GITHUB_OUTPUT"
+
+      - name: Build app
+        env:
+          APP_BASE_URL: ${{ steps.version.outputs.pr_base }}
+          VITE_APP_VERSION: ${{ steps.version.outputs.version }}
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+          VITE_ONEDRIVE_CLIENT_ID: ${{ secrets.VITE_ONEDRIVE_CLIENT_ID }}
+          VITE_CF_WORKER_URL: ${{ secrets.VITE_CF_WORKER_URL }}
+          VITE_ANALYTICS_PROVIDER: ${{ vars.VITE_ANALYTICS_PROVIDER }}
+        run: yarn build
+
+      - name: Copy shell to index.html
+        run: cp dist/client/_shell.html dist/client/index.html
+
+      - name: SPA fallback
+        run: cp dist/client/index.html dist/client/404.html
+
+      - name: Stamp version.json
+        run: |
+          echo '{
+            "version": "${{ steps.version.outputs.version }}",
+            "buildSha": "${{ github.event.pull_request.head.sha }}",
+            "buildDate": "${{ github.event.pull_request.updated_at }}"
+          }' > dist/client/version.json
+
+      - name: Build storybook
+        run: yarn build-storybook --output-dir storybook-static
+
+      - name: Stage preview directory
+        run: |
+          rm -rf preview-staging
+          mkdir -p preview-staging/app preview-staging/storybook
+          cp -r dist/client/. preview-staging/app/
+          cp -r storybook-static/. preview-staging/storybook/
+
+      - name: Deploy preview
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: preview-staging
+          target-folder: pr/${{ github.event.pull_request.number }}
+          clean: true
+          commit-message: 'deploy: PR #${{ github.event.pull_request.number }} preview'
+
+      - name: Comment PR with preview URLs
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: |
+            ## 🚀 Preview deployed
+
+            | Target    | URL                                                                                                    |
+            | --------- | ------------------------------------------------------------------------------------------------------ |
+            | App       | https://leocaseiro.github.io/base-skill/pr/${{ github.event.pull_request.number }}/app/                |
+            | Storybook | https://leocaseiro.github.io/base-skill/pr/${{ github.event.pull_request.number }}/storybook/          |
+
+            **Version:** `${{ steps.version.outputs.version }}`
+            **Commit:** `${{ github.event.pull_request.head.sha }}`
+
+            Previews are kept forever — no cleanup on close.
+```
+
+**Storybook base path note:** Storybook's static build emits relative URLs by
+default, so it works in subdirectories without additional configuration. If it
+turns out not to, we will pass `--base-path /base-skill/pr/${PR_NUMBER}/storybook/`
+to `storybook build`. Implementer should verify the built `storybook-static/index.html`
+uses relative asset paths (e.g., `./assets/...` not `/assets/...`).
+
+**Verification:**
+
+- Workflow file parses
+- Does not actually run until the PR is open (meta: this plan's own PR will
+  be the first real test)
+
+## Sequencing and Dependencies
+
+Tasks must be done in this order because of dependencies:
+
+1. Task 1 (`determine-bump.sh`) — standalone, no deps
+2. Task 2 (`vite.config.ts`) — standalone, no deps
+3. Task 3 (`deploy.yml`) — depends on Task 1 and Task 2
+4. Task 4 (`pr-preview.yml`) — depends on Task 2
+
+Tasks 1 and 2 can technically be done in any order, but we will execute
+strictly sequentially per subagent-driven-development rules.
+
+## Definition of Done
+
+- [ ] All four tasks implemented, reviewed, and committed on the
+      `feat/pr-previews-auto-bump` branch
+- [ ] `scripts/determine-bump.test.sh` passes locally
+- [ ] `yarn lint`, `yarn typecheck`, `yarn test`, `yarn build` all pass
+- [ ] PR description explains the manual GitHub Pages setting change required
+- [ ] No changes to IndexedDB, service worker, or app source beyond
+      `vite.config.ts:100`
+- [ ] Plan document itself passes `yarn fix:md`

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:vr:report": "playwright show-report",
     "storybook": "storybook dev --port 6006",
     "build-storybook": "storybook build",
+    "test:scripts": "bash scripts/determine-bump.test.sh",
     "test:storybook": "test-storybook",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0 && knip --no-config-hints",

--- a/scripts/determine-bump.sh
+++ b/scripts/determine-bump.sh
@@ -15,12 +15,15 @@ PR_NUMBER="$1"
 # Read commits into an array. Each element is one full commit text (headline + body).
 commits=()
 
-if [[ -n "${PR_COMMITS_FILE:-}" ]]; then
-  # Test mode: read from file. Commits separated by lines containing exactly "---".
-  current=""
+# Populates the global `commits` array from a multi-commit string on stdin.
+# Commits are separated by lines containing exactly "---".
+parse_commits() {
+  local current=""
   while IFS= read -r line || [[ -n "$line" ]]; do
     if [[ "$line" == "---" ]]; then
-      commits+=("$current")
+      if [[ -n "$current" ]]; then
+        commits+=("$current")
+      fi
       current=""
     else
       if [[ -n "$current" ]]; then
@@ -29,11 +32,15 @@ if [[ -n "${PR_COMMITS_FILE:-}" ]]; then
         current="$line"
       fi
     fi
-  done <"$PR_COMMITS_FILE"
-  # Capture any trailing commit not followed by ---
+  done
   if [[ -n "$current" ]]; then
     commits+=("$current")
   fi
+}
+
+if [[ -n "${PR_COMMITS_FILE:-}" ]]; then
+  # Test mode: read from file. Commits separated by lines containing exactly "---".
+  parse_commits <"$PR_COMMITS_FILE"
 else
   # Live mode: fetch commits from the PR via gh CLI.
   raw=""
@@ -41,22 +48,7 @@ else
     echo "Error fetching PR $PR_NUMBER: $raw" >&2
     exit 1
   fi
-  current=""
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    if [[ "$line" == "---" ]]; then
-      commits+=("$current")
-      current=""
-    else
-      if [[ -n "$current" ]]; then
-        current="$current"$'\n'"$line"
-      else
-        current="$line"
-      fi
-    fi
-  done <<<"$raw"
-  if [[ -n "$current" ]]; then
-    commits+=("$current")
-  fi
+  parse_commits <<<"$raw"
 fi
 
 # If no commits were found, default to patch.

--- a/scripts/determine-bump.sh
+++ b/scripts/determine-bump.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# determine-bump.sh — Determine the semver bump type for a PR based on its commits.
+# Usage: determine-bump.sh <PR_NUMBER>
+# In test mode, set PR_COMMITS_FILE to a file containing commits separated by "---" lines.
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $(basename "$0") <PR_NUMBER>" >&2
+  exit 1
+fi
+
+PR_NUMBER="$1"
+
+# Read commits into an array. Each element is one full commit text (headline + body).
+commits=()
+
+if [[ -n "${PR_COMMITS_FILE:-}" ]]; then
+  # Test mode: read from file. Commits separated by lines containing exactly "---".
+  current=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" == "---" ]]; then
+      commits+=("$current")
+      current=""
+    else
+      if [[ -n "$current" ]]; then
+        current="$current"$'\n'"$line"
+      else
+        current="$line"
+      fi
+    fi
+  done <"$PR_COMMITS_FILE"
+  # Capture any trailing commit not followed by ---
+  if [[ -n "$current" ]]; then
+    commits+=("$current")
+  fi
+else
+  # Live mode: fetch commits from the PR via gh CLI.
+  raw=""
+  if ! raw=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[] | (.messageHeadline + "\n" + .messageBody + "\n---")' 2>&1); then
+    echo "Error fetching PR $PR_NUMBER: $raw" >&2
+    exit 1
+  fi
+  current=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" == "---" ]]; then
+      commits+=("$current")
+      current=""
+    else
+      if [[ -n "$current" ]]; then
+        current="$current"$'\n'"$line"
+      else
+        current="$line"
+      fi
+    fi
+  done <<<"$raw"
+  if [[ -n "$current" ]]; then
+    commits+=("$current")
+  fi
+fi
+
+# If no commits were found, default to patch.
+if [[ ${#commits[@]} -eq 0 ]]; then
+  echo "patch"
+  exit 0
+fi
+
+# Track which bump levels were triggered.
+has_major=0
+has_minor=0
+has_patch=0
+has_skip=0
+has_unclassified=0
+
+# Regex patterns (case-sensitive, POSIX ERE via grep -E).
+PATTERN_BREAKING_BODY="BREAKING CHANGE"
+PATTERN_BREAKING_HEADER="^[a-z]+(\([^)]+\))?!:"
+PATTERN_FEAT="^feat(\([^)]+\))?:"
+PATTERN_PATCH="^(fix|perf|refactor|style)(\([^)]+\))?:"
+PATTERN_SKIP="^(docs|ci|chore|test|build)(\([^)]+\))?:"
+
+for commit in "${commits[@]}"; do
+  # Extract the headline (first line).
+  headline="${commit%%$'\n'*}"
+  # The body is everything after the first line.
+  body="${commit#*$'\n'}"
+  # If there was no newline, body == commit (same as headline); treat body as empty.
+  if [[ "$body" == "$commit" ]]; then
+    body=""
+  fi
+
+  # Rule 1: BREAKING CHANGE in body OR ! in header.
+  if echo "$body" | grep -qF "$PATTERN_BREAKING_BODY" \
+    || echo "$headline" | grep -qE "$PATTERN_BREAKING_HEADER"; then
+    has_major=1
+    continue
+  fi
+
+  # Rule 2: feat header.
+  if echo "$headline" | grep -qE "$PATTERN_FEAT"; then
+    has_minor=1
+    continue
+  fi
+
+  # Rule 3: fix/perf/refactor/style header.
+  if echo "$headline" | grep -qE "$PATTERN_PATCH"; then
+    has_patch=1
+    continue
+  fi
+
+  # Rule 4: docs/ci/chore/test/build header.
+  if echo "$headline" | grep -qE "$PATTERN_SKIP"; then
+    has_skip=1
+    continue
+  fi
+
+  # Rule 5: unclassifiable.
+  has_unclassified=1
+done
+
+# Apply priority: major > minor > patch > skip.
+# skip only applies if ALL commits matched the skip pattern (no minor/patch/major/unclassified).
+if [[ $has_major -eq 1 ]]; then
+  echo "major"
+elif [[ $has_minor -eq 1 ]]; then
+  echo "minor"
+elif [[ $has_patch -eq 1 ]]; then
+  echo "patch"
+elif [[ $has_skip -eq 1 && $has_unclassified -eq 0 ]]; then
+  echo "skip"
+else
+  echo "patch"
+fi

--- a/scripts/determine-bump.test.sh
+++ b/scripts/determine-bump.test.sh
@@ -40,7 +40,13 @@ run_test() {
   printf '%s' "$fixture_content" >"$fixture_file"
 
   local actual
-  actual="$(PR_COMMITS_FILE="$fixture_file" bash "$BUMP_SCRIPT" 999)"
+  local exit_code=0
+  actual="$(PR_COMMITS_FILE="$fixture_file" bash "$BUMP_SCRIPT" 999)" || exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
+    printf '%bFAIL%b — %s (script exited %d)\n' "$RED" "$RESET" "$description" "$exit_code"
+    fail=$((fail + 1))
+    return
+  fi
 
   if [[ "$actual" == "$expected" ]]; then
     echo "${GREEN}PASS${RESET} — $description"
@@ -142,6 +148,23 @@ run_test "feat(a) + chore(b) → minor" \
 ---
 chore(b): y" \
   "minor"
+
+# 16. Leading --- guard: phantom empty commit must not affect result
+run_test "leading --- separator → skip (no phantom commit)" \
+  "---
+docs: update readme" \
+  "skip"
+
+# 17. Trailing --- guard: trailing separator must not produce phantom commit
+run_test "trailing --- separator → patch" \
+  "fix: handle null
+---" \
+  "patch"
+
+# 18. Scoped breaking change with scope in header → major
+run_test "scoped feat(api)! breaking header → major" \
+  "feat(api)!: drop v1 endpoint" \
+  "major"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/determine-bump.test.sh
+++ b/scripts/determine-bump.test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# determine-bump.test.sh — Shell test suite for determine-bump.sh
+# Run from repo root:    bash scripts/determine-bump.test.sh
+# Run from scripts dir:  bash determine-bump.test.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUMP_SCRIPT="$SCRIPT_DIR/determine-bump.sh"
+
+# Colour support (optional).
+if command -v tput &>/dev/null && tput colors &>/dev/null && [[ "$(tput colors)" -ge 8 ]]; then
+  GREEN="$(tput setaf 2)"
+  RED="$(tput setaf 1)"
+  RESET="$(tput sgr0)"
+  BOLD="$(tput bold)"
+else
+  GREEN=""
+  RED=""
+  RESET=""
+  BOLD=""
+fi
+
+# Temp directory for fixture files; cleaned up on exit.
+TMPDIR_TESTS="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TESTS"' EXIT
+
+pass=0
+fail=0
+# Note: use "|| true" with arithmetic expressions that may evaluate to 0,
+# because (( expr )) exits 1 when the result is 0, which triggers set -e.
+
+run_test() {
+  local description="$1"
+  local fixture_content="$2"
+  local expected="$3"
+
+  local fixture_file
+  fixture_file="$(mktemp "$TMPDIR_TESTS/fixture.XXXXXX")"
+  printf '%s' "$fixture_content" >"$fixture_file"
+
+  local actual
+  actual="$(PR_COMMITS_FILE="$fixture_file" bash "$BUMP_SCRIPT" 999)"
+
+  if [[ "$actual" == "$expected" ]]; then
+    echo "${GREEN}PASS${RESET} — $description"
+    pass=$((pass + 1))
+  else
+    echo "${RED}FAIL${RESET} — $description"
+    echo "       expected: ${BOLD}$expected${RESET}"
+    echo "       actual:   ${BOLD}$actual${RESET}"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+# 1. Single feat → minor
+run_test "single feat commit → minor" \
+  "feat: add pause mode" \
+  "minor"
+
+# 2. Single fix → patch
+run_test "single fix commit → patch" \
+  "fix: handle null" \
+  "patch"
+
+# 3. style → patch (style is NOT skip)
+run_test "style commit → patch (not skip)" \
+  "style: reformat" \
+  "patch"
+
+# 4. Single docs → skip
+run_test "single docs commit → skip" \
+  "docs: update readme" \
+  "skip"
+
+# 5. All chore/ci/test → skip
+run_test "all chore/ci/test commits → skip" \
+  "chore: x
+---
+ci: y
+---
+test: z" \
+  "skip"
+
+# 6. docs + fix → patch (fix beats docs)
+run_test "docs + fix → patch" \
+  "docs: x
+---
+fix: y" \
+  "patch"
+
+# 7. fix + feat → minor (feat beats fix)
+run_test "fix + feat → minor" \
+  "fix: x
+---
+feat: y" \
+  "minor"
+
+# 8. feat! → major
+run_test "feat! breaking header → major" \
+  "feat!: breaking api" \
+  "major"
+
+# 9. fix with BREAKING CHANGE in body → major
+run_test "fix with BREAKING CHANGE body → major" \
+  "fix: handle null
+BREAKING CHANGE: token format changed" \
+  "major"
+
+# 10. No conventional prefix → patch (safe default)
+run_test "non-conventional commit → patch" \
+  "random text here" \
+  "patch"
+
+# 11. Scoped fix → patch
+run_test "scoped fix(auth) → patch" \
+  "fix(auth): handle null" \
+  "patch"
+
+# 12. Scoped feat → minor
+run_test "scoped feat(ui) → minor" \
+  "feat(ui): add modal" \
+  "minor"
+
+# 13. Uppercase FEAT: → patch (case-sensitive, must NOT match minor)
+run_test "uppercase FEAT: → patch (case-sensitive)" \
+  "FEAT: broken" \
+  "patch"
+
+# 14. Empty commit file → patch (defensive default)
+run_test "empty commit file → patch" \
+  "" \
+  "patch"
+
+# 15. feat(a) + chore(b) → minor (feat beats chore)
+run_test "feat(a) + chore(b) → minor" \
+  "feat(a): x
+---
+chore(b): y" \
+  "minor"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+total=$((pass + fail))
+if [[ $fail -eq 0 ]]; then
+  echo "${GREEN}${BOLD}All $total tests passed.${RESET}"
+  exit 0
+else
+  echo "${RED}${BOLD}$fail of $total tests FAILED.${RESET}"
+  exit 1
+fi

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -97,7 +97,9 @@ const config = defineConfig({
     },
   },
   define: {
-    'import.meta.env.VITE_APP_VERSION': JSON.stringify(version),
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(
+      process.env['VITE_APP_VERSION'] ?? version,
+    ),
   },
   ssr: {
     // workbox-window ships only CJS; bundle it so the SSR server can import it


### PR DESCRIPTION
## Summary

Adds two CI capabilities: live per-PR preview deploys of the app and Storybook, and automatic semver version bumping on merge to master.

- Every PR now publishes a live preview at `https://leocaseiro.github.io/base-skill/pr/<N>/app/` (app) and `.../pr/<N>/storybook/` (Storybook), stamped with a `0.1.0-pr.<N>` version string. Previews are kept forever — no cleanup on close — so history is preserved.
- When a PR merges to master, the workflow inspects the PR's commit messages, picks a semver bump (`major` / `minor` / `patch` / `skip`), updates `package.json`, tags the commit (`v0.2.0`), pushes both back to master, and deploys to the `gh-pages` root.
- The deploy workflow is migrated off the GitHub Pages API and onto a `gh-pages` branch push so production and PR previews can coexist on the same branch.

## Version bump rules

Bump type is auto-detected from the PR's commit messages by `scripts/determine-bump.sh` (precedence high → low):

| Priority | Commit pattern                                   | Bump    |
| -------- | ------------------------------------------------ | ------- |
| 1        | `BREAKING CHANGE:` in body, or `<type>!:` header | `major` |
| 2        | `feat:` / `feat(scope):`                         | `minor` |
| 3        | `fix:` / `perf:` / `refactor:` / `style:`        | `patch` |
| 4        | Only `docs:` / `ci:` / `chore:` / `test:` / `build:` | `skip`  |
| 5        | Anything else (unclassifiable or empty)          | `patch` |

The script is covered by 18 shell tests runnable via `yarn test:scripts`.

## What changed

- **`scripts/determine-bump.sh`** (new) — commit-scanning bump detector with test-mode support via `PR_COMMITS_FILE`
- **`scripts/determine-bump.test.sh`** (new) — 18 test cases covering scoped prefixes, breaking changes, skip-only commits, mixed precedence, and edge cases
- **`.github/workflows/deploy.yml`** — migrated from `actions/deploy-pages` to `JamesIves/github-pages-deploy-action@v4` targeting `gh-pages` with `clean-exclude: pr/**`; triggers on `pull_request: closed && merged == true`; runs bump, tags, and pushes back to master
- **`.github/workflows/pr-preview.yml`** (new) — triggers on PR open/sync/reopen; builds app with `APP_BASE_URL=/base-skill/pr/<N>/app/` and `VITE_APP_VERSION=<base>-pr.<N>`; deploys to `gh-pages/pr/<N>/` with `clean: true` scoped to that folder; posts/updates a sticky PR comment with preview URLs
- **`vite.config.ts`** — one-line change: `VITE_APP_VERSION` env var now overrides `package.json` version when set. Production builds are unchanged (env var not set).
- **`package.json`** — new `test:scripts` entry for running the bump-script tests
- **`docs/superpowers/plans/2026-04-10-pr-previews-and-auto-bump-plan.md`** — design plan

## Required manual step after merge

The `gh-pages` branch does not exist yet. This PR's own merge will create it via the migrated `deploy.yml`. **After the merge workflow completes successfully**, switch GitHub Pages to serve from the new branch:

1. Go to **Settings → Pages → Source**
2. Change from **GitHub Actions** to **Deploy from a branch**
3. Select branch **`gh-pages`**, folder **`/ (root)`**
4. Save

Until this switch is made, the site will still be served by the old Pages API deployment. After the switch, the production site stays at `https://leocaseiro.github.io/base-skill/` and every future PR automatically gets a preview.

## Version bump this PR triggers

This PR's commits include several `feat:` entries, so `determine-bump.sh` will output `minor`. On merge, `0.1.0` bumps to `0.2.0`, tagged `v0.2.0`.

## Known tradeoffs (intentional)

- **PR previews share same-origin state with production** — localStorage, IndexedDB, and cookies are shared across all versions served from `leocaseiro.github.io`. A PR that changes the IndexedDB schema may corrupt master's local DB on a browser that visited the PR preview. Accepted as a known sharp edge; can revisit with namespacing later if it bites.
- **Service workers have a first-load edge case** — on the first navigation to a PR preview, master's service worker (scope `/base-skill/`) may intercept and return master's shell HTML. Resolves on second load once the PR's own SW registers in the narrower scope.
- **Fork PRs cannot use the preview workflow** — fork PRs have read-only `GITHUB_TOKEN` and no access to secrets. The preview job will fail on fork PRs. Fine for a solo repo; documented in a comment at the top of `pr-preview.yml`.
- **Previews are never cleaned up** — by design. The `gh-pages` branch grows over time; this is acceptable for keeping a browsable history.

## Test plan

- [x] Unit tests pass locally (`yarn test`) — already verified
- [x] Bump-script tests pass (`yarn test:scripts`) — 18/18 verified
- [x] Lint, typecheck, prettier pass (`yarn lint && yarn typecheck && npx prettier --check .`) — verified
- [x] Build succeeds with default env (`yarn build`) — verified
- [x] Build succeeds with PR-preview env (`VITE_APP_VERSION=0.1.0-pr.42 APP_BASE_URL=/base-skill/pr/42/app/ yarn build`) — verified
- [x] On merge: `deploy.yml` runs, bumps `0.1.0 → 0.2.0`, tags `v0.2.0`, pushes back to master, deploys to `gh-pages` root — verify post-merge
- [x] After merge + Pages setting change: `https://leocaseiro.github.io/base-skill/` serves the new deployment — verify post-merge
- [x] On next PR: `pr-preview.yml` runs, deploys to `gh-pages/pr/<N>/`, posts sticky comment — verify post-merge

## Push flags

Pushed with `SKIP_VR=1 SKIP_E2E=1` — this branch only touches CI workflows, a build-config one-liner, and a standalone bash script. Neither UI pixels nor routing behavior are affected, so VR and E2E are not meaningful signals here. Unit, lint, typecheck, storybook, and the bump-script tests all pass.
