### PR TITLE
fix(touch-drag): clear drag state when bank tile released back onto bank

### DIFF
--- a/src/components/answer-game/useDraggableTile.test.tsx
+++ b/src/components/answer-game/useDraggableTile.test.tsx
@@ -48,14 +48,39 @@ vi.mock('./useAnswerGameContext', () => ({
   }),
 }));
 
+const mockDispatch = vi.fn();
+
 vi.mock('./useAnswerGameDispatch', () => ({
-  useAnswerGameDispatch: () => vi.fn(),
+  useAnswerGameDispatch: () => mockDispatch,
 }));
 
 const mockPlaceTile = vi.fn();
 
 vi.mock('./useTileEvaluation', () => ({
   useTileEvaluation: () => ({ placeTile: mockPlaceTile }),
+}));
+
+// Capture the options passed to useTouchDrag so tests can invoke the touch
+// callbacks directly without simulating real pointer events.
+type CapturedTouchDragOptions = {
+  onDropOnBank?: () => void;
+  onDropOnBankTile?: (bankTileId: string) => void;
+};
+
+let capturedTouchDragOptions: CapturedTouchDragOptions | null = null;
+
+vi.mock('./useTouchDrag', () => ({
+  useTouchDrag: vi
+    .fn()
+    .mockImplementation((opts: CapturedTouchDragOptions) => {
+      capturedTouchDragOptions = opts;
+      return {
+        onPointerDown: vi.fn(),
+        onPointerMove: vi.fn(),
+        onPointerUp: vi.fn(),
+        onPointerCancel: vi.fn(),
+      };
+    }),
 }));
 
 const providerConfig: AnswerGameConfig = {
@@ -124,5 +149,46 @@ describe('useDraggableTile', () => {
       onDragEnter: () => void;
     };
     expect(typeof dropArgs.onDragEnter).toBe('function');
+  });
+
+  describe('touch drag — onDropOnBank', () => {
+    it('clears drag state when bank tile is released back onto the bank', () => {
+      // Regression: dragging a bank tile a few pixels then releasing within the
+      // bank left dragActiveTileId set, making the tile permanently faded and
+      // uninteractable. onDropOnBank must reset the active drag state.
+      capturedTouchDragOptions = null;
+      mockDispatch.mockClear();
+
+      renderHook(() => useDraggableTile(tile));
+
+      expect(capturedTouchDragOptions?.onDropOnBank).toBeDefined();
+      act(() => capturedTouchDragOptions?.onDropOnBank?.());
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_DRAG_ACTIVE',
+        tileId: null,
+      });
+    });
+  });
+
+  describe('touch drag — onDropOnBankTile', () => {
+    it('clears drag state when bank tile is dropped onto another bank tile hole', () => {
+      // Same regression path — dropping on a bank tile hole also left
+      // dragActiveTileId set when onDropOnBankTile was not provided.
+      capturedTouchDragOptions = null;
+      mockDispatch.mockClear();
+
+      renderHook(() => useDraggableTile(tile));
+
+      expect(capturedTouchDragOptions?.onDropOnBankTile).toBeDefined();
+      act(() =>
+        capturedTouchDragOptions?.onDropOnBankTile?.('other-tile'),
+      );
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_DRAG_ACTIVE',
+        tileId: null,
+      });
+    });
   });
 });

--- a/src/components/answer-game/useDraggableTile.test.tsx
+++ b/src/components/answer-game/useDraggableTile.test.tsx
@@ -161,8 +161,11 @@ describe('useDraggableTile', () => {
 
       renderHook(() => useDraggableTile(tile));
 
-      expect(capturedTouchDragOptions?.onDropOnBank).toBeDefined();
-      act(() => capturedTouchDragOptions?.onDropOnBank?.());
+      expect(capturedTouchDragOptions).not.toBeNull();
+      const opts =
+        capturedTouchDragOptions as unknown as CapturedTouchDragOptions;
+      expect(opts.onDropOnBank).toBeDefined();
+      act(() => opts.onDropOnBank?.());
 
       expect(mockDispatch).toHaveBeenCalledWith({
         type: 'SET_DRAG_ACTIVE',
@@ -180,10 +183,11 @@ describe('useDraggableTile', () => {
 
       renderHook(() => useDraggableTile(tile));
 
-      expect(capturedTouchDragOptions?.onDropOnBankTile).toBeDefined();
-      act(() =>
-        capturedTouchDragOptions?.onDropOnBankTile?.('other-tile'),
-      );
+      expect(capturedTouchDragOptions).not.toBeNull();
+      const opts =
+        capturedTouchDragOptions as unknown as CapturedTouchDragOptions;
+      expect(opts.onDropOnBankTile).toBeDefined();
+      act(() => opts.onDropOnBankTile?.('other-tile'));
 
       expect(mockDispatch).toHaveBeenCalledWith({
         type: 'SET_DRAG_ACTIVE',

--- a/src/components/answer-game/useDraggableTile.ts
+++ b/src/components/answer-game/useDraggableTile.ts
@@ -77,6 +77,10 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
         dispatch({ type: 'SET_DRAG_ACTIVE', tileId: null });
         placeTile(droppedTileId, zoneIndex);
       },
+      onDropOnBank: () =>
+        dispatch({ type: 'SET_DRAG_ACTIVE', tileId: null }),
+      onDropOnBankTile: () =>
+        dispatch({ type: 'SET_DRAG_ACTIVE', tileId: null }),
       onHoverZone: (zoneIndex) =>
         dispatch({ type: 'SET_DRAG_HOVER', zoneIndex }),
     });


### PR DESCRIPTION
## Summary

- Fixes a touch-only bug where dragging a bank tile a few pixels (just crossing the 8px threshold) then releasing within the bank caused the tile to permanently fade out and become uninteractable
- Root cause: `useDraggableTile` didn't provide `onDropOnBank` or `onDropOnBankTile` callbacks to `useTouchDrag`, so `SET_DRAG_ACTIVE` was never reset to `null` when the drop landed back on the bank
- Added both callbacks to clear drag state, matching the pattern already used in `useSlotTileDrag`

## Test plan

- [ ] On an iOS device (Safari/Chrome/Brave), tap and drag a bank tile just a few pixels up (still within the bank), then release — tile should return to normal (not fade out)
- [ ] Verify normal drag-to-slot still works on touch
- [ ] Verify desktop drag-and-drop is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)