### PR TITLE
feat(words): makeCurriculumEntry + validateEntry (Task 5/18)

### DIFF
--- a/src/data/words/builders.test.ts
+++ b/src/data/words/builders.test.ts
@@ -1,6 +1,11 @@
 // src/data/words/builders.test.ts
 import { describe, expect, it } from 'vitest';
-import { makeGraphemes, makeWordCore } from './builders';
+import {
+  makeCurriculumEntry,
+  makeGraphemes,
+  makeWordCore,
+  validateEntry,
+} from './builders';
 import { graphemePool } from './levels';
 
 describe('makeWordCore', () => {
@@ -96,6 +101,89 @@ describe('makeGraphemes', () => {
     for (const word of ['cat', 'ship', 'thing', 'pack']) {
       const result = makeGraphemes(word, L4);
       expect(result!.map((g) => g.g).join('')).toBe(word);
+    }
+  });
+});
+
+describe('makeCurriculumEntry', () => {
+  const L2 = graphemePool(2);
+
+  it('builds a CurriculumEntry with graphemes derived from the level set', () => {
+    const entry = makeCurriculumEntry('cat', 2, {
+      levelGraphemes: L2,
+      ipa: 'kæt',
+    });
+    expect(entry).not.toBeNull();
+    expect(entry!.word).toBe('cat');
+    expect(entry!.level).toBe(2);
+    expect(entry!.ipa).toBe('kæt');
+    expect(entry!.graphemes.map((g) => g.g)).toEqual(['c', 'a', 't']);
+  });
+
+  it('returns null when graphemes cannot be derived', () => {
+    const entry = makeCurriculumEntry('zip', 2, { levelGraphemes: L2 });
+    expect(entry).toBeNull();
+  });
+
+  it('accepts explicit graphemes override', () => {
+    const entry = makeCurriculumEntry('cake', 7, {
+      levelGraphemes: [...L2, 'a_e'],
+      ipa: 'keɪk',
+      graphemes: [
+        { g: 'c', p: 'k' },
+        { g: 'a_e', p: 'eɪ', span: [1, 3] },
+        { g: 'k', p: 'k' },
+      ],
+    });
+    expect(entry!.graphemes).toHaveLength(3);
+    expect(entry!.graphemes[1]!.g).toBe('a_e');
+  });
+});
+
+describe('validateEntry', () => {
+  const core = { word: 'cat', syllableCount: 1 };
+  const good = {
+    word: 'cat',
+    level: 2,
+    ipa: 'kæt',
+    graphemes: [
+      { g: 'c', p: 'k' },
+      { g: 'a', p: 'æ' },
+      { g: 't', p: 't' },
+    ],
+  };
+
+  it('passes valid entries', () => {
+    expect(validateEntry(core, good)).toEqual({ ok: true });
+  });
+
+  it('rejects grapheme mismatch', () => {
+    const bad = { ...good, graphemes: [{ g: 'c', p: 'k' }] };
+    const result = validateEntry(core, bad);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors[0]!.field).toBe('graphemes');
+    }
+  });
+
+  it('rejects word mismatch between core and curriculum', () => {
+    const mismatched = { ...good, word: 'dog' };
+    const result = validateEntry(core, mismatched);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects syllables that do not join to the word', () => {
+    const badCore = {
+      word: 'cat',
+      syllableCount: 1,
+      syllables: ['ca'],
+    };
+    const result = validateEntry(badCore, good);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.field === 'syllables')).toBe(
+        true,
+      );
     }
   });
 });

--- a/src/data/words/builders.ts
+++ b/src/data/words/builders.ts
@@ -1,5 +1,10 @@
 // src/data/words/builders.ts
-import type { Grapheme, WordCore } from './types';
+import type {
+  CurriculumEntry,
+  Grapheme,
+  ValidationError,
+  WordCore,
+} from './types';
 
 /**
  * Counts syllables via vowel-group heuristic with silent-e subtraction.
@@ -69,4 +74,77 @@ export const makeWordCore = (
   if (opts.syllables) base.syllables = opts.syllables;
   if (opts.variants) base.variants = opts.variants;
   return base;
+};
+
+export const makeCurriculumEntry = (
+  word: string,
+  level: number,
+  opts: {
+    levelGraphemes: readonly string[];
+    ipa?: string;
+    graphemes?: Grapheme[];
+    phonemeByGrapheme?: Record<string, string>;
+  },
+): CurriculumEntry | null => {
+  const graphemes =
+    opts.graphemes ??
+    makeGraphemes(word, opts.levelGraphemes, opts.phonemeByGrapheme);
+  if (graphemes === null) return null;
+  return {
+    word,
+    level,
+    ipa: opts.ipa ?? graphemes.map((g) => g.p).join(''),
+    graphemes,
+  };
+};
+
+export const validateEntry = (
+  core: WordCore,
+  curriculum: CurriculumEntry,
+): { ok: true } | { ok: false; errors: ValidationError[] } => {
+  const errors: ValidationError[] = [];
+
+  if (core.word !== curriculum.word) {
+    errors.push({
+      field: 'word',
+      message: `core.word "${core.word}" !== curriculum.word "${curriculum.word}"`,
+    });
+  }
+
+  if (core.syllables && core.syllables.join('') !== core.word) {
+    errors.push({
+      field: 'syllables',
+      message: `syllables.join('') "${core.syllables.join('')}" !== word "${core.word}"`,
+    });
+  }
+
+  if (core.syllables && core.syllables.length !== core.syllableCount) {
+    errors.push({
+      field: 'syllables',
+      message: `syllables.length (${core.syllables.length}) !== syllableCount (${core.syllableCount})`,
+    });
+  }
+
+  const concat = curriculum.graphemes
+    .map((g) => g.g.replace('_', ''))
+    .join('');
+  if (concat !== curriculum.word) {
+    errors.push({
+      field: 'graphemes',
+      message: `graphemes concat "${concat}" !== word "${curriculum.word}"`,
+    });
+  }
+
+  if (!curriculum.ipa || curriculum.ipa.trim() === '') {
+    errors.push({ field: 'ipa', message: 'ipa is empty' });
+  }
+
+  if (curriculum.level < 1 || !Number.isInteger(curriculum.level)) {
+    errors.push({
+      field: 'level',
+      message: `level must be a positive integer, got ${curriculum.level}`,
+    });
+  }
+
+  return errors.length === 0 ? { ok: true } : { ok: false, errors };
 };


### PR DESCRIPTION
## Summary

- Adds `makeCurriculumEntry(word, level, opts)` — composes an explicit or derived grapheme list into a `CurriculumEntry`, falling back to concat phonemes for IPA when not given; returns `null` if structural derivation fails.
- Adds `validateEntry(core, curriculum)` — runs 6 independent checks (word equality, syllable concat + count invariants, graphemes concat with `_` stripped, non-empty IPA, integer level ≥ 1) and accumulates all errors in a single pass.
- Stacked on Task 4 (#58). Tests 21/21 green (6 `makeWordCore` + 8 `makeGraphemes` + 3 `makeCurriculumEntry` + 4 `validateEntry`).

## Review checkpoints

- ✅ Spec compliance — functions, tests, and imports match plan verbatim
- ✅ Code quality — approved; one follow-up noted for Task 7's corpus invariant harness (a bare `syllableCount` check when `syllables` is absent)

## Test plan

- [x] TDD red (7 new failing) → green (21 passing)
- [x] `yarn typecheck`
- [x] Pre-push gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)