### PR TITLE
feat(words): makeGraphemes longest-match splitter (Task 4/18)

### DIFF
--- a/src/data/words/builders.test.ts
+++ b/src/data/words/builders.test.ts
@@ -1,6 +1,7 @@
 // src/data/words/builders.test.ts
 import { describe, expect, it } from 'vitest';
-import { makeWordCore } from './builders';
+import { makeGraphemes, makeWordCore } from './builders';
+import { graphemePool } from './levels';
 
 describe('makeWordCore', () => {
   it('counts one syllable for simple CVC', () => {
@@ -38,5 +39,63 @@ describe('makeWordCore', () => {
   it('records variants when provided', () => {
     const result = makeWordCore('colour', { variants: ['color'] });
     expect(result.variants).toEqual(['color']);
+  });
+});
+
+describe('makeGraphemes', () => {
+  // graphemePool dedupes the orthographic forms; the phoneme each form
+  // teaches at its level comes from GRAPHEMES_BY_LEVEL itself and is not
+  // needed by the structural splitter.
+  const L2 = graphemePool(2);
+  const L4 = graphemePool(4);
+
+  it('splits simple CVC letter-by-letter', () => {
+    const result = makeGraphemes('cat', L2);
+    expect(result).not.toBeNull();
+    expect(result!.map((x) => x.g)).toEqual(['c', 'a', 't']);
+  });
+
+  it('prefers longest match (ck over c+k)', () => {
+    const result = makeGraphemes('pack', L2);
+    expect(result).not.toBeNull();
+    expect(result!.map((x) => x.g)).toEqual(['p', 'a', 'ck']);
+  });
+
+  it('recognises sh as a single grapheme', () => {
+    const result = makeGraphemes('ship', L4);
+    expect(result).not.toBeNull();
+    expect(result!.map((x) => x.g)).toEqual(['sh', 'i', 'p']);
+  });
+
+  it('recognises th + ng in thing', () => {
+    const result = makeGraphemes('thing', L4);
+    expect(result).not.toBeNull();
+    expect(result!.map((x) => x.g)).toEqual(['th', 'i', 'ng']);
+  });
+
+  it('populates phonemes from phonemeByGrapheme map', () => {
+    const result = makeGraphemes('ship', L4, {
+      sh: 'ʃ',
+      i: 'ɪ',
+      p: 'p',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.map((x) => x.p)).toEqual(['ʃ', 'ɪ', 'p']);
+  });
+
+  it('leaves phonemes blank when no map supplied', () => {
+    const result = makeGraphemes('cat', L2);
+    expect(result!.map((x) => x.p)).toEqual(['', '', '']);
+  });
+
+  it('returns null when a letter is outside the level grapheme set', () => {
+    expect(makeGraphemes('zip', L2)).toBeNull();
+  });
+
+  it('invariant: graphemes concat equals word', () => {
+    for (const word of ['cat', 'ship', 'thing', 'pack']) {
+      const result = makeGraphemes(word, L4);
+      expect(result!.map((g) => g.g).join('')).toBe(word);
+    }
   });
 });

--- a/src/data/words/builders.ts
+++ b/src/data/words/builders.ts
@@ -1,5 +1,5 @@
 // src/data/words/builders.ts
-import type { WordCore } from './types';
+import type { Grapheme, WordCore } from './types';
 
 /**
  * Counts syllables via vowel-group heuristic with silent-e subtraction.
@@ -13,6 +13,47 @@ const countSyllables = (word: string): number => {
     count -= 1;
   }
   return Math.max(count, 1);
+};
+
+/**
+ * Longest-match-first split of `word` into graphemes drawn from
+ * `levelGraphemes`. Returns null if the word contains a character sequence
+ * that can't be explained by any grapheme in the set.
+ * Case-insensitive on the input; output preserves lowercase.
+ */
+export const makeGraphemes = (
+  word: string,
+  levelGraphemes: readonly string[],
+  phonemeByGrapheme?: Record<string, string>,
+): Grapheme[] | null => {
+  const lower = word.toLowerCase();
+  // Sort by length desc so the greedy scan prefers digraphs/trigraphs.
+  const sorted = [...levelGraphemes].toSorted(
+    (a, b) => b.length - a.length,
+  );
+  const graphemes: Grapheme[] = [];
+  let i = 0;
+
+  while (i < lower.length) {
+    let matched: string | null = null;
+    for (const g of sorted) {
+      // Split digraph notation like 'a_e' isn't a contiguous substring
+      // at codegen time — we handle those in a dedicated step (Task 6).
+      if (g.includes('_')) continue;
+      if (lower.startsWith(g, i)) {
+        matched = g;
+        break;
+      }
+    }
+    if (matched === null) return null;
+    graphemes.push({
+      g: matched,
+      p: phonemeByGrapheme?.[matched] ?? '',
+    });
+    i += matched.length;
+  }
+
+  return graphemes;
 };
 
 export const makeWordCore = (


### PR DESCRIPTION
## Summary

- Adds `makeGraphemes(word, levelGraphemes, phonemeByGrapheme?)` to `src/data/words/builders.ts` — longest-match-first structural splitter. Sorts the grapheme pool by length descending, greedily scans the word, returns `Grapheme[]` or `null` on an unmatchable character. Skips grapheme forms containing `_` (split digraphs like `a_e`) — those are handled later in the writer module.
- Adds 8 Vitest cases: CVC split, `ck` longest-match preference, digraphs (`sh`, `th`, `ng`), phoneme-map injection, empty-phoneme default, null on out-of-set, and a concat invariant.
- Stacked on Task 3. 14/14 builder tests green.

Replaces the closed #58 (orphaned after history rewrite).

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test` — full suite
