### PR TITLE
ci(deploy): auto-merge release PRs once checks pass

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,3 +152,6 @@ jobs:
           The site has already been deployed to gh-pages with version \`${NEW_VERSION}\` (see \`dist/client/version.json\`). Merging this PR lands the matching \`package.json\` bump on master and makes the \`v${NEW_VERSION}\` tag reachable from master.
 
           The bump type was derived from the merged PR's conventional-commit messages by \`scripts/determine-bump.sh\`."
+          # Enable auto-merge so the release PR lands the moment required
+          # checks go green — no human review needed for version bumps.
+          gh pr merge "$BRANCH" --auto --squash --delete-branch


### PR DESCRIPTION
## Summary

- Release PRs (the `chore(release): vX.Y.Z` bumps opened by `deploy.yml`) are purely automated version bumps and don't need human review.
- Add `gh pr merge --auto --squash --delete-branch` right after `gh pr create` so each release PR lands the moment its required checks go green, instead of sitting open like #102.

## Test plan

- [ ] After merge, next release cut should auto-land once CI goes green.
- [ ] PR #102 separately: enable auto-merge manually (it predates this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)