### PR TITLE
fix(ci): open release PR instead of pushing version bump to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Markdownlint
         run: npx markdownlint-cli2 "**/*.md" "#node_modules" "#.specstory" "#.cursor" "#dist" "#worktrees"
 
+      - name: Shell script tests (determine-bump, workflow guards)
+        run: yarn test:scripts
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ concurrency:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   build:
@@ -111,10 +111,15 @@ jobs:
             pr/**
           commit-message: 'deploy: production ${{ steps.version.outputs.version }}'
 
-      - name: Commit and tag version bump
+      - name: Open release PR for version bump
+        # Master is protected by a ruleset requiring PRs, so the bot cannot
+        # push the chore(release) commit directly. Instead we land the
+        # package.json bump via a PR and push the tag separately (tags are
+        # not covered by the branch ruleset).
         if: steps.bump.outputs.bumped == 'true' && github.actor != 'github-actions[bot]'
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Bypass the local pre-push quality gate — every check in the hook
           # (lint, typecheck, unit, storybook, VR, e2e) already ran in ci.yml
           # on the merging PR. The runner also uses dash as /bin/sh, which
@@ -124,8 +129,18 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BRANCH="release/v${NEW_VERSION}"
+          git checkout -b "$BRANCH"
           git add package.json
           git commit -m "chore(release): v${NEW_VERSION}"
           git tag "v${NEW_VERSION}"
-          git pull --rebase origin master
-          git push origin master --follow-tags
+          git push origin "$BRANCH" --follow-tags
+          gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "chore(release): v${NEW_VERSION}" \
+            --body "Automated version bump from the deploy workflow.
+
+          The site has already been deployed to gh-pages with version \`${NEW_VERSION}\` (see \`dist/client/version.json\`). Merging this PR lands the matching \`package.json\` bump on master and makes the \`v${NEW_VERSION}\` tag reachable from master.
+
+          The bump type was derived from the merged PR's conventional-commit messages by \`scripts/determine-bump.sh\`."

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:vr:report": "playwright show-report",
     "storybook": "storybook dev --port 6006",
     "build-storybook": "storybook build",
-    "test:scripts": "bash scripts/determine-bump.test.sh",
+    "test:scripts": "bash scripts/determine-bump.test.sh && bash scripts/check-no-master-push.test.sh && bash scripts/check-no-master-push.sh",
     "test:storybook": "test-storybook",
     "typecheck": "tsc --noEmit",
     "word:seed": "tsx scripts/seed-word-library.ts",

--- a/scripts/check-no-master-push.sh
+++ b/scripts/check-no-master-push.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-no-master-push.sh — Fails if any .github/workflows/*.yml file pushes
+# directly to master. Master is protected by a ruleset that requires changes
+# to land via pull request; direct pushes from CI will be rejected, so we
+# catch them here instead of letting deploys fail silently.
+
+WORKFLOW_DIR=".github/workflows"
+
+if [[ ! -d "$WORKFLOW_DIR" ]]; then
+  echo "No $WORKFLOW_DIR directory; nothing to check."
+  exit 0
+fi
+
+offenders=$(grep -rnE \
+  'git[[:space:]]+push[^#]*(origin[[:space:]]+[^[:space:]]*[[:space:]]*:?master\b|origin[[:space:]]+master\b|HEAD:master\b)' \
+  "$WORKFLOW_DIR" || true)
+
+if [[ -n "$offenders" ]]; then
+  echo "ERROR: Workflow files push directly to master:" >&2
+  echo "" >&2
+  echo "$offenders" >&2
+  echo "" >&2
+  echo "Master is protected — direct pushes will be rejected." >&2
+  echo "Use a PR-based flow instead:" >&2
+  echo "  git checkout -b release/v\${NEW_VERSION}" >&2
+  echo "  git push origin release/v\${NEW_VERSION}" >&2
+  echo "  gh pr create --base master --head release/v\${NEW_VERSION} ..." >&2
+  exit 1
+fi
+
+echo "OK: No direct master pushes in $WORKFLOW_DIR."

--- a/scripts/check-no-master-push.test.sh
+++ b/scripts/check-no-master-push.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-no-master-push.test.sh — Tests for check-no-master-push.sh
+# Run from repo root:    bash scripts/check-no-master-push.test.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GUARD_SCRIPT="$SCRIPT_DIR/check-no-master-push.sh"
+
+if command -v tput &>/dev/null && tput colors &>/dev/null && [[ "$(tput colors)" -ge 8 ]]; then
+  GREEN="$(tput setaf 2)"
+  RED="$(tput setaf 1)"
+  RESET="$(tput sgr0)"
+else
+  GREEN=""
+  RED=""
+  RESET=""
+fi
+
+TMPDIR_TESTS="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TESTS"' EXIT
+
+pass=0
+fail=0
+
+# run_test <description> <fixture_content> <expected_exit_code>
+run_test() {
+  local description="$1"
+  local fixture_content="$2"
+  local expected_exit="$3"
+
+  local fixture_dir="$TMPDIR_TESTS/$(date +%s%N)_$RANDOM"
+  mkdir -p "$fixture_dir/.github/workflows"
+  printf '%s' "$fixture_content" >"$fixture_dir/.github/workflows/test.yml"
+
+  local exit_code=0
+  (cd "$fixture_dir" && bash "$GUARD_SCRIPT" >/dev/null 2>&1) || exit_code=$?
+
+  if [[ "$exit_code" == "$expected_exit" ]]; then
+    echo "${GREEN}PASS${RESET} — $description"
+    pass=$((pass + 1))
+  else
+    echo "${RED}FAIL${RESET} — $description (expected exit $expected_exit, got $exit_code)"
+    fail=$((fail + 1))
+  fi
+}
+
+run_test \
+  "detects direct push to master" \
+  'jobs:
+  deploy:
+    steps:
+      - run: git push origin master --follow-tags' \
+  1
+
+run_test \
+  "detects direct push to master with HEAD:master refspec" \
+  'jobs:
+  deploy:
+    steps:
+      - run: git push origin HEAD:master' \
+  1
+
+run_test \
+  "allows push to a release branch" \
+  'jobs:
+  deploy:
+    steps:
+      - run: git push origin "release/v1.2.3"' \
+  0
+
+run_test \
+  "allows push of tags only" \
+  'jobs:
+  deploy:
+    steps:
+      - run: git push origin "v1.2.3"' \
+  0
+
+run_test \
+  "allows no git push commands at all" \
+  'jobs:
+  deploy:
+    steps:
+      - run: yarn build' \
+  0
+
+run_test \
+  "ignores the word master in comments that are not push commands" \
+  'jobs:
+  deploy:
+    steps:
+      # pushes to a release branch, never master
+      - run: git push origin release/v1.2.3' \
+  0
+
+echo ""
+echo "Total: $((pass + fail)) — ${GREEN}$pass passed${RESET}, ${RED}$fail failed${RESET}"
+if [[ $fail -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Deploy workflow no longer pushes directly to `master` — it opens a `release/vX.Y.Z` PR with the `package.json` bump. Tags still push directly (tags aren't covered by the branch ruleset).
- Adds `scripts/check-no-master-push.sh` guard that greps workflow files for direct-to-master pushes, plus 6 unit tests covering each pattern (offending pushes, release branches, tag-only pushes, comments mentioning master).
- Wires the guard into the lint job via `yarn test:scripts`.

## Root cause

Master is protected by a ruleset requiring PRs (`GH013: Changes must be made through a pull request`). The deploy workflow's final step pushed `chore(release): vX.Y.Z` directly and was rejected. This failed on every non-docs PR (`mobile-resilience`, `architecture-docs`, `claude/mystifying-snyder`, `#93`) — only docs-only PRs passed because they skip the bump entirely.

The site always deployed successfully to gh-pages; only the post-deploy version commit failed, so users didn't notice.

## New release flow

1. Feature PR merges → deploy workflow runs
2. Site deploys to `gh-pages` with the new version in `dist/client/version.json`
3. Workflow creates `release/vX.Y.Z` branch, commits the `package.json` bump, pushes the branch **and** the `vX.Y.Z` tag
4. Workflow opens a PR titled `chore(release): vX.Y.Z`
5. **Release PR follows the standard PR flow** — it must pass all required status checks and be merged by a maintainer via the GitHub UI, just like any other PR. No auto-merge, no bypass. The bump type is derived by `scripts/determine-bump.sh` from the merged PR's conventional commits, so the diff is trivial (one line in `package.json`) and easy to verify.

## Prevention

Any future workflow that tries to push directly to master will now fail CI with a clear error:

```
ERROR: Workflow files push directly to master:
.github/workflows/foo.yml:42:  git push origin master
Master is protected — direct pushes will be rejected.
Use a PR-based flow instead: ...
```

This closes the loophole for new contributors who might copy patterns from the old `deploy.yml` or other projects.

## Test plan

- [x] 6 new guard tests pass (detect offending patterns, allow safe ones)
- [x] Guard runs cleanly against the updated `deploy.yml`
- [x] All 664 unit tests still pass
- [x] Lint + typecheck pass
- [ ] After merge: verify next feature PR triggers a `release/vX.Y.Z` PR instead of failing, and that the release PR itself can be reviewed + merged normally

`SKIP_E2E=1 SKIP_VR=1 SKIP_STORYBOOK=1` — changes are CI/workflow-only, no runtime/UI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)