### PR TITLE
feat(words): toWordSpellRound adapter (Task 12/18)

### DIFF
--- a/src/data/words/adapters.test.ts
+++ b/src/data/words/adapters.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { toWordSpellRound } from './adapters';
+import type { WordHit } from './types';
+
+describe('toWordSpellRound', () => {
+  const base: WordHit = {
+    word: 'cat',
+    region: 'aus',
+    level: 2,
+    syllableCount: 1,
+  };
+
+  it('uses syllables joined by - when present', () => {
+    const round = toWordSpellRound({
+      ...base,
+      word: 'sunset',
+      syllables: ['sun', 'set'],
+      syllableCount: 2,
+    });
+    expect(round.word).toBe('sun-set');
+  });
+
+  it('falls back to raw word when no syllables', () => {
+    expect(toWordSpellRound(base).word).toBe('cat');
+  });
+});

--- a/src/data/words/adapters.ts
+++ b/src/data/words/adapters.ts
@@ -1,0 +1,6 @@
+import type { WordHit } from './types';
+import type { WordSpellRound } from '@/games/word-spell/types';
+
+export const toWordSpellRound = (hit: WordHit): WordSpellRound => ({
+  word: hit.syllables ? hit.syllables.join('-') : hit.word,
+});


### PR DESCRIPTION
## Summary

- Adds `src/data/words/adapters.ts` with `toWordSpellRound(hit): WordSpellRound` — joins syllables with `-` when present, otherwise uses the raw word.
- Adds `src/data/words/adapters.test.ts` with 2 tests covering both branches.

Stacked on Task 11. Task 13 re-exports this from the words barrel.

Replaces the closed #66 (orphaned after history rewrite).

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test` — full suite
