### PR TITLE
ci(deploy): use RELEASE_PAT so release PRs trigger CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           ref: master
           fetch-depth: 0
+          # Use a PAT so the release branch/tag push is attributed to a real
+          # user. Pushes made with the default GITHUB_TOKEN do NOT trigger
+          # downstream workflows (prevents recursion), which means CI checks
+          # never run on the auto-generated release PR. Falls back to
+          # GITHUB_TOKEN locally / in forks where RELEASE_PAT isn't set.
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v6
         with:
@@ -119,7 +125,9 @@ jobs:
         if: steps.bump.outputs.bumped == 'true' && github.actor != 'github-actions[bot]'
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT required so the created PR triggers CI checks. With the default
+          # GITHUB_TOKEN, PRs open but no workflows run on them.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           # Bypass the local pre-push quality gate — every check in the hook
           # (lint, typecheck, unit, storybook, VR, e2e) already ran in ci.yml
           # on the merging PR. The runner also uses dash as /bin/sh, which


### PR DESCRIPTION
## Summary

- Switch the deploy workflow's checkout token and \`gh pr create\` token to \`secrets.RELEASE_PAT\` (with fallback to \`GITHUB_TOKEN\`)
- Fixes the empty-checks problem on auto-generated release PRs (e.g. #97)

## Why

GitHub deliberately suppresses workflow runs triggered by the default \`GITHUB_TOKEN\` to prevent recursion. That means:

- the release branch push didn't fire \`push\`/\`pull_request\` workflows
- the auto-opened release PR shows **0 status checks**
- the merge gate is effectively bypassed

Using a PAT attributes the push and PR creation to a real user, so \`pull_request\` workflows fire as expected.

## Required before merge

Add a repo secret named **\`RELEASE_PAT\`** (Settings → Secrets and variables → Actions):

- classic PAT: \`repo\` + \`workflow\` scopes, **or**
- fine-grained PAT scoped to this repo with \`Contents: write\` and \`Pull requests: write\`

Without the secret the workflow still runs (falls back to \`GITHUB_TOKEN\`), but release PRs will keep opening without checks — the whole point of this change. Don't merge until the secret exists.

## Test plan

- [ ] Add \`RELEASE_PAT\` secret
- [ ] Merge this PR
- [ ] Merge any follow-up feature PR and confirm the next auto-opened release PR has the full CI check suite attached