### PR TITLE
feat(words): makeWordCore builder (Task 3/18)

### DIFF
--- a/src/data/words/builders.test.ts
+++ b/src/data/words/builders.test.ts
@@ -1,0 +1,42 @@
+// src/data/words/builders.test.ts
+import { describe, expect, it } from 'vitest';
+import { makeWordCore } from './builders';
+
+describe('makeWordCore', () => {
+  it('counts one syllable for simple CVC', () => {
+    expect(makeWordCore('cat')).toEqual({
+      word: 'cat',
+      syllableCount: 1,
+    });
+  });
+
+  it('counts silent-e as not a syllable', () => {
+    expect(makeWordCore('cake')).toEqual({
+      word: 'cake',
+      syllableCount: 1,
+    });
+  });
+
+  it('counts two syllables for sunset', () => {
+    const result = makeWordCore('sunset');
+    expect(result.syllableCount).toBe(2);
+  });
+
+  it('counts three syllables for elephant', () => {
+    const result = makeWordCore('elephant');
+    expect(result.syllableCount).toBe(3);
+  });
+
+  it('accepts explicit syllables override', () => {
+    const result = makeWordCore('chicken', {
+      syllables: ['chick', 'en'],
+    });
+    expect(result.syllableCount).toBe(2);
+    expect(result.syllables).toEqual(['chick', 'en']);
+  });
+
+  it('records variants when provided', () => {
+    const result = makeWordCore('colour', { variants: ['color'] });
+    expect(result.variants).toEqual(['color']);
+  });
+});

--- a/src/data/words/builders.ts
+++ b/src/data/words/builders.ts
@@ -1,0 +1,31 @@
+// src/data/words/builders.ts
+import type { WordCore } from './types';
+
+/**
+ * Counts syllables via vowel-group heuristic with silent-e subtraction.
+ * Good enough for K–Y2 English. Caller can override via opts.syllables.
+ */
+const countSyllables = (word: string): number => {
+  const lower = word.toLowerCase();
+  const groups = lower.match(/[aeiouy]+/g) ?? [];
+  let count = groups.length;
+  if (count > 1 && lower.endsWith('e') && !/[aeiouy]e$/.test(lower)) {
+    count -= 1;
+  }
+  return Math.max(count, 1);
+};
+
+export const makeWordCore = (
+  word: string,
+  opts: { syllables?: string[]; variants?: string[] } = {},
+): WordCore => {
+  const base: WordCore = {
+    word,
+    syllableCount: opts.syllables
+      ? opts.syllables.length
+      : countSyllables(word),
+  };
+  if (opts.syllables) base.syllables = opts.syllables;
+  if (opts.variants) base.variants = opts.variants;
+  return base;
+};


### PR DESCRIPTION
## Summary

- Adds `src/data/words/builders.ts` exporting `makeWordCore(word, opts?)` — the first builder in the codegen pipeline. Uses a vowel-group syllable heuristic with silent-e subtraction (floored at 1). Callers can override via `opts.syllables` or record alt-spellings via `opts.variants`.
- Adds `src/data/words/builders.test.ts` with 6 TDD-first Vitest cases covering CVC, silent-e, multi-syllable, explicit override, and variants.
- Stacked on Task 2 (#56). Tasks 4 and 5 will extend this same `builders.ts` with `makeGraphemes` and `makeCurriculumEntry` + `validateEntry`.

## Review checkpoints

- ✅ Spec compliance — verbatim against plan, only the plan-allowed import narrow (`WordCore` only) applied; ESLint auto-fixed `/e\$/.test` → `.endsWith('e')` (semantically identical)
- ✅ Code quality — approved; minor suggestion noted for an explicit `count == 1 && ends-in-e` regression test (deferred to Task 7's corpus harness)

## Test plan

- [x] TDD red (missing module) → green (6/6 passing)
- [x] `yarn typecheck`
- [x] Pre-push gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)