### PR TITLE
feat(words): levels + phoneme code tables (Task 2/18)

### DIFF
--- a/src/data/words/levels.ts
+++ b/src/data/words/levels.ts
@@ -1,0 +1,155 @@
+// src/data/words/levels.ts
+import type { Region } from './types';
+
+export const ALL_REGIONS: readonly Region[] = ['aus', 'uk', 'us', 'br'];
+
+export const LEVEL_LABELS: Record<Region, (level: number) => string> = {
+  aus: (n) => `Level ${n}`,
+  uk: (n) => `Phase ${n}`,
+  us: (n) => `K Unit ${n}`,
+  br: (n) => `Unidade ${n}`,
+};
+
+/**
+ * A single grapheme-phoneme pairing taught at a given level. A grapheme like
+ * `c` appears twice across the AUS progression — once at level 2 teaching /k/,
+ * once at level 4 teaching /s/. Modelling each as its own unit keeps both
+ * variants addressable in the cumulative pool and in filter queries.
+ */
+export interface LevelGraphemeUnit {
+  /** Orthographic form: `c`, `sh`, `igh`, `a_e`. */
+  g: string;
+  /** IPA of the sound this unit teaches at this level: `k`, `s`, `ʃ`, `aɪ`. */
+  p: string;
+  /** Optional teacher label: `soft c`, `th voiced`. */
+  name?: string;
+}
+
+/**
+ * Grapheme-phoneme units newly introduced at each level of the AUS
+ * progression. Source:
+ * docs/superpowers/plans/2026-04-11-phonic-word-library_words-list.md
+ * Cumulative sets use `cumulativeGraphemes(level)` below.
+ */
+export const GRAPHEMES_BY_LEVEL: Record<
+  number,
+  readonly LevelGraphemeUnit[]
+> = {
+  1: [
+    { g: 's', p: 's' },
+    { g: 'a', p: 'æ' },
+    { g: 't', p: 't' },
+    { g: 'p', p: 'p' },
+    { g: 'i', p: 'ɪ' },
+    { g: 'n', p: 'n' },
+  ],
+  2: [
+    { g: 'm', p: 'm' },
+    { g: 'd', p: 'd' },
+    { g: 'g', p: 'g' },
+    { g: 'o', p: 'ɒ' },
+    { g: 'c', p: 'k' },
+    { g: 'k', p: 'k' },
+    { g: 'ck', p: 'k' },
+    { g: 'e', p: 'e' },
+    { g: 'u', p: 'ʌ' },
+    { g: 'r', p: 'r' },
+  ],
+  3: [
+    { g: 'b', p: 'b' },
+    { g: 'h', p: 'h' },
+    { g: 'f', p: 'f' },
+    { g: 'l', p: 'l' },
+    { g: 'j', p: 'dʒ' },
+    { g: 'v', p: 'v' },
+    { g: 'w', p: 'w' },
+    { g: 'x', p: 'ks' },
+    { g: 'y', p: 'j' },
+    { g: 'z', p: 'z' },
+  ],
+  4: [
+    { g: 'sh', p: 'ʃ' },
+    { g: 'ch', p: 'tʃ' },
+    { g: 'th', p: 'θ', name: 'th voiceless' },
+    { g: 'th', p: 'ð', name: 'th voiced' },
+    { g: 'qu', p: 'kw' },
+    { g: 'ng', p: 'ŋ' },
+    { g: 'wh', p: 'w' },
+    { g: 'ph', p: 'f' },
+    { g: 'g', p: 'dʒ', name: 'soft g' },
+    { g: 'c', p: 's', name: 'soft c' },
+  ],
+  5: [
+    { g: 'ai', p: 'eɪ' },
+    { g: 'ay', p: 'eɪ' },
+    { g: 'ea', p: 'iː' },
+    { g: 'ee', p: 'iː' },
+    { g: 'ie', p: 'aɪ' },
+    { g: 'igh', p: 'aɪ' },
+    { g: 'oa', p: 'oʊ' },
+    { g: 'ow', p: 'oʊ' },
+    { g: 'ew', p: 'juː' },
+    { g: 'ue', p: 'juː' },
+  ],
+  6: [
+    { g: 'oi', p: 'ɔɪ' },
+    { g: 'oy', p: 'ɔɪ' },
+    { g: 'oo', p: 'uː', name: 'oo long' },
+    { g: 'oo', p: 'ʊ', name: 'oo short' },
+    { g: 'ou', p: 'aʊ' },
+    { g: 'er', p: 'ɜː' },
+    { g: 'ir', p: 'ɜː' },
+    { g: 'ur', p: 'ɜː' },
+    { g: 'ar', p: 'ɑː' },
+    { g: 'or', p: 'ɔː' },
+  ],
+  7: [
+    { g: 'a_e', p: 'eɪ' },
+    { g: 'e_e', p: 'iː' },
+    { g: 'i_e', p: 'aɪ' },
+    { g: 'o_e', p: 'oʊ' },
+    { g: 'u_e', p: 'juː' },
+  ],
+  8: [
+    { g: 'aw', p: 'ɔː' },
+    { g: 'air', p: 'eə' },
+    { g: 'are', p: 'eə' },
+    { g: 'ear', p: 'ɪə' },
+    { g: 'eer', p: 'ɪə' },
+    { g: 'ore', p: 'ɔː' },
+    { g: 'dge', p: 'dʒ' },
+    { g: 'tch', p: 'tʃ' },
+  ],
+};
+
+/**
+ * Returns all LevelGraphemeUnits introduced at or before `level`, preserving
+ * introduction order and keeping multiple variants of the same orthography
+ * (e.g. both `c=/k/` and `c=/s/` at level 4+).
+ */
+export const cumulativeGraphemes = (
+  level: number,
+): LevelGraphemeUnit[] => {
+  const out: LevelGraphemeUnit[] = [];
+  const seen = new Set<string>();
+  for (let l = 1; l <= level; l++) {
+    for (const unit of GRAPHEMES_BY_LEVEL[l] ?? []) {
+      const key = `${unit.g}|${unit.p}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(unit);
+    }
+  }
+  return out;
+};
+
+/**
+ * Deduped orthographic pool for structural word splitting. Used by
+ * `makeGraphemes` — the splitter only needs to know which grapheme forms
+ * exist, not which phoneme each one teaches.
+ */
+export const graphemePool = (level: number): string[] => {
+  const seen = new Set<string>();
+  for (const unit of cumulativeGraphemes(level)) seen.add(unit.g);
+  return [...seen];
+};

--- a/src/data/words/phoneme-codes.ts
+++ b/src/data/words/phoneme-codes.ts
@@ -1,0 +1,22 @@
+// src/data/words/phoneme-codes.ts
+
+/** Teacher-friendly codes → IPA. Used by filter UIs that prefer plain text. */
+export const PHONEME_CODE_TO_IPA: Record<string, string> = {
+  sh: 'ʃ',
+  ch: 'tʃ',
+  th_voiceless: 'θ',
+  th_voiced: 'ð',
+  ng: 'ŋ',
+  zh: 'ʒ',
+  oo_long: 'uː',
+  oo_short: 'ʊ',
+  schwa: 'ə',
+};
+
+export const IPA_TO_PHONEME_CODE: Record<string, string> =
+  Object.fromEntries(
+    Object.entries(PHONEME_CODE_TO_IPA).map(([code, ipa]) => [
+      ipa,
+      code,
+    ]),
+  );


### PR DESCRIPTION
## Summary

- Adds `src/data/words/levels.ts` — AUS curriculum progression (`GRAPHEMES_BY_LEVEL` for levels 1–8), `LevelGraphemeUnit`, `cumulativeGraphemes(level)` (dedups on `g|p` so both `c=/k/` and `c=/s/` survive), `graphemePool(level)` for the structural splitter, `ALL_REGIONS`, and per-region `LEVEL_LABELS` formatters.
- Adds `src/data/words/phoneme-codes.ts` — teacher-friendly code↔IPA lookup.
- Foundation for Tasks 3–5 (builders), Task 4's grapheme splitter, and the filter in Tasks 10–11.

Reopened after rebase onto master; replaces the closed #56 (orphaned after history rewrite).

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test` — full suite
