### PR TITLE
ci: run all workflows on every PR regardless of base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
   schedule:
     - cron: '0 0 * * 0' # weekly — Sunday at 00:00 UTC
   workflow_dispatch:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -5,7 +5,6 @@ name: PR Preview
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [master]
 
 concurrency:
   group: pr-preview-${{ github.event.pull_request.number }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -4,7 +4,6 @@ name: Visual Regression
 
 on:
   pull_request:
-    branches: [master]
   workflow_dispatch:
     inputs:
       update_snapshots:


### PR DESCRIPTION
## Summary

- Removed `branches: [master]` filter from the `pull_request` trigger in `ci.yml`, `e2e.yml`, `pr-preview.yml`, and `visual-regression.yml`
- All PRs now get CI checks, E2E tests, VR tests, and a live preview — regardless of their base branch
- `deploy.yml` (production deploy) is unchanged — still only fires on merge to master

## Test plan

- [ ] Open a PR targeting a non-master branch and verify CI, E2E, VR, and PR Preview workflows trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)