### PR TITLE
feat(words): task 10 — entryMatches pure filter predicate

### DIFF
--- a/src/data/words/filter.test.ts
+++ b/src/data/words/filter.test.ts
@@ -1,0 +1,135 @@
+// src/data/words/filter.test.ts
+import { describe, expect, it } from 'vitest';
+import { entryMatches } from './filter';
+import type { WordHit } from './types';
+
+const hit = (overrides: Partial<WordHit> = {}): WordHit => ({
+  word: 'cat',
+  region: 'aus',
+  level: 2,
+  syllableCount: 1,
+  graphemes: [
+    { g: 'c', p: 'k' },
+    { g: 'a', p: 'æ' },
+    { g: 't', p: 't' },
+  ],
+  ...overrides,
+});
+
+describe('entryMatches', () => {
+  it('matches by exact level', () => {
+    expect(entryMatches(hit(), { region: 'aus', level: 2 })).toBe(true);
+    expect(entryMatches(hit(), { region: 'aus', level: 3 })).toBe(
+      false,
+    );
+  });
+
+  it('matches by levels[]', () => {
+    expect(
+      entryMatches(hit(), { region: 'aus', levels: [1, 2, 3] }),
+    ).toBe(true);
+    expect(entryMatches(hit(), { region: 'aus', levels: [4, 5] })).toBe(
+      false,
+    );
+  });
+
+  it('matches by levelRange', () => {
+    expect(
+      entryMatches(hit(), { region: 'aus', levelRange: [1, 3] }),
+    ).toBe(true);
+    expect(
+      entryMatches(hit(), { region: 'aus', levelRange: [3, 5] }),
+    ).toBe(false);
+  });
+
+  it('matches syllableCountEq and syllableCountRange', () => {
+    expect(
+      entryMatches(hit(), { region: 'aus', syllableCountEq: 1 }),
+    ).toBe(true);
+    expect(
+      entryMatches(hit({ syllableCount: 3 }), {
+        region: 'aus',
+        syllableCountRange: [2, 4],
+      }),
+    ).toBe(true);
+  });
+
+  it('graphemesAllowed: passes only when every grapheme is in the set', () => {
+    expect(
+      entryMatches(hit(), {
+        region: 'aus',
+        graphemesAllowed: ['c', 'a', 't'],
+      }),
+    ).toBe(true);
+    expect(
+      entryMatches(hit(), {
+        region: 'aus',
+        graphemesAllowed: ['c', 'a'], // missing 't'
+      }),
+    ).toBe(false);
+  });
+
+  it('graphemesRequired: passes when at least one required is present', () => {
+    expect(
+      entryMatches(hit(), {
+        region: 'aus',
+        graphemesRequired: ['c'],
+      }),
+    ).toBe(true);
+    expect(
+      entryMatches(hit(), {
+        region: 'aus',
+        graphemesRequired: ['sh'],
+      }),
+    ).toBe(false);
+  });
+
+  it('phonemesAllowed + Required: "c making /k/" case', () => {
+    // cat: c/k, a/æ, t/t
+    expect(
+      entryMatches(hit(), {
+        region: 'aus',
+        graphemesRequired: ['c'],
+        phonemesRequired: ['k'],
+      }),
+    ).toBe(true);
+
+    // city: c/s, i/ɪ, t/t, y/i — has 'c' but no /k/
+    const city: WordHit = {
+      word: 'city',
+      region: 'aus',
+      level: 4,
+      syllableCount: 2,
+      graphemes: [
+        { g: 'c', p: 's' },
+        { g: 'i', p: 'ɪ' },
+        { g: 't', p: 't' },
+        { g: 'y', p: 'i' },
+      ],
+    };
+    expect(
+      entryMatches(city, {
+        region: 'aus',
+        graphemesRequired: ['c'],
+        phonemesRequired: ['k'],
+      }),
+    ).toBe(false);
+  });
+
+  it('excludes Tier-1-only words from Tier-2 filters', () => {
+    const tier1: WordHit = {
+      word: 'cat',
+      region: 'aus',
+      level: 2,
+      syllableCount: 1,
+      // no graphemes
+    };
+    expect(
+      entryMatches(tier1, {
+        region: 'aus',
+        graphemesAllowed: ['c', 'a', 't'],
+      }),
+    ).toBe(false);
+    expect(entryMatches(tier1, { region: 'aus', level: 2 })).toBe(true);
+  });
+});

--- a/src/data/words/filter.test.ts
+++ b/src/data/words/filter.test.ts
@@ -1,4 +1,3 @@
-// src/data/words/filter.test.ts
 import { describe, expect, it } from 'vitest';
 import { entryMatches } from './filter';
 import type { WordHit } from './types';

--- a/src/data/words/filter.ts
+++ b/src/data/words/filter.ts
@@ -1,4 +1,3 @@
-// src/data/words/filter.ts
 import type { WordFilter, WordHit } from './types';
 
 const inRange = (
@@ -29,31 +28,30 @@ export const entryMatches = (
   )
     return false;
 
-  const tier2Active =
+  const hasGraphemeFilter =
     filter.graphemesAllowed !== undefined ||
     filter.graphemesRequired !== undefined ||
     filter.phonemesAllowed !== undefined ||
     filter.phonemesRequired !== undefined;
 
-  if (tier2Active && !hit.graphemes) return false;
+  if (!hasGraphemeFilter) return true;
+  if (!hit.graphemes) return false;
 
-  if (hit.graphemes) {
-    if (filter.graphemesAllowed) {
-      const allowed = new Set(filter.graphemesAllowed);
-      if (!hit.graphemes.every((g) => allowed.has(g.g))) return false;
-    }
-    if (filter.graphemesRequired) {
-      const required = new Set(filter.graphemesRequired);
-      if (!hit.graphemes.some((g) => required.has(g.g))) return false;
-    }
-    if (filter.phonemesAllowed) {
-      const allowed = new Set(filter.phonemesAllowed);
-      if (!hit.graphemes.every((g) => allowed.has(g.p))) return false;
-    }
-    if (filter.phonemesRequired) {
-      const required = new Set(filter.phonemesRequired);
-      if (!hit.graphemes.some((g) => required.has(g.p))) return false;
-    }
+  if (filter.graphemesAllowed) {
+    const allowed = new Set(filter.graphemesAllowed);
+    if (!hit.graphemes.every((g) => allowed.has(g.g))) return false;
+  }
+  if (filter.graphemesRequired) {
+    const required = new Set(filter.graphemesRequired);
+    if (!hit.graphemes.some((g) => required.has(g.g))) return false;
+  }
+  if (filter.phonemesAllowed) {
+    const allowed = new Set(filter.phonemesAllowed);
+    if (!hit.graphemes.every((g) => allowed.has(g.p))) return false;
+  }
+  if (filter.phonemesRequired) {
+    const required = new Set(filter.phonemesRequired);
+    if (!hit.graphemes.some((g) => required.has(g.p))) return false;
   }
 
   return true;

--- a/src/data/words/filter.ts
+++ b/src/data/words/filter.ts
@@ -1,0 +1,60 @@
+// src/data/words/filter.ts
+import type { WordFilter, WordHit } from './types';
+
+const inRange = (
+  n: number,
+  [min, max]: readonly [number, number],
+): boolean => n >= min && n <= max;
+
+export const entryMatches = (
+  hit: WordHit,
+  filter: WordFilter,
+): boolean => {
+  if (hit.region !== filter.region) return false;
+
+  if (filter.level !== undefined && hit.level !== filter.level)
+    return false;
+  if (filter.levels && !filter.levels.includes(hit.level)) return false;
+  if (filter.levelRange && !inRange(hit.level, filter.levelRange))
+    return false;
+
+  if (
+    filter.syllableCountEq !== undefined &&
+    hit.syllableCount !== filter.syllableCountEq
+  )
+    return false;
+  if (
+    filter.syllableCountRange &&
+    !inRange(hit.syllableCount, filter.syllableCountRange)
+  )
+    return false;
+
+  const tier2Active =
+    filter.graphemesAllowed !== undefined ||
+    filter.graphemesRequired !== undefined ||
+    filter.phonemesAllowed !== undefined ||
+    filter.phonemesRequired !== undefined;
+
+  if (tier2Active && !hit.graphemes) return false;
+
+  if (hit.graphemes) {
+    if (filter.graphemesAllowed) {
+      const allowed = new Set(filter.graphemesAllowed);
+      if (!hit.graphemes.every((g) => allowed.has(g.g))) return false;
+    }
+    if (filter.graphemesRequired) {
+      const required = new Set(filter.graphemesRequired);
+      if (!hit.graphemes.some((g) => required.has(g.g))) return false;
+    }
+    if (filter.phonemesAllowed) {
+      const allowed = new Set(filter.phonemesAllowed);
+      if (!hit.graphemes.every((g) => allowed.has(g.p))) return false;
+    }
+    if (filter.phonemesRequired) {
+      const required = new Set(filter.phonemesRequired);
+      if (!hit.graphemes.some((g) => required.has(g.p))) return false;
+    }
+  }
+
+  return true;
+};


### PR DESCRIPTION
## Summary

- Adds `src/data/words/filter.ts` with the pure `entryMatches(hit, filter)` predicate: short-circuits on region, then evaluates level / levels / levelRange, then syllableCountEq / syllableCountRange, then grapheme-filter gate and the four Tier-2 dimensions (graphemesAllowed / graphemesRequired / phonemesAllowed / phonemesRequired).
- Tier-1-only hits (no `graphemes`) are correctly excluded when any Tier-2 filter is active.
- Adds `src/data/words/filter.test.ts` — 8 tests covering every filter dimension plus the "c making /k/" phoneme-distinction case and the Tier-1/Tier-2 gate.
- Applied post-review refactor: flattened the Tier-2 block via early returns and renamed internal `tier2Active` → `hasGraphemeFilter` for clarity.

## Task

Task 10 of the Phonics Word Library P1 plan. Task 11 builds `filterWords` on top of this predicate with the two-file join + AUS fallback.

## Verification

- [x] `yarn test src/data/words/filter.test.ts` — 8/8 passing
- [x] Full unit suite — 599/599 passing
- [x] pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)