### PR TITLE
feat(words): public API barrel (Task 13/18)

### DIFF
--- a/src/data/words/index.ts
+++ b/src/data/words/index.ts
@@ -1,0 +1,41 @@
+export type {
+  CurriculumEntry,
+  FilterResult,
+  Grapheme,
+  Region,
+  ValidationError,
+  WordCore,
+  WordFilter,
+  WordHit,
+  WordSpellSource,
+} from './types';
+export type { LevelGraphemeUnit } from './levels';
+export {
+  ALL_REGIONS,
+  cumulativeGraphemes,
+  GRAPHEMES_BY_LEVEL,
+  graphemePool,
+  LEVEL_LABELS,
+} from './levels';
+export {
+  IPA_TO_PHONEME_CODE,
+  PHONEME_CODE_TO_IPA,
+} from './phoneme-codes';
+export {
+  makeCurriculumEntry,
+  makeGraphemes,
+  makeWordCore,
+  validateEntry,
+} from './builders';
+export {
+  removeCurriculumEntry,
+  removeWordCore,
+  upsertCurriculumEntry,
+  upsertWordCore,
+} from './writer';
+export {
+  __resetChunkCacheForTests,
+  entryMatches,
+  filterWords,
+} from './filter';
+export { toWordSpellRound } from './adapters';


### PR DESCRIPTION
## Summary

- Adds `src/data/words/index.ts` — single barrel re-exporting the public surface of the words module: types, level metadata, phoneme code maps, builders, writer helpers, filter (+ `__resetChunkCacheForTests` for tests), and the `toWordSpellRound` adapter.
- Consumers (Tasks 14-17 WordSpell integration) can import everything from `@/data/words` instead of reaching into individual files.

Stacked on Task 12. Unblocks Tasks 14-17 (bundled WordSpell integration).

Replaces the closed #67 (orphaned after history rewrite).

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test` — full suite
