### PR TITLE
feat(words): task 12 — toWordSpellRound adapter

### DIFF
--- a/src/data/words/adapters.test.ts
+++ b/src/data/words/adapters.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { toWordSpellRound } from './adapters';
+import type { WordHit } from './types';
+
+describe('toWordSpellRound', () => {
+  const base: WordHit = {
+    word: 'cat',
+    region: 'aus',
+    level: 2,
+    syllableCount: 1,
+  };
+
+  it('uses syllables joined by - when present', () => {
+    const round = toWordSpellRound({
+      ...base,
+      word: 'sunset',
+      syllables: ['sun', 'set'],
+      syllableCount: 2,
+    });
+    expect(round.word).toBe('sun-set');
+  });
+
+  it('falls back to raw word when no syllables', () => {
+    expect(toWordSpellRound(base).word).toBe('cat');
+  });
+});

--- a/src/data/words/adapters.ts
+++ b/src/data/words/adapters.ts
@@ -1,0 +1,6 @@
+import type { WordHit } from './types';
+import type { WordSpellRound } from '@/games/word-spell/types';
+
+export const toWordSpellRound = (hit: WordHit): WordSpellRound => ({
+  word: hit.syllables ? hit.syllables.join('-') : hit.word,
+});


### PR DESCRIPTION
## Summary

- Adds `src/data/words/adapters.ts` with `toWordSpellRound(hit): WordSpellRound` — joins syllables with `-` when present, otherwise uses the raw word.
- Adds `src/data/words/adapters.test.ts` with 2 tests covering both branches.

## Task

Task 12 of the Phonics Word Library P1 plan. Task 13 re-exports this from the words barrel.

## Verification

- [x] `yarn test src/data/words/adapters.test.ts` — 2/2 passing
- [x] Full unit suite — 606/606 passing
- [x] pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)