### PR TITLE
feat(number-match): render visual hover preview in slots and bank

### DIFF
--- a/src/components/answer-game/Slot/Slot.tsx
+++ b/src/components/answer-game/Slot/Slot.tsx
@@ -8,6 +8,14 @@ interface SlotProps {
   as?: 'li' | 'span' | 'div';
   className?: string;
   children: (props: SlotRenderProps) => ReactNode;
+  /**
+   * Optional custom preview renderer. Invoked during drag-hover or swap
+   * preview when there is a `previewLabel`. Lets a game render a visual
+   * preview (e.g. a domino face) instead of the default bold text. Must
+   * apply its own opacity/styling. When omitted, the default
+   * `<span>{previewLabel}</span>` is used.
+   */
+  renderPreview?: (previewLabel: string) => ReactNode;
 }
 
 export const Slot = ({
@@ -15,6 +23,7 @@ export const Slot = ({
   as: Tag = 'li',
   className,
   children,
+  renderPreview,
 }: SlotProps) => {
   const {
     renderProps,
@@ -90,9 +99,13 @@ export const Slot = ({
         {isEmpty ? (
           <>
             {isPreview && previewLabel !== null ? (
-              <span className="text-xl font-bold opacity-50">
-                {previewLabel}
-              </span>
+              renderPreview ? (
+                renderPreview(previewLabel)
+              ) : (
+                <span className="text-xl font-bold opacity-50">
+                  {previewLabel}
+                </span>
+              )
             ) : (
               children(renderProps)
             )}
@@ -124,9 +137,13 @@ export const Slot = ({
               onPointerCancel={pointerHandlers.onPointerCancel}
             >
               {isPreview && previewLabel !== null ? (
-                <span className="text-xl font-bold">
-                  {previewLabel}
-                </span>
+                renderPreview ? (
+                  renderPreview(previewLabel)
+                ) : (
+                  <span className="text-xl font-bold">
+                    {previewLabel}
+                  </span>
+                )
               ) : (
                 children(renderProps)
               )}

--- a/src/games/number-match/NumberMatch/NumberMatch.tsx
+++ b/src/games/number-match/NumberMatch/NumberMatch.tsx
@@ -220,7 +220,42 @@ const NumberMatchSession = ({
         <AnswerGame.Answer>
           <SlotRow className="gap-4">
             {zones.map((zone, i) => (
-              <Slot key={zone.id} index={i} className={slotClass}>
+              <Slot
+                key={zone.id}
+                index={i}
+                className={slotClass}
+                renderPreview={(previewLabel) => {
+                  if (dotsDominoMode) {
+                    const n = Number.parseInt(previewLabel, 10);
+                    if (!Number.isNaN(n)) {
+                      return (
+                        <div className="opacity-50">
+                          <DominoTile value={n} />
+                        </div>
+                      );
+                    }
+                  }
+                  if (wordMode) {
+                    return (
+                      <span
+                        className={[
+                          'block text-center font-bold leading-tight hyphens-auto break-words opacity-50',
+                          previewLabel.length > 6
+                            ? 'text-sm'
+                            : 'text-xl',
+                        ].join(' ')}
+                      >
+                        {previewLabel}
+                      </span>
+                    );
+                  }
+                  return (
+                    <span className="text-3xl font-bold tabular-nums opacity-50">
+                      {previewLabel}
+                    </span>
+                  );
+                }}
+              >
                 {({ label }) => {
                   if (!label) return null;
                   if (dotsDominoMode) {

--- a/src/games/number-match/NumeralTileBank/NumeralTileBank.test.tsx
+++ b/src/games/number-match/NumeralTileBank/NumeralTileBank.test.tsx
@@ -156,7 +156,9 @@ describe('NumeralTileBank', () => {
     );
     const hole = container.querySelector('[data-tile-bank-hole="t1"]');
     expect(hole?.className).toMatch(/border-dashed/);
-    expect(hole?.textContent).toContain('3');
+    // In dots+group mode the preview renders a DominoTile (not plain text).
+    // Value 3 → DOMINO_SPLIT[3] = [3, 0] → 3 total pips.
+    expect(hole?.querySelectorAll('[data-pip]')).toHaveLength(3);
   });
 
   it('renders tiles for all bank tile IDs', () => {

--- a/src/games/number-match/NumeralTileBank/NumeralTileBank.tsx
+++ b/src/games/number-match/NumeralTileBank/NumeralTileBank.tsx
@@ -241,11 +241,25 @@ export const NumeralTileBank = ({
                 .join(' ')}
               aria-hidden="true"
             >
-              {isHoverTarget && (
-                <span className="absolute inset-0 flex items-center justify-center text-2xl font-bold opacity-50">
-                  {tile.label}
-                </span>
-              )}
+              {isHoverTarget &&
+                (showDomino ? (
+                  <div className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-50">
+                    <DominoTile value={numericValue} />
+                  </div>
+                ) : isWordTile ? (
+                  <span
+                    className={[
+                      'pointer-events-none absolute inset-0 flex items-center justify-center px-2 text-center font-bold leading-tight hyphens-auto break-words opacity-50',
+                      isLongWord(tile.label) ? 'text-sm' : 'text-xl',
+                    ].join(' ')}
+                  >
+                    {tile.label}
+                  </span>
+                ) : (
+                  <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-2xl font-bold opacity-50">
+                    {tile.label}
+                  </span>
+                ))}
             </div>
           );
         })}


### PR DESCRIPTION
## Summary

- Extend `Slot` with an optional `renderPreview(previewLabel)` prop so games can render a custom drag-hover preview (domino face, long-word text, etc.) instead of the default bold text span. Both empty and filled slot branches honour it and fall back to the old `<span>` when omitted.
- `NumberMatch` wires `renderPreview` to render a `DominoTile` in `dots` + `numeral-to-group` mode, long-word styling in word modes, and plain numeric text otherwise — so the hover preview visually matches the dragged tile.
- `NumeralTileBank`'s empty bank-hole hover target renders the same domino / word / numeric preview instead of hard-coded text.

Closes Wave 3 Agent E of the match-number-improvements plan.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` (548 passed — updated `NumeralTileBank.test.tsx` to assert the new domino pip count during a bank-hover preview instead of the legacy text fallback)
- [x] `yarn test:storybook` (155 passed)
- [x] `yarn test:vr` via Docker (21 passed — existing baselines unchanged, no hover-preview screenshot in the suite yet)
- [x] `yarn test:e2e` via pre-push hook

Pre-push hook: lint ✓, typecheck ✓, unit ✓, VR ✓, e2e ✓; Storybook skipped (server not running — verified locally above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)