### PR TITLE
feat(words): task 11 — filterWords with two-file join + AUS fallback

### DIFF
--- a/src/data/words/filter.test.ts
+++ b/src/data/words/filter.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { entryMatches } from './filter';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetChunkCacheForTests,
+  entryMatches,
+  filterWords,
+} from './filter';
 import type { WordHit } from './types';
 
 const hit = (overrides: Partial<WordHit> = {}): WordHit => ({
@@ -130,5 +134,76 @@ describe('entryMatches', () => {
       }),
     ).toBe(false);
     expect(entryMatches(tier1, { region: 'aus', level: 2 })).toBe(true);
+  });
+});
+
+describe('filterWords (integration against seeded chunks)', () => {
+  beforeEach(() => __resetChunkCacheForTests());
+  afterEach(() => __resetChunkCacheForTests());
+
+  it('returns AUS level 1 hits', async () => {
+    const result = await filterWords({ region: 'aus', level: 1 });
+    expect(result.hits.length).toBeGreaterThan(0);
+    for (const hit of result.hits) {
+      expect(hit.level).toBe(1);
+      expect(hit.region).toBe('aus');
+    }
+    expect(result.usedFallback).toBeUndefined();
+  });
+
+  it('joins WordCore + CurriculumEntry (hit has syllableCount)', async () => {
+    const result = await filterWords({ region: 'aus', level: 1 });
+    expect(result.hits[0]!.syllableCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('Tier-2 filter excludes Tier-1-only words', async () => {
+    const result = await filterWords({
+      region: 'aus',
+      levels: [1, 2],
+      graphemesAllowed: [
+        's',
+        'a',
+        't',
+        'p',
+        'i',
+        'n',
+        'm',
+        'd',
+        'g',
+        'o',
+      ],
+    });
+    for (const hit of result.hits) {
+      for (const g of hit.graphemes ?? []) {
+        expect([
+          's',
+          'a',
+          't',
+          'p',
+          'i',
+          'n',
+          'm',
+          'd',
+          'g',
+          'o',
+        ]).toContain(g.g);
+      }
+    }
+  });
+
+  it('falls back to AUS when UK has no data', async () => {
+    const result = await filterWords({ region: 'uk', level: 1 });
+    expect(result.hits.length).toBeGreaterThan(0);
+    expect(result.usedFallback).toEqual({ from: 'uk', to: 'aus' });
+  });
+
+  it('respects fallbackToAus: false', async () => {
+    const result = await filterWords({
+      region: 'uk',
+      level: 1,
+      fallbackToAus: false,
+    });
+    expect(result.hits).toHaveLength(0);
+    expect(result.usedFallback).toBeUndefined();
   });
 });

--- a/src/data/words/filter.test.ts
+++ b/src/data/words/filter.test.ts
@@ -144,9 +144,9 @@ describe('filterWords (integration against seeded chunks)', () => {
   it('returns AUS level 1 hits', async () => {
     const result = await filterWords({ region: 'aus', level: 1 });
     expect(result.hits.length).toBeGreaterThan(0);
-    for (const hit of result.hits) {
-      expect(hit.level).toBe(1);
-      expect(hit.region).toBe('aus');
+    for (const h of result.hits) {
+      expect(h.level).toBe(1);
+      expect(h.region).toBe('aus');
     }
     expect(result.usedFallback).toBeUndefined();
   });
@@ -173,8 +173,8 @@ describe('filterWords (integration against seeded chunks)', () => {
         'o',
       ],
     });
-    for (const hit of result.hits) {
-      for (const g of hit.graphemes ?? []) {
+    for (const h of result.hits) {
+      for (const g of h.graphemes ?? []) {
         expect([
           's',
           'a',

--- a/src/data/words/filter.ts
+++ b/src/data/words/filter.ts
@@ -1,4 +1,12 @@
-import type { WordFilter, WordHit } from './types';
+import { ALL_REGIONS } from './levels';
+import type {
+  CurriculumEntry,
+  FilterResult,
+  Region,
+  WordCore,
+  WordFilter,
+  WordHit,
+} from './types';
 
 const inRange = (
   n: number,
@@ -55,4 +63,121 @@ export const entryMatches = (
   }
 
   return true;
+};
+
+const coreLoaders = import.meta.glob<{ default: WordCore[] }>(
+  './core/level*.json',
+);
+const ausLoaders = import.meta.glob<{ default: CurriculumEntry[] }>(
+  './curriculum/aus/level*.json',
+);
+const ukLoaders = import.meta.glob<{ default: CurriculumEntry[] }>(
+  './curriculum/uk/level*.json',
+);
+const usLoaders = import.meta.glob<{ default: CurriculumEntry[] }>(
+  './curriculum/us/level*.json',
+);
+const brLoaders = import.meta.glob<{ default: CurriculumEntry[] }>(
+  './curriculum/br/level*.json',
+);
+
+const loadersForRegion = (
+  region: Region,
+): Record<string, () => Promise<{ default: CurriculumEntry[] }>> => {
+  switch (region) {
+    case 'aus': {
+      return ausLoaders;
+    }
+    case 'uk': {
+      return ukLoaders;
+    }
+    case 'us': {
+      return usLoaders;
+    }
+    case 'br': {
+      return brLoaders;
+    }
+  }
+};
+
+let coreCache: Map<string, WordCore> | null = null;
+const curriculumCache: Partial<Record<Region, CurriculumEntry[]>> = {};
+
+export const __resetChunkCacheForTests = (): void => {
+  coreCache = null;
+  for (const r of ALL_REGIONS) delete curriculumCache[r];
+};
+
+const loadCore = async (): Promise<Map<string, WordCore>> => {
+  if (coreCache) return coreCache;
+  const map = new Map<string, WordCore>();
+  const chunks = await Promise.all(
+    Object.values(coreLoaders).map((load) => load()),
+  );
+  for (const chunk of chunks) {
+    for (const entry of chunk.default) map.set(entry.word, entry);
+  }
+  coreCache = map;
+  return map;
+};
+
+const loadCurriculum = async (
+  region: Region,
+): Promise<CurriculumEntry[]> => {
+  if (curriculumCache[region]) return curriculumCache[region];
+  const chunks = await Promise.all(
+    Object.values(loadersForRegion(region)).map((load) => load()),
+  );
+  const flat = chunks.flatMap((c) => c.default);
+  curriculumCache[region] = flat;
+  return flat;
+};
+
+const joinHits = (
+  curriculum: CurriculumEntry[],
+  core: Map<string, WordCore>,
+  region: Region,
+): WordHit[] =>
+  curriculum.flatMap((entry) => {
+    const c = core.get(entry.word);
+    if (!c) return [];
+    return [
+      {
+        word: entry.word,
+        region,
+        level: entry.level,
+        syllableCount: c.syllableCount,
+        syllables: c.syllables,
+        variants: c.variants,
+        ipa: entry.ipa || undefined,
+        graphemes: entry.graphemes,
+      } as WordHit,
+    ];
+  });
+
+export const filterWords = async (
+  filter: WordFilter,
+): Promise<FilterResult> => {
+  const core = await loadCore();
+  const curriculum = await loadCurriculum(filter.region);
+  const hits = joinHits(curriculum, core, filter.region).filter((h) =>
+    entryMatches(h, filter),
+  );
+
+  if (
+    hits.length > 0 ||
+    filter.region === 'aus' ||
+    filter.fallbackToAus === false
+  ) {
+    return { hits };
+  }
+
+  const ausCurriculum = await loadCurriculum('aus');
+  const ausHits = joinHits(ausCurriculum, core, 'aus').filter((h) =>
+    entryMatches(h, { ...filter, region: 'aus' }),
+  );
+  return {
+    hits: ausHits,
+    usedFallback: { from: filter.region, to: 'aus' },
+  };
 };


### PR DESCRIPTION
## Summary

- Adds async `filterWords(filter): Promise<FilterResult>` to `src/data/words/filter.ts`. Lazy-loads chunks via `import.meta.glob` (4 region loaders + 1 core loader), joins `WordCore` + per-region `CurriculumEntry` on `word`, filters via `entryMatches`, and returns the hits.
- AUS fallback: when a non-AUS region returns zero hits and `fallbackToAus !== false`, re-runs the filter against the AUS curriculum and flags `usedFallback: { from, to: 'aus' }` on the result.
- Module-level caches (`coreCache` + `curriculumCache`) make repeat calls idempotent. `__resetChunkCacheForTests` is exported for test isolation.
- Integration tests (5 new) run against the real Task 9 chunks: AUS level-1 hits, join carries `syllableCount`, Tier-2 filter excludes Tier-1-only words, UK→AUS fallback, and `fallbackToAus: false` suppresses fallback.
- Renamed inner loop variables `hit → h` to avoid shadowing the test's `hit()` factory (ESLint `no-shadow`).

## Task

Task 11 of the Phonics Word Library P1 plan. Task 12 builds the `toWordSpellRound` adapter on top of this.

## Verification

- [x] `yarn test src/data/words/filter.test.ts` — 13/13 passing (8 from Task 10 + 5 new)
- [x] Full unit suite — 604/604 passing
- [x] pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)