### PR TITLE
feat(word-spell): library-sourced story (Task 17/18)

### DIFF
--- a/src/games/word-spell/WordSpell/WordSpell.stories.tsx
+++ b/src/games/word-spell/WordSpell/WordSpell.stories.tsx
@@ -78,3 +78,28 @@ export const WithDistractors: Story = {
 export const LockManualWrongTile: Story = {
   args: { config: { ...baseConfig, wrongTileBehavior: 'lock-manual' } },
 };
+
+export const LibrarySourced: Story = {
+  args: {
+    config: {
+      gameId: 'word-spell-library-sourced',
+      component: 'WordSpell',
+      inputMethod: 'drag',
+      wrongTileBehavior: 'lock-auto-eject',
+      tileBankMode: 'exact',
+      totalRounds: 4,
+      roundsInOrder: true,
+      ttsEnabled: false,
+      mode: 'recall',
+      tileUnit: 'letter',
+      source: {
+        type: 'word-library',
+        filter: {
+          region: 'aus',
+          levels: [1, 2],
+          syllableCountEq: 1,
+        },
+      },
+    },
+  },
+};

--- a/src/games/word-spell/WordSpell/WordSpell.tsx
+++ b/src/games/word-spell/WordSpell/WordSpell.tsx
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { buildSentenceGapRound } from '../build-sentence-gap-round';
 import { LetterTileBank } from '../LetterTileBank/LetterTileBank';
+import { useLibraryRounds } from '../useLibraryRounds';
 import type { WordSpellConfig } from '../types';
 import type {
   AnswerGameConfig,
@@ -90,11 +91,16 @@ const WordSpellSession = ({
   const navigate = useNavigate();
   const completionToken = useRef(0);
 
+  const rounds = useMemo(
+    () => wordSpellConfig.rounds ?? [],
+    [wordSpellConfig.rounds],
+  );
+
   const configRoundIndex = roundOrder[roundIndex];
   const round =
     configRoundIndex === undefined
       ? undefined
-      : wordSpellConfig.rounds[configRoundIndex];
+      : rounds[configRoundIndex];
 
   useRoundTTS(round?.word ?? '');
 
@@ -127,7 +133,7 @@ const WordSpellSession = ({
       const nextRound =
         nextConfigIndex === undefined
           ? undefined
-          : wordSpellConfig.rounds[nextConfigIndex];
+          : rounds[nextConfigIndex];
       const word = nextRound?.word.trim() ?? '';
       if (!word) {
         dispatch({ type: 'COMPLETE_GAME' });
@@ -161,7 +167,7 @@ const WordSpellSession = ({
     roundIndex,
     dispatch,
     roundOrder,
-    wordSpellConfig.rounds,
+    rounds,
     wordSpellConfig.tileUnit,
   ]);
 
@@ -238,66 +244,84 @@ export const WordSpell = ({
   sessionId,
   seed,
 }: WordSpellProps) => {
-  const roundsInOrder = config.roundsInOrder === true;
+  const { rounds: resolvedRounds, isLoading } =
+    useLibraryRounds(config);
+
+  const resolvedConfig = useMemo<WordSpellConfig>(
+    () => ({ ...config, rounds: resolvedRounds }),
+    [config, resolvedRounds],
+  );
+
+  const roundsInOrder = resolvedConfig.roundsInOrder === true;
   const [sessionEpoch, setSessionEpoch] = useState(0);
 
   const roundOrder = useMemo(() => {
     void sessionEpoch;
-    return buildRoundOrder(config.rounds.length, roundsInOrder, seed);
-  }, [config.rounds.length, roundsInOrder, seed, sessionEpoch]);
+    return buildRoundOrder(resolvedRounds.length, roundsInOrder, seed);
+  }, [resolvedRounds.length, roundsInOrder, seed, sessionEpoch]);
 
   const firstConfigIndex = roundOrder[0];
   const round0 =
     firstConfigIndex === undefined
       ? undefined
-      : config.rounds[firstConfigIndex];
+      : resolvedRounds[firstConfigIndex];
   const roundWord = round0?.word.trim() ? round0.word : '';
 
   const { tiles, zones } = useMemo(() => {
     if (!roundWord)
       return { tiles: [] as TileItem[], zones: [] as AnswerZone[] };
 
-    // Sentence-gap with gaps array
     if (round0?.gaps && round0.gaps.length > 0) {
       return buildSentenceGapRound(round0.gaps);
     }
 
-    // Default: letter/syllable/word spelling
-    return buildTilesAndZones(roundWord, config.tileUnit);
-  }, [roundWord, config.tileUnit, round0]);
+    return buildTilesAndZones(roundWord, resolvedConfig.tileUnit);
+  }, [roundWord, resolvedConfig.tileUnit, round0]);
 
   const answerGameConfig = useMemo(
     (): AnswerGameConfig => ({
-      gameId: config.gameId,
-      inputMethod: config.inputMethod,
-      wrongTileBehavior: config.wrongTileBehavior,
-      tileBankMode: config.tileBankMode,
-      distractorCount: config.distractorCount,
-      totalRounds: config.rounds.length,
-      roundsInOrder: config.roundsInOrder,
-      ttsEnabled: config.ttsEnabled,
+      gameId: resolvedConfig.gameId,
+      inputMethod: resolvedConfig.inputMethod,
+      wrongTileBehavior: resolvedConfig.wrongTileBehavior,
+      tileBankMode: resolvedConfig.tileBankMode,
+      distractorCount: resolvedConfig.distractorCount,
+      totalRounds: resolvedRounds.length,
+      roundsInOrder: resolvedConfig.roundsInOrder,
+      ttsEnabled: resolvedConfig.ttsEnabled,
       touchKeyboardInputMode: 'text',
       initialTiles: tiles,
       initialZones: zones,
       slotInteraction:
-        config.mode === 'scramble' || config.mode === 'sentence-gap'
+        resolvedConfig.mode === 'scramble' ||
+        resolvedConfig.mode === 'sentence-gap'
           ? 'free-swap'
           : 'ordered',
     }),
     [
-      config.gameId,
-      config.inputMethod,
-      config.wrongTileBehavior,
-      config.tileBankMode,
-      config.distractorCount,
-      config.rounds.length,
-      config.roundsInOrder,
-      config.ttsEnabled,
-      config.mode,
+      resolvedConfig.gameId,
+      resolvedConfig.inputMethod,
+      resolvedConfig.wrongTileBehavior,
+      resolvedConfig.tileBankMode,
+      resolvedConfig.distractorCount,
+      resolvedRounds.length,
+      resolvedConfig.roundsInOrder,
+      resolvedConfig.ttsEnabled,
+      resolvedConfig.mode,
       tiles,
       zones,
     ],
   );
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        className="flex min-h-[200px] w-full items-center justify-center text-foreground"
+      >
+        Loading words…
+      </div>
+    );
+  }
 
   if (!round0) return null;
 
@@ -309,7 +333,7 @@ export const WordSpell = ({
       sessionId={sessionId}
     >
       <WordSpellSession
-        wordSpellConfig={config}
+        wordSpellConfig={resolvedConfig}
         roundOrder={roundOrder}
         onRestartSession={() => {
           setSessionEpoch((e) => e + 1);

--- a/src/games/word-spell/types.ts
+++ b/src/games/word-spell/types.ts
@@ -1,4 +1,5 @@
 import type { AnswerGameConfig } from '@/components/answer-game/types';
+import type { WordSpellSource } from '@/data/words';
 import type { ConfigField } from '@/lib/config-fields';
 
 export interface GapDefinition {
@@ -29,7 +30,10 @@ export interface WordSpellConfig extends AnswerGameConfig {
   mode: 'picture' | 'scramble' | 'recall' | 'sentence-gap';
   /** @default 'letter' */
   tileUnit: 'letter' | 'syllable' | 'word';
-  rounds: WordSpellRound[];
+  /** Explicit hand-authored rounds. Wins over `source` when both are present. */
+  rounds?: WordSpellRound[];
+  /** Library-driven rounds. Resolved at WordSpell mount time. */
+  source?: WordSpellSource;
 }
 
 export const wordSpellConfigFields: ConfigField[] = [

--- a/src/games/word-spell/useLibraryRounds.test.tsx
+++ b/src/games/word-spell/useLibraryRounds.test.tsx
@@ -1,0 +1,95 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useLibraryRounds } from './useLibraryRounds';
+import type { WordSpellConfig } from './types';
+import { __resetChunkCacheForTests } from '@/data/words';
+
+const baseConfig: WordSpellConfig = {
+  gameId: 'test',
+  component: 'WordSpell',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 3,
+  roundsInOrder: true,
+  ttsEnabled: false,
+  mode: 'picture',
+  tileUnit: 'letter',
+};
+
+afterEach(() => __resetChunkCacheForTests());
+
+describe('useLibraryRounds', () => {
+  it('returns explicit rounds synchronously when source is absent', () => {
+    const rounds = [{ word: 'cat' }, { word: 'dog' }];
+    const { result } = renderHook(() =>
+      useLibraryRounds({ ...baseConfig, rounds }),
+    );
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.rounds).toBe(rounds);
+  });
+
+  it('returns empty rounds when neither rounds nor source is set', () => {
+    const { result } = renderHook(() => useLibraryRounds(baseConfig));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.rounds).toEqual([]);
+  });
+
+  it('resolves library rounds from a filter when source is set', async () => {
+    const config: WordSpellConfig = {
+      ...baseConfig,
+      totalRounds: 3,
+      source: {
+        type: 'word-library',
+        filter: { region: 'aus', level: 1 },
+      },
+    };
+    const { result } = renderHook(() => useLibraryRounds(config));
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.rounds).toHaveLength(3);
+    for (const r of result.current.rounds) {
+      expect(r.word).toBeDefined();
+    }
+  });
+
+  it('respects explicit source.limit over totalRounds', async () => {
+    const config: WordSpellConfig = {
+      ...baseConfig,
+      totalRounds: 10,
+      source: {
+        type: 'word-library',
+        filter: { region: 'aus', level: 1 },
+        limit: 2,
+      },
+    };
+    const { result } = renderHook(() => useLibraryRounds(config));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.rounds).toHaveLength(2);
+  });
+
+  it('surfaces usedFallback when the filter falls back to AUS', async () => {
+    const config: WordSpellConfig = {
+      ...baseConfig,
+      totalRounds: 3,
+      source: {
+        type: 'word-library',
+        filter: { region: 'uk', level: 1 },
+      },
+    };
+    const { result } = renderHook(() => useLibraryRounds(config));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.usedFallback).toEqual({
+      from: 'uk',
+      to: 'aus',
+    });
+  });
+});

--- a/src/games/word-spell/useLibraryRounds.ts
+++ b/src/games/word-spell/useLibraryRounds.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import type { WordSpellConfig, WordSpellRound } from './types';
+import type { Region } from '@/data/words';
+import { filterWords, toWordSpellRound } from '@/data/words';
+
+interface LibraryRoundsState {
+  rounds: WordSpellRound[];
+  isLoading: boolean;
+  usedFallback?: { from: Region; to: 'aus' };
+}
+
+const initialStateFor = (
+  config: WordSpellConfig,
+): LibraryRoundsState => {
+  if (config.source) return { rounds: [], isLoading: true };
+  return { rounds: config.rounds ?? [], isLoading: false };
+};
+
+export const useLibraryRounds = (
+  config: WordSpellConfig,
+): LibraryRoundsState => {
+  const [state, setState] = useState<LibraryRoundsState>(() =>
+    initialStateFor(config),
+  );
+
+  useEffect(() => {
+    if (config.rounds && config.rounds.length > 0) {
+      const explicit = config.rounds;
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- sync state when config transitions to explicit rounds; bail-out updater is a no-op when already in sync
+      setState((prev) =>
+        prev.rounds === explicit &&
+        !prev.isLoading &&
+        prev.usedFallback === undefined
+          ? prev
+          : { rounds: explicit, isLoading: false },
+      );
+      return;
+    }
+
+    const source = config.source;
+    if (!source) {
+      setState((prev) =>
+        prev.rounds.length === 0 &&
+        !prev.isLoading &&
+        prev.usedFallback === undefined
+          ? prev
+          : { rounds: [], isLoading: false },
+      );
+      return;
+    }
+
+    const cancellation = { isCancelled: false };
+
+    setState((prev) =>
+      prev.isLoading ? prev : { ...prev, isLoading: true },
+    );
+
+    void (async () => {
+      const result = await filterWords(source.filter);
+      if (cancellation.isCancelled) return;
+      const limit = source.limit ?? config.totalRounds;
+      const picked = result.hits
+        .slice(0, limit)
+        .map((hit) => toWordSpellRound(hit));
+      setState({
+        rounds: picked,
+        isLoading: false,
+        usedFallback: result.usedFallback,
+      });
+    })();
+
+    return () => {
+      cancellation.isCancelled = true;
+    };
+  }, [config.rounds, config.source, config.totalRounds]);
+
+  return state;
+};

--- a/src/routes/$locale/_app/game/$gameId.tsx
+++ b/src/routes/$locale/_app/game/$gameId.tsx
@@ -189,7 +189,9 @@ const resolveWordSpellConfig = (
 ): WordSpellConfig => {
   const base: WordSpellConfig = {
     ...DEFAULT_WORD_SPELL_CONFIG,
-    rounds: DEFAULT_WORD_SPELL_CONFIG.rounds.map((r) => ({ ...r })),
+    rounds: (DEFAULT_WORD_SPELL_CONFIG.rounds ?? []).map((r) => ({
+      ...r,
+    })),
   };
   if (!saved || saved.component !== 'WordSpell') return base;
   const merged: WordSpellConfig = {


### PR DESCRIPTION
## Summary

- Adds a `LibrarySourced` Storybook story to `WordSpell.stories.tsx` demonstrating the library-driven rounds path via `config.source` (feeds through `useLibraryRounds` → `filterWords` → `toWordSpellRound`).
- Stacked on Tasks 14-16 (#83). Final integration story for the P1 word library work.

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test` — full suite
- [x] Storybook renders the story against real chunks
