### PR TITLE
feat(words): pure writer helpers (Task 6/18)

### DIFF
--- a/src/data/words/writer.test.ts
+++ b/src/data/words/writer.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  removeCurriculumEntry,
+  removeWordCore,
+  upsertCurriculumEntry,
+  upsertWordCore,
+} from './writer';
+import type { CurriculumEntry, WordCore } from './types';
+
+const e = (word: string, level: number): CurriculumEntry => ({
+  word,
+  level,
+  ipa: word,
+  graphemes: [...word].map((c) => ({ g: c, p: '' })),
+});
+
+const c = (word: string): WordCore => ({ word, syllableCount: 1 });
+
+describe('upsertCurriculumEntry', () => {
+  it('appends a new entry to an empty chunk', () => {
+    const next = upsertCurriculumEntry([], e('cat', 2));
+    expect(next).toHaveLength(1);
+    expect(next[0]!.word).toBe('cat');
+  });
+
+  it('replaces an existing entry matched by word', () => {
+    const before = [e('cat', 2)];
+    const updated = { ...e('cat', 2), ipa: 'kæt' };
+    const after = upsertCurriculumEntry(before, updated);
+    expect(after).toHaveLength(1);
+    expect(after[0]!.ipa).toBe('kæt');
+  });
+
+  it('sorts alphabetically so output is deterministic', () => {
+    const chunk = upsertCurriculumEntry(
+      [e('pin', 2), e('cat', 2)],
+      e('bat', 2),
+    );
+    expect(chunk.map((x) => x.word)).toEqual(['bat', 'cat', 'pin']);
+  });
+});
+
+describe('removeCurriculumEntry', () => {
+  it('removes a matching word', () => {
+    const chunk = [e('cat', 2), e('dog', 2)];
+    const after = removeCurriculumEntry(chunk, 'cat');
+    expect(after.map((x) => x.word)).toEqual(['dog']);
+  });
+
+  it('is idempotent when the word is absent', () => {
+    const chunk = [e('cat', 2)];
+    const after = removeCurriculumEntry(chunk, 'zebra');
+    expect(after).toEqual(chunk);
+  });
+});
+
+describe('upsertWordCore + removeWordCore', () => {
+  it('upserts by word', () => {
+    const chunk = upsertWordCore([c('cat')], {
+      ...c('cat'),
+      syllables: ['cat'],
+    });
+    expect(chunk[0]!.syllables).toEqual(['cat']);
+  });
+
+  it('removes by word', () => {
+    const chunk = removeWordCore([c('cat'), c('dog')], 'cat');
+    expect(chunk.map((x) => x.word)).toEqual(['dog']);
+  });
+});

--- a/src/data/words/writer.ts
+++ b/src/data/words/writer.ts
@@ -1,0 +1,33 @@
+import type { CurriculumEntry, WordCore } from './types';
+
+const byWord = <T extends { word: string }>(a: T, b: T): number =>
+  a.word.localeCompare(b.word);
+
+export const upsertCurriculumEntry = (
+  chunk: readonly CurriculumEntry[],
+  entry: CurriculumEntry,
+): CurriculumEntry[] => {
+  const next = chunk.filter((e) => e.word !== entry.word);
+  next.push(entry);
+  return next.toSorted(byWord);
+};
+
+export const removeCurriculumEntry = (
+  chunk: readonly CurriculumEntry[],
+  word: string,
+): CurriculumEntry[] =>
+  chunk.filter((e) => e.word !== word).toSorted(byWord);
+
+export const upsertWordCore = (
+  chunk: readonly WordCore[],
+  entry: WordCore,
+): WordCore[] => {
+  const next = chunk.filter((e) => e.word !== entry.word);
+  next.push(entry);
+  return next.toSorted(byWord);
+};
+
+export const removeWordCore = (
+  chunk: readonly WordCore[],
+  word: string,
+): WordCore[] => chunk.filter((e) => e.word !== word).toSorted(byWord);

--- a/src/data/words/writer.ts
+++ b/src/data/words/writer.ts
@@ -1,7 +1,7 @@
 import type { CurriculumEntry, WordCore } from './types';
 
 const byWord = <T extends { word: string }>(a: T, b: T): number =>
-  a.word.localeCompare(b.word);
+  a.word.localeCompare(b.word, 'en');
 
 export const upsertCurriculumEntry = (
   chunk: readonly CurriculumEntry[],


### PR DESCRIPTION
## Summary

- Adds `src/data/words/writer.ts` with four pure helpers — `upsertCurriculumEntry`, `removeCurriculumEntry`, `upsertWordCore`, `removeWordCore`. Each accepts a `readonly` chunk and returns a new alphabetically-sorted array. No I/O, no input mutation — Task 8's codegen script composes these into deterministic JSON chunks.
- Adds `src/data/words/writer.test.ts` with 7 Vitest cases covering append, replace, sort order, remove, and idempotent-remove.
- Follow-up commit pins the sort locale to `'en'` so JSON output is deterministic across developer machines and CI containers.
- Stacked on Task 5.

Replaces the closed #60 (orphaned after history rewrite).

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test` — full suite
