### PR TITLE
fix(ios): add touch-action manipulation for tap reliability

### DIFF
--- a/src/components/SavedConfigChip.test.tsx
+++ b/src/components/SavedConfigChip.test.tsx
@@ -163,6 +163,22 @@ describe('SavedConfigChip', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('applies touch-manipulation to all buttons for iOS tap reliability', () => {
+    render(
+      <SavedConfigChip
+        doc={mockDoc}
+        configFields={fields}
+        onPlay={vi.fn()}
+        onDelete={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+    const buttons = screen.getAllByRole('button');
+    for (const button of buttons) {
+      expect(button).toHaveClass('touch-manipulation');
+    }
+  });
+
   it('collapses without saving when Cancel is clicked', async () => {
     const onSave = vi.fn();
     render(

--- a/src/components/SavedConfigChip.tsx
+++ b/src/components/SavedConfigChip.tsx
@@ -75,7 +75,7 @@ export const SavedConfigChip = ({
           type="button"
           aria-label={`Expand ${doc.name}`}
           onClick={() => setExpanded((v) => !v)}
-          className="flex min-h-12 flex-1 items-center gap-2 px-3 text-left"
+          className="flex min-h-12 flex-1 touch-manipulation items-center gap-2 px-3 text-left"
         >
           <span
             className={`text-sm font-semibold ${expanded ? 'text-white' : 'bookmark-text'}`}
@@ -92,7 +92,7 @@ export const SavedConfigChip = ({
           type="button"
           aria-label={`Play ${doc.name}`}
           onClick={() => onPlay(doc.id)}
-          className="flex min-h-12 w-12 items-center justify-center text-sm text-white"
+          className="flex min-h-12 w-12 touch-manipulation items-center justify-center text-sm text-white"
           style={{ background: 'var(--bookmark-play)' }}
         >
           ▶
@@ -101,7 +101,7 @@ export const SavedConfigChip = ({
           type="button"
           aria-label={`Delete ${doc.name}`}
           onClick={() => onDelete(doc.id)}
-          className="flex min-h-12 w-12 items-center justify-center border-l border-destructive/20 text-sm text-destructive"
+          className="flex min-h-12 w-12 touch-manipulation items-center justify-center border-l border-destructive/20 text-sm text-destructive"
           style={{
             background:
               'color-mix(in srgb, var(--bs-error) 15%, transparent)',
@@ -154,7 +154,7 @@ export const SavedConfigChip = ({
               type="button"
               aria-label="Save"
               onClick={() => void handleSave()}
-              className="h-12 flex-1 rounded-xl bg-primary text-sm font-bold text-primary-foreground"
+              className="h-12 flex-1 touch-manipulation rounded-xl bg-primary text-sm font-bold text-primary-foreground"
             >
               Save
             </button>
@@ -162,7 +162,7 @@ export const SavedConfigChip = ({
               type="button"
               aria-label="Cancel"
               onClick={handleCancel}
-              className="h-12 flex-1 rounded-xl border border-input bg-background text-sm text-muted-foreground"
+              className="h-12 flex-1 touch-manipulation rounded-xl border border-input bg-background text-sm text-muted-foreground"
             >
               Cancel
             </button>

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Button } from './button';
+
+describe('Button', () => {
+  it('applies touch-manipulation to prevent iOS double-tap-to-zoom delay', () => {
+    render(<Button>Tap me</Button>);
+    expect(screen.getByRole('button')).toHaveClass(
+      'touch-manipulation',
+    );
+  });
+});

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import type * as React from 'react';
 import { cn } from '#/lib/utils';
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 touch-manipulation items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

- Adds `touch-manipulation` (CSS `touch-action: manipulation`) to the base `<Button>` component and all native `<button>` elements in `SavedConfigChip`
- Prevents iOS Safari's double-tap-to-zoom gesture detection from intercepting single taps, which caused intermittent button unresponsiveness
- Affects all iOS browsers since they all use WebKit

## Root cause

iOS Safari evaluates whether a tap might be the start of a double-tap-to-zoom gesture. Without `touch-action: manipulation`, this can cause the browser to delay or swallow single taps — especially on smaller touch targets or after scrolling. Setting `manipulation` explicitly tells the browser: allow panning and pinch-zoom, but skip double-tap-to-zoom detection.

## Test plan

- [x] New unit test for `Button` verifying `touch-manipulation` class is applied
- [x] New unit test for `SavedConfigChip` verifying all buttons have `touch-manipulation`
- [x] All 664 unit tests pass
- [x] Lint, typecheck, unit tests pass (pre-push hook)
- [ ] Manual iOS testing: tap Play buttons on GameCard and SavedConfigChip across Safari/Chrome/Firefox — should respond reliably on every tap

SKIP_STORYBOOK=1 — no visual changes to stories
SKIP_VR=1 — no visual changes (class-only, no layout shift)
SKIP_E2E=1 — E2E doesn't cover iOS touch behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)