### PR TITLE
fix(number-match): regenerate rounds when saved values collapse to one

### DIFF
--- a/src/routes/$locale/_app/game/$gameId.tsx
+++ b/src/routes/$locale/_app/game/$gameId.tsx
@@ -133,7 +133,7 @@ const makeDefaultNumberMatchConfig = (): NumberMatchConfig => ({
   rounds: DEFAULT_NUMBER_MATCH_ROUND_VALUES.map((value) => ({ value })),
 });
 
-const resizeNumberMatchRounds = (
+export const resizeNumberMatchRounds = (
   prev: NumberMatchRound[],
   count: number,
   range: { min: number; max: number },
@@ -146,6 +146,24 @@ const resizeNumberMatchRounds = (
   // round value via the settings panel.
   const fillValueAt = (index: number): number =>
     range.min + (index % span);
+
+  // Detect a collapsed state: every round has the same value even though the
+  // range allows variety. This happens when the user narrows the range down
+  // to a single value (collapsing every round to that value) and then widens
+  // it again — without this check the preserved values stay stuck at the
+  // collapse point and the player sees the same number every round. Also
+  // handles the empty-prev case from a legacy saved config.
+  const firstValue = prev[0]?.value;
+  const allCollapsed =
+    prev.length >= 2 &&
+    span > 1 &&
+    prev.every((r) => r.value === firstValue);
+  if (prev.length === 0 || allCollapsed) {
+    return Array.from({ length: n }, (_, i) => ({
+      value: fillValueAt(i),
+    }));
+  }
+
   const next = prev.slice(0, n).map((r, i) => {
     if (r.value >= range.min && r.value <= range.max) return { ...r };
     return { value: fillValueAt(i) };

--- a/src/routes/$locale/_app/game/resize-number-match-rounds.test.ts
+++ b/src/routes/$locale/_app/game/resize-number-match-rounds.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { resizeNumberMatchRounds } from './$gameId';
+
+describe('resizeNumberMatchRounds', () => {
+  const range = { min: 1, max: 12 };
+
+  it('returns a deterministic cycle from min when prev is empty', () => {
+    const out = resizeNumberMatchRounds([], 5, range);
+    expect(out.map((r) => r.value)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('preserves existing in-range values when growing the list', () => {
+    const prev = [{ value: 5 }, { value: 8 }, { value: 3 }];
+    const out = resizeNumberMatchRounds(prev, 5, range);
+    // First three preserved, last two filled by deterministic cycle.
+    expect(out.map((r) => r.value)).toEqual([5, 8, 3, 4, 5]);
+  });
+
+  it('replaces out-of-range values without touching in-range neighbours', () => {
+    const prev = [{ value: 5 }, { value: 99 }, { value: 3 }];
+    const out = resizeNumberMatchRounds(prev, 3, range);
+    expect(out[0]?.value).toBe(5);
+    expect(out[1]?.value).not.toBe(99);
+    expect(out[2]?.value).toBe(3);
+  });
+
+  it('regenerates fully when every round is collapsed to the same value and the range allows variety', () => {
+    // Simulates the bug: a previous narrow-range edit (e.g. {min:5,max:5})
+    // collapsed every round to 5. The range is now wide again but the
+    // preserved values are stuck.
+    const prev = [
+      { value: 5 },
+      { value: 5 },
+      { value: 5 },
+      { value: 5 },
+      { value: 5 },
+    ];
+    const out = resizeNumberMatchRounds(prev, 5, range);
+    const values = out.map((r) => r.value);
+    expect(values).toEqual([1, 2, 3, 4, 5]);
+    expect(new Set(values).size).toBeGreaterThan(1);
+  });
+
+  it('keeps all rounds the same when the range legitimately only allows one value', () => {
+    const prev = [{ value: 7 }, { value: 7 }, { value: 7 }];
+    const out = resizeNumberMatchRounds(prev, 3, { min: 7, max: 7 });
+    expect(out.map((r) => r.value)).toEqual([7, 7, 7]);
+  });
+
+  it('does not regenerate a single-round collapsed state (trivially "all same")', () => {
+    const prev = [{ value: 5 }];
+    const out = resizeNumberMatchRounds(prev, 1, range);
+    expect(out.map((r) => r.value)).toEqual([5]);
+  });
+
+  it('caps the count at 50', () => {
+    const out = resizeNumberMatchRounds([], 100, range);
+    expect(out).toHaveLength(50);
+  });
+
+  it('clamps the count at 1', () => {
+    const out = resizeNumberMatchRounds([], 0, range);
+    expect(out).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a stuck-state bug where every round in NumberMatch kept the same value forever (e.g. five rounds, every answer "fifth"), even across new game starts.

## Root cause

A sequence of range edits in the settings panel could narrow the range down to a single value, collapsing every round in the persisted config to that value. Widening the range again kept the stuck values because `resizeNumberMatchRounds` (introduced in #46) treated each one as still "in range" and preserved it. On every subsequent load the route loader fed the stuck array back through resize, so the player saw the same number every round, every session.

This is a regression from PR #46 — before that fix, the default rounds were regenerated with `Math.random` on every load, which masked the problem at the cost of VR determinism.

## Fix

- Detect the collapsed state in `resizeNumberMatchRounds`: `prev.length >= 2 && span > 1 && every round has the same value`. Regenerate the whole list via the existing deterministic cycle (`range.min + (index % span)`).
- Also handle the previously-unhandled empty `prev` case explicitly.
- Export the helper so it can be unit-tested directly.
- Add a dedicated `resize-number-match-rounds.test.ts` with 8 cases, including the exact regression (`[5,5,5,5,5]` in a `{1,12}` range → `[1,2,3,4,5]`) and a legitimate single-value range (`{7,7}` → `[7,7,7]` is preserved).

## Upgrade path for already-stuck users

No manual IndexedDB clearing required. On the next page load after this ships:

1. Loader reads the stuck `[5,5,5,5,5]` from IndexedDB.
2. `resolveNumberMatchConfig` calls the fixed `resizeNumberMatchRounds`.
3. Collapsed state detected → returns `[1,2,3,4,5]`.
4. `usePersistLastGameConfig` writes the new variety back to IndexedDB.
5. Player sees variety from then on.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` — 556 passed (8 new)
- [x] `yarn test:vr` via pre-push hook
- [x] `yarn test:e2e` via pre-push hook
- [ ] Storybook skipped via `SKIP_STORYBOOK=1` — this fix touches a pure helper function, no component or story changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)