### PR TITLE
docs(claude): require regression tests for every bug fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,24 @@ Config lives in `.markdownlint.yaml`. Most default rules are active; key disable
 
 **Never commit a markdown file that fails `yarn lint:md` or `npx prettier --check`.**
 
+## Test-Driven Development
+
+Every bug fix and every new feature **must** follow the red-green-refactor cycle.
+
+### Bug fixes
+
+1. Write a failing test that reproduces the bug **before** touching production code
+2. Confirm the test fails for the right reason (missing behaviour, not a syntax error)
+3. Apply the minimal fix
+4. Confirm the test goes green and no other tests regress
+5. **Never open a bug-fix PR without a regression test** — a fix without a test gives no
+   proof it caught the bug and no protection against future regressions
+
+### Features
+
+Use the `superpowers:test-driven-development` skill at the start of every feature
+branch. Write tests first; implement only enough code to make them pass.
+
 ## Pre-push Quality Gate
 
 A `.husky/pre-push` hook runs automatically on every `git push`. It enforces the


### PR DESCRIPTION
## Summary

- Adds a **Test-Driven Development** section to `CLAUDE.md` with an explicit rule: every bug fix must include a failing test before the fix is applied, and no bug-fix PR may be opened without regression test coverage
- Triggered by PR #91 (touch-drag fade bug) where the fix was shipped without tests and required a follow-up commit

## What changed

New `## Test-Driven Development` section placed before `## Pre-push Quality Gate`, covering:

- **Bug fixes** — 5-step red-green cycle, explicit "never open a PR without a regression test" rule
- **Features** — reminder to invoke the `superpowers:test-driven-development` skill

## Test plan

- [ ] Read the new section in `CLAUDE.md` and verify it is clear and actionable
- [ ] Confirm `yarn lint:md` passes (CI enforces this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)