### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-skill",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary

- Bumps `package.json` from `0.1.0` to `0.2.0` to align master with the
  v0.2.0 build already published on `gh-pages`.
- Pure reconciliation — no code changes.

## Why

When PR #42 merged, `deploy.yml` auto-detected a `minor` bump, ran
`yarn version --minor`, built the site, and published `deploy: production 0.2.0`
to the `gh-pages` branch successfully. The final step of the workflow (the
bot's `git push origin master --follow-tags`) then failed because husky v9
invokes `.husky/pre-push` via `sh` (dash on Ubuntu runners), and the hook's
line 20 `set -euo pipefail` is not POSIX — dash rejects `-o pipefail`. The
bump commit `chore(release): v0.2.0` and the `v0.2.0` tag were created on the
runner but never pushed, so master stayed at `0.1.0` even though the live site
already reports `0.2.0`.

## What will happen on merge

1. `deploy.yml` runs on `pull_request: closed`.
2. `scripts/determine-bump.sh` sees a `chore:` commit → prints `skip`.
3. Because `BUMP == skip`, no `yarn version` runs and the "Commit and tag
   version bump" step is skipped entirely (gated on `bumped == 'true'`).
4. The build reads `0.2.0` from the now-updated `package.json` and re-publishes
   to `gh-pages`. Content is identical to what's already there.
5. **No bot push, no husky invocation** — the broken code path is not
   exercised.

## Follow-ups after merge

- Manually create the `v0.2.0` tag on master and push it:

  ```bash
  git fetch origin master
  git tag v0.2.0 origin/master
  git push origin v0.2.0
  ```

- Separately, a PR against `fix/ci-pre-push-hook` patches the pre-push hook
  to be dash-safe and adds `SKIP_PREPUSH=1` to the bot's push step so the
  next auto-bump does not repeat this failure.

## Test plan

- [ ] Merge this PR.
- [ ] Confirm `deploy.yml` runs, detects `skip`, does not attempt any
      commit/tag/push step.
- [ ] Confirm `version.json` on gh-pages still reports `0.2.0`.
- [ ] Manually tag `v0.2.0` on master per the follow-up above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)