### PR TITLE
fix(db): recover from broken DM4 migrations on boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ storybook-static
 worktrees/
 .specstory/statistics.json
 .superpowers/
+.local-debug/

--- a/e2e/bookmarks-dm4-recovery.spec.ts
+++ b/e2e/bookmarks-dm4-recovery.spec.ts
@@ -1,0 +1,315 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+import { seedMathRandom } from './seed-math-random';
+import type { Page } from '@playwright/test';
+
+type ExportedDb = {
+  databaseName: string;
+  databaseVersion: number;
+  objectStoreNames: string[];
+  stores: { name: string; data: { key: unknown; value: unknown }[] }[];
+};
+
+const PROD_DB_NAME = 'baseskill-data';
+const V0_BOOKMARKS_IDB = `rxdb-dexie-${PROD_DB_NAME}--0--bookmarks`;
+const V0_INTERNAL_IDB = `rxdb-dexie-${PROD_DB_NAME}--0--_rxdb_internal`;
+const V0_MIGRATION_META_IDB = `rxdb-dexie-${PROD_DB_NAME}--0--rx-migration-state-meta-bookmarks-0`;
+
+/**
+ * Seeds the exact pre-#117 broken IndexedDB shape that v0.10.0 left on
+ * real users' devices: gameId-keyed v0 bookmark docs + a `collection|bookmarks-0`
+ * meta entry that points at a v0 schema with the `gameId` field.
+ */
+const seedBrokenV0BookmarksState = async (page: Page) => {
+  await page.evaluate(
+    async ({ bookmarksDb, internalDb, metaDb }) => {
+      const wipe = (name: string) =>
+        new Promise<void>((resolve, reject) => {
+          const request = indexedDB.deleteDatabase(name);
+          request.addEventListener('success', () => resolve());
+          request.addEventListener('error', () =>
+            reject(request.error),
+          );
+          request.addEventListener('blocked', () => resolve());
+        });
+      const open = (name: string) =>
+        new Promise<IDBDatabase>((resolve, reject) => {
+          const request = indexedDB.open(name);
+          request.addEventListener('success', () =>
+            resolve(request.result),
+          );
+          request.addEventListener('error', () =>
+            reject(request.error),
+          );
+          request.addEventListener('upgradeneeded', () => {
+            request.result.createObjectStore('docs', { keyPath: 'id' });
+          });
+        });
+      const put = (db: IDBDatabase, doc: Record<string, unknown>) =>
+        new Promise<void>((resolve, reject) => {
+          const tx = db.transaction('docs', 'readwrite');
+          tx.objectStore('docs').put(doc);
+          tx.addEventListener('complete', () => resolve());
+          tx.addEventListener('error', () => reject(tx.error));
+        });
+
+      await Promise.all([
+        wipe(bookmarksDb),
+        wipe(internalDb),
+        wipe(metaDb),
+      ]);
+
+      const bookmarks = await open(bookmarksDb);
+      const fixtures = [
+        {
+          id: 'tJDLrcsRUtvroJvbMo6AE',
+          profileId: 'anonymous',
+          gameId: 'math-subtraction',
+          createdAt: '2026-04-02T12:06:57.559Z',
+          _deleted: '0',
+          _rev: '1-blcbcgzyjl',
+          _meta: { lwt: 1_775_131_617_559.01 },
+          _attachments: {},
+        },
+        {
+          id: 'zngVeBJa_tBjWvqdEWc3m',
+          profileId: 'anonymous',
+          gameId: 'placeholder-game',
+          createdAt: '2026-04-02T12:06:58.698Z',
+          _deleted: '0',
+          _rev: '1-blcbcgzyjl',
+          _meta: { lwt: 1_775_131_618_698.01 },
+          _attachments: {},
+        },
+      ];
+      for (const f of fixtures) await put(bookmarks, f);
+      bookmarks.close();
+
+      const internal = await open(internalDb);
+      await put(internal, {
+        id: 'collection|bookmarks-0',
+        key: 'bookmarks-0',
+        context: 'collection',
+        data: {
+          name: 'bookmarks',
+          schemaHash: 'seed-v0-hash',
+          schema: {
+            additionalProperties: false,
+            encrypted: [],
+            indexes: [
+              ['_deleted', 'id'],
+              ['_meta.lwt', 'id'],
+            ],
+            keyCompression: false,
+            primaryKey: 'id',
+            properties: {
+              _attachments: { type: 'object' },
+              _deleted: { type: 'boolean' },
+              _meta: {
+                additionalProperties: true,
+                properties: {
+                  lwt: {
+                    maximum: 1e15,
+                    minimum: 1,
+                    multipleOf: 0.01,
+                    type: 'number',
+                  },
+                },
+                required: ['lwt'],
+                type: 'object',
+              },
+              _rev: { minLength: 1, type: 'string' },
+              createdAt: { format: 'date-time', type: 'string' },
+              gameId: { maxLength: 64, type: 'string' },
+              id: { maxLength: 36, type: 'string' },
+              profileId: { maxLength: 36, type: 'string' },
+            },
+            required: [
+              'id',
+              'profileId',
+              'gameId',
+              'createdAt',
+              '_deleted',
+              '_rev',
+              '_meta',
+              '_attachments',
+            ],
+            type: 'object',
+            version: 0,
+          },
+          version: 0,
+          connectedStorages: [],
+        },
+        _deleted: '0',
+        _rev: '1-rsxfshggzi',
+        _meta: { lwt: 1_774_964_092_655.01 },
+        _attachments: {},
+      });
+      internal.close();
+    },
+    {
+      bookmarksDb: V0_BOOKMARKS_IDB,
+      internalDb: V0_INTERNAL_IDB,
+      metaDb: V0_MIGRATION_META_IDB,
+    },
+  );
+};
+
+/**
+ * Seeds the entire IndexedDB layout from a DevTools JSON export, so a
+ * developer can verify recovery against their own real-device data without
+ * leaving the local dev server.
+ *
+ * Run with:
+ *   SEED_FROM_EXPORT=./.local-debug/indexeddb-exports/<file>.json \
+ *     yarn test:e2e --project=chromium --headed e2e/bookmarks-dm4-recovery.spec.ts
+ */
+const seedFromDevtoolsExport = async (
+  page: Page,
+  exportPath: string,
+) => {
+  const absolutePath = path.isAbsolute(exportPath)
+    ? exportPath
+    : path.resolve(process.cwd(), exportPath);
+  const raw = fs.readFileSync(absolutePath, 'utf8');
+  const dbs = JSON.parse(raw) as ExportedDb[];
+  const baseskillDbs = dbs.filter((d) =>
+    d.databaseName.startsWith('rxdb-dexie-baseskill-data'),
+  );
+
+  // Helpers below are defined inline because they must serialize into the
+  // page.evaluate browser context — they cannot be hoisted to module scope.
+  /* eslint-disable unicorn/consistent-function-scoping -- arrow helpers must live inside page.evaluate so they serialize into the browser context */
+  await page.evaluate(async (payload) => {
+    const wipe = (name: string) =>
+      new Promise<void>((resolve, reject) => {
+        const request = indexedDB.deleteDatabase(name);
+        request.addEventListener('success', () => resolve());
+        request.addEventListener('error', () => reject(request.error));
+        request.addEventListener('blocked', () => resolve());
+      });
+    const open = (name: string, stores: string[]) =>
+      new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open(name);
+        request.addEventListener('success', () =>
+          resolve(request.result),
+        );
+        request.addEventListener('error', () => reject(request.error));
+        request.addEventListener('upgradeneeded', () => {
+          for (const store of stores) {
+            if (!request.result.objectStoreNames.contains(store)) {
+              // Out-of-line keys: collections like session_history_index use
+              // `sessionId` (not `id`) as primary; we pass the explicit key
+              // from the export so all variants seed consistently.
+              request.result.createObjectStore(store);
+            }
+          }
+        });
+      });
+    const put = (
+      db: IDBDatabase,
+      store: string,
+      key: unknown,
+      value: unknown,
+    ) =>
+      new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(store, 'readwrite');
+        tx.objectStore(store).put(value, key as IDBValidKey);
+        tx.addEventListener('complete', () => resolve());
+        tx.addEventListener('error', () => reject(tx.error));
+      });
+
+    for (const dbExport of payload) await wipe(dbExport.databaseName);
+
+    for (const dbExport of payload) {
+      const db = await open(
+        dbExport.databaseName,
+        dbExport.objectStoreNames,
+      );
+      // Only seed `docs` — RxDB rebuilds `changes`/`attachments` on demand
+      // and those rows in DevTools exports often lack the keyPath field.
+      const docsStore = dbExport.stores.find((s) => s.name === 'docs');
+      if (docsStore) {
+        for (const row of docsStore.data) {
+          await put(db, 'docs', row.key, row.value);
+        }
+      }
+      db.close();
+    }
+  }, baseskillDbs);
+  /* eslint-enable unicorn/consistent-function-scoping -- end of page.evaluate block */
+};
+
+test.beforeEach(async ({ page }) => {
+  await seedMathRandom(page);
+});
+
+test('app boots when v0 bookmarks (gameId shape) are present from v0.10.0', async ({
+  page,
+}) => {
+  // Land on the origin so subsequent IndexedDB calls run against it.
+  await page.goto('/en/');
+  await page.getByRole('main').waitFor({ state: 'visible' });
+
+  await seedBrokenV0BookmarksState(page);
+
+  await page.reload();
+  await page.getByRole('main').waitFor({ state: 'visible' });
+
+  await expect(
+    page.getByRole('button', { name: /^Play / }).first(),
+  ).toBeVisible();
+
+  await page.goto('/en/game/word-spell');
+  await page.getByRole('main').waitFor({ state: 'visible' });
+  await expect(
+    page.getByRole('button', { name: /let's go/i }),
+  ).toBeVisible();
+});
+
+const SEED_FROM_EXPORT = process.env['SEED_FROM_EXPORT'];
+
+test.describe('verify against a real DevTools IndexedDB export', () => {
+  test.skip(
+    !SEED_FROM_EXPORT,
+    'set SEED_FROM_EXPORT=path/to/export.json to enable',
+  );
+
+  test('app boots after seeding the entire DB layout from an export', async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', (error) =>
+      consoleErrors.push(`pageerror: ${error.message}`),
+    );
+
+    await page.goto('/en/');
+    await page.getByRole('main').waitFor({ state: 'visible' });
+
+    await seedFromDevtoolsExport(page, SEED_FROM_EXPORT as string);
+
+    await page.reload();
+    await page
+      .getByRole('main')
+      .waitFor({ state: 'visible', timeout: 60_000 });
+
+    await expect(
+      page.getByRole('button', { name: /^Play / }).first(),
+    ).toBeVisible({ timeout: 60_000 });
+
+    const fatal = consoleErrors.filter(
+      (m) =>
+        m.includes('DM4') ||
+        m.includes('RxError') ||
+        m.includes('is closed'),
+    );
+    expect(
+      fatal,
+      `unexpected RxDB errors:\n${fatal.join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/src/db/bookmarks-migration.test.ts
+++ b/src/db/bookmarks-migration.test.ts
@@ -1,0 +1,113 @@
+import { nanoid } from 'nanoid';
+import { addRxPlugin, createRxDatabase } from 'rxdb';
+import { RxDBMigrationSchemaPlugin } from 'rxdb/plugins/migration-schema';
+import { getRxStorageDexie } from 'rxdb/plugins/storage-dexie';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { bookmarksSchema } from './schemas';
+import type { RxJsonSchema } from 'rxdb';
+
+addRxPlugin(RxDBMigrationSchemaPlugin);
+
+const structuredCloneFallback = <T>(value: T): T =>
+  // eslint-disable-next-line unicorn/prefer-structured-clone -- fallback IS the structuredClone shim
+  JSON.parse(JSON.stringify(value)) as T;
+
+type V0GameIdShape = {
+  id: string;
+  profileId: string;
+  gameId: string;
+  createdAt: string;
+};
+
+const bookmarksV0GameIdSchema: RxJsonSchema<V0GameIdShape> = {
+  version: 0,
+  primaryKey: 'id',
+  type: 'object',
+  properties: {
+    id: { type: 'string', maxLength: 36 },
+    profileId: { type: 'string', maxLength: 36 },
+    gameId: { type: 'string', maxLength: 64 },
+    createdAt: { type: 'string', format: 'date-time' },
+  },
+  required: ['id', 'profileId', 'gameId', 'createdAt'],
+  additionalProperties: false,
+};
+
+const migrationStrategies = {
+  1: (oldDoc: Record<string, unknown>) => {
+    const profileId = oldDoc.profileId as string;
+    const gameId = oldDoc.gameId as string;
+    return {
+      id: `${profileId}:game:${gameId}`,
+      profileId,
+      targetType: 'game',
+      targetId: gameId,
+      createdAt: oldDoc.createdAt,
+    };
+  },
+};
+
+const realWorldV0Fixtures: V0GameIdShape[] = [
+  {
+    id: 'tJDLrcsRUtvroJvbMo6AE',
+    profileId: 'anonymous',
+    gameId: 'math-subtraction',
+    createdAt: '2026-04-02T12:06:57.559Z',
+  },
+  {
+    id: 'zngVeBJa_tBjWvqdEWc3m',
+    profileId: 'anonymous',
+    gameId: 'placeholder-game',
+    createdAt: '2026-04-02T12:06:58.698Z',
+  },
+];
+
+describe('bookmarks v0 (gameId shape) → v1 migration', () => {
+  beforeAll(() => {
+    if (typeof structuredClone === 'undefined') {
+      // jsdom lacks structuredClone in older Node; fake-indexeddb relies on it.
+      (
+        globalThis as unknown as {
+          structuredClone: typeof structuredClone;
+        }
+      ).structuredClone = (v) => structuredCloneFallback(v);
+    }
+  });
+
+  it('reopens a v0 DB at v1 and migrates real-world docs without DM4', async () => {
+    const dbName = `bs-mig-${nanoid()}`;
+
+    const db0 = await createRxDatabase({
+      name: dbName,
+      storage: getRxStorageDexie(),
+      multiInstance: false,
+    });
+    const cols0 = await db0.addCollections({
+      bookmarks: { schema: bookmarksV0GameIdSchema },
+    });
+    await cols0.bookmarks.bulkInsert(realWorldV0Fixtures);
+    await db0.close();
+
+    const db1 = await createRxDatabase({
+      name: dbName,
+      storage: getRxStorageDexie(),
+      multiInstance: false,
+    });
+    const cols1 = await db1.addCollections({
+      bookmarks: {
+        schema: bookmarksSchema,
+        migrationStrategies,
+      },
+    });
+
+    const migrated = await cols1.bookmarks.find().exec();
+    const ids = migrated.map((d) => d.id).toSorted();
+    expect(ids).toEqual([
+      'anonymous:game:math-subtraction',
+      'anonymous:game:placeholder-game',
+    ]);
+    expect(migrated.every((d) => d.targetType === 'game')).toBe(true);
+
+    await db1.close();
+  });
+});

--- a/src/db/create-database.ts
+++ b/src/db/create-database.ts
@@ -6,6 +6,10 @@ import { getRxStorageMemory } from 'rxdb/plugins/storage-memory';
 import { wrappedValidateAjvStorage } from 'rxdb/plugins/validate-ajv';
 import { checkVersionAndMigrate } from './migrations';
 import {
+  getMigrationFailureCollection,
+  recoverBrokenMigration,
+} from './recover-bookmarks-migration';
+import {
   appMetaSchema,
   bookmarksSchema,
   customGamesSchema,
@@ -134,14 +138,37 @@ export async function getOrCreateDatabase(): Promise<BaseSkillDatabase> {
     );
   }
   productionDbPromise ??= (async () => {
-    const db = await createRxDatabase<BaseSkillDatabase>({
-      name: PRODUCTION_DB_NAME,
-      storage: getRxStorageDexie(),
-      multiInstance: false,
-    });
-    const withCols = await addBaseSkillCollections(db);
-    await checkVersionAndMigrate(withCols);
-    return withCols;
+    const open = async (): Promise<BaseSkillDatabase> => {
+      const db = await createRxDatabase<BaseSkillDatabase>({
+        name: PRODUCTION_DB_NAME,
+        storage: getRxStorageDexie(),
+        multiInstance: false,
+      });
+      try {
+        const withCols = await addBaseSkillCollections(db);
+        await checkVersionAndMigrate(withCols);
+        return withCols;
+      } catch (error) {
+        await db.close().catch(() => {});
+        throw error;
+      }
+    };
+    // RxDB's parallel migration plumbing intermittently throws DM4 with a
+    // closed-instance inner error during `addCollections` for users whose
+    // IndexedDB carries stale legacy schema versions. Recover by wiping
+    // the broken collection's old storage + meta and retrying. Loop a few
+    // times in case multiple collections trip the same race in one boot.
+    const MAX_RECOVERY_ATTEMPTS = 5;
+    for (let attempt = 0; attempt < MAX_RECOVERY_ATTEMPTS; attempt++) {
+      try {
+        return await open();
+      } catch (error) {
+        const collection = getMigrationFailureCollection(error);
+        if (!collection) throw error;
+        await recoverBrokenMigration(collection);
+      }
+    }
+    return await open();
   })();
   return productionDbPromise;
 }

--- a/src/db/recover-bookmarks-migration.test.ts
+++ b/src/db/recover-bookmarks-migration.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getMigrationFailureCollection,
+  recoverBrokenMigration,
+} from './recover-bookmarks-migration';
+
+const PROD_DB_NAME = 'baseskill-data';
+const v0Idb = (collection: string) =>
+  `rxdb-dexie-${PROD_DB_NAME}--0--${collection}`;
+const v0MigMetaIdb = (collection: string) =>
+  `rxdb-dexie-${PROD_DB_NAME}--0--rx-migration-state-meta-${collection}-0`;
+const internalIdb = (version: number) =>
+  `rxdb-dexie-${PROD_DB_NAME}--${version}--_rxdb_internal`;
+
+const openIdb = (name: string) =>
+  new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(name);
+    request.addEventListener('success', () => resolve(request.result));
+    request.addEventListener('error', () => reject(request.error));
+    request.addEventListener('upgradeneeded', () => {
+      request.result.createObjectStore('docs', { keyPath: 'id' });
+    });
+  });
+
+const seedDoc = (db: IDBDatabase, doc: Record<string, unknown>) =>
+  new Promise<void>((resolve, reject) => {
+    const tx = db.transaction('docs', 'readwrite');
+    tx.objectStore('docs').put(doc);
+    tx.addEventListener('complete', () => resolve());
+    tx.addEventListener('error', () => reject(tx.error));
+  });
+
+const listDocIds = (db: IDBDatabase) =>
+  new Promise<IDBValidKey[]>((resolve, reject) => {
+    const tx = db.transaction('docs', 'readonly');
+    const request = tx.objectStore('docs').getAllKeys();
+    request.addEventListener('success', () => resolve(request.result));
+    request.addEventListener('error', () => reject(request.error));
+  });
+
+const dbExists = async (name: string): Promise<boolean> => {
+  const dbs = await indexedDB.databases();
+  return dbs.some((d) => d.name === name);
+};
+
+const wipeAllBaseskillIdbs = async () => {
+  const dbs = await indexedDB.databases();
+  for (const d of dbs) {
+    if (
+      typeof d.name === 'string' &&
+      d.name.startsWith('rxdb-dexie-baseskill-data')
+    ) {
+      await new Promise<void>((resolve, reject) => {
+        const request = indexedDB.deleteDatabase(d.name as string);
+        request.addEventListener('success', () => resolve());
+        request.addEventListener('error', () => reject(request.error));
+        request.addEventListener('blocked', () => resolve());
+      });
+    }
+  }
+};
+
+afterEach(wipeAllBaseskillIdbs);
+
+describe('getMigrationFailureCollection', () => {
+  it('returns the collection name for a closed-instance DM4', () => {
+    expect(
+      getMigrationFailureCollection({
+        code: 'DM4',
+        parameters: {
+          collection: 'bookmarks',
+          error: {
+            message:
+              'RxStorageInstanceDexie is closed baseskill-data-bookmarks',
+          },
+        },
+      }),
+    ).toBe('bookmarks');
+  });
+
+  it('returns the collection name for a closed-instance DM4 on app_meta', () => {
+    expect(
+      getMigrationFailureCollection({
+        code: 'DM4',
+        parameters: {
+          collection: 'app_meta',
+          error: {
+            message:
+              'RxStorageInstanceDexie is closed baseskill-data-app_meta',
+          },
+        },
+      }),
+    ).toBe('app_meta');
+  });
+
+  it('returns null for DM4 without a closed-instance inner error', () => {
+    expect(
+      getMigrationFailureCollection({
+        code: 'DM4',
+        parameters: {
+          collection: 'profiles',
+          error: { message: 'something else' },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null for unrelated errors', () => {
+    expect(getMigrationFailureCollection(new Error('boom'))).toBeNull();
+    expect(getMigrationFailureCollection(null)).toBeNull();
+    expect(getMigrationFailureCollection({ code: 'DB1' })).toBeNull();
+  });
+});
+
+describe('recoverBrokenMigration', () => {
+  it('deletes the v0 IDB and v0 migration-meta IDB for the named collection', async () => {
+    const v0 = await openIdb(v0Idb('bookmarks'));
+    await seedDoc(v0, { id: 'doc1', profileId: 'a', gameId: 'g' });
+    v0.close();
+
+    const meta = await openIdb(v0MigMetaIdb('bookmarks'));
+    await seedDoc(meta, { id: 'up|1' });
+    meta.close();
+
+    expect(await dbExists(v0Idb('bookmarks'))).toBe(true);
+    expect(await dbExists(v0MigMetaIdb('bookmarks'))).toBe(true);
+
+    // Provide a current-version IDB so recovery knows which to keep.
+    const v1 = await openIdb(
+      `rxdb-dexie-${PROD_DB_NAME}--1--bookmarks`,
+    );
+    v1.close();
+
+    await recoverBrokenMigration('bookmarks');
+
+    expect(await dbExists(v0Idb('bookmarks'))).toBe(false);
+    expect(await dbExists(v0MigMetaIdb('bookmarks'))).toBe(false);
+    expect(
+      await dbExists(`rxdb-dexie-${PROD_DB_NAME}--1--bookmarks`),
+    ).toBe(true);
+  });
+
+  it('works for app_meta and leaves bookmarks rows intact in _rxdb_internal', async () => {
+    const internal = await openIdb(internalIdb(0));
+    await seedDoc(internal, {
+      id: 'collection|app_meta-0',
+      _deleted: '0',
+    });
+    await seedDoc(internal, {
+      id: 'rx-migration-status|app_meta-v-1',
+      _deleted: '0',
+    });
+    await seedDoc(internal, {
+      id: 'collection|bookmarks-0',
+      _deleted: '0',
+    });
+    await seedDoc(internal, {
+      id: 'collection|profiles-0',
+      _deleted: '0',
+    });
+    await seedDoc(internal, {
+      id: 'storage-token|storageToken',
+      _deleted: '0',
+    });
+    internal.close();
+
+    await recoverBrokenMigration('app_meta');
+
+    const after = await openIdb(internalIdb(0));
+    const ids = await listDocIds(after);
+    after.close();
+    expect(ids.toSorted()).toEqual([
+      'collection|bookmarks-0',
+      'collection|profiles-0',
+      'storage-token|storageToken',
+    ]);
+  });
+
+  it('is a no-op when no broken state exists', async () => {
+    await expect(
+      recoverBrokenMigration('bookmarks'),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/db/recover-bookmarks-migration.ts
+++ b/src/db/recover-bookmarks-migration.ts
@@ -1,0 +1,165 @@
+const PRODUCTION_DB_NAME = 'baseskill-data';
+const INTERNAL_IDB = (version: number): string =>
+  `rxdb-dexie-${PRODUCTION_DB_NAME}--${version}--_rxdb_internal`;
+
+/**
+ * Old (closed-during-migration) Dexie storage. Wipes the legacy schema-version
+ * IndexedDB(s) for `<collectionName>` and its `rx-migration-state-meta` peer,
+ * then removes the corresponding `collection|<name>-<version>` and
+ * `rx-migration-status|<name>-v-*` rows from every `_rxdb_internal` partition
+ * so RxDB stops attempting the broken migration on subsequent boots.
+ */
+
+type DM4Like = {
+  code?: unknown;
+  parameters?: {
+    collection?: unknown;
+    error?: { message?: unknown } | null;
+  } | null;
+};
+
+const ID_PREFIX_TO_DROP = (collection: string) => [
+  `collection|${collection}-`,
+  `rx-migration-status|${collection}-`,
+];
+
+export const getMigrationFailureCollection = (
+  error: unknown,
+): string | null => {
+  if (typeof error !== 'object' || error === null) return null;
+  const e = error as DM4Like;
+  if (e.code !== 'DM4') return null;
+  const collection = e.parameters?.collection;
+  if (typeof collection !== 'string') return null;
+  const innerMessage = e.parameters?.error?.message;
+  if (
+    typeof innerMessage !== 'string' ||
+    !innerMessage.includes('is closed')
+  )
+    return null;
+  return collection;
+};
+
+/** @deprecated kept as a thin alias so older imports still type-check */
+export const isBookmarksMigrationFailure = (error: unknown): boolean =>
+  getMigrationFailureCollection(error) === 'bookmarks';
+
+const deleteIdb = (name: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.addEventListener('success', () => resolve());
+    request.addEventListener('error', () =>
+      reject(
+        request.error ?? new Error(`deleteDatabase failed: ${name}`),
+      ),
+    );
+    // Don't block recovery if another tab/worker holds the DB open;
+    // the browser completes deletion asynchronously and recovery resumes.
+    request.addEventListener('blocked', () => resolve());
+  });
+
+const dropFromInternalStore = async (
+  collection: string,
+): Promise<void> => {
+  const list = await indexedDB.databases();
+  const internalDbs = list
+    .map((d) => d.name)
+    .filter((n): n is string => typeof n === 'string')
+    .filter((n) =>
+      /^rxdb-dexie-baseskill-data--\d+--_rxdb_internal$/.test(n),
+    );
+  const prefixes = ID_PREFIX_TO_DROP(collection);
+
+  await Promise.all(
+    internalDbs.map(
+      (name) =>
+        new Promise<void>((resolve, reject) => {
+          const openRequest = indexedDB.open(name);
+          openRequest.addEventListener('error', () =>
+            reject(openRequest.error),
+          );
+          openRequest.addEventListener('success', () => {
+            const db = openRequest.result;
+            if (!db.objectStoreNames.contains('docs')) {
+              db.close();
+              resolve();
+              return;
+            }
+            const tx = db.transaction('docs', 'readwrite');
+            const store = tx.objectStore('docs');
+            const cursorRequest = store.openCursor();
+            cursorRequest.addEventListener('success', () => {
+              const cursor = cursorRequest.result;
+              if (!cursor) return;
+              const id =
+                typeof cursor.key === 'string' ? cursor.key : undefined;
+              if (id && prefixes.some((p) => id.startsWith(p))) {
+                cursor.delete();
+              }
+              cursor.continue();
+            });
+            tx.addEventListener('complete', () => {
+              db.close();
+              resolve();
+            });
+            tx.addEventListener('error', () => {
+              db.close();
+              reject(tx.error);
+            });
+          });
+        }),
+    ),
+  );
+};
+
+const wipeOldStorageVersions = async (
+  collection: string,
+  excludeVersion: number,
+): Promise<void> => {
+  const list = await indexedDB.databases();
+  const pattern = new RegExp(
+    String.raw`^rxdb-dexie-baseskill-data--(\d+)--(?:${collection}|rx-migration-state-meta-${collection}-\d+)$`,
+  );
+  const targets = list
+    .map((d) => d.name)
+    .filter((n): n is string => typeof n === 'string')
+    .filter((n) => {
+      const match = pattern.exec(n);
+      return !!match && Number(match[1]) !== excludeVersion;
+    });
+  await Promise.all(targets.map((name) => deleteIdb(name)));
+};
+
+const findCurrentSchemaVersion = async (
+  collection: string,
+): Promise<number> => {
+  const list = await indexedDB.databases();
+  const pattern = new RegExp(
+    String.raw`^rxdb-dexie-baseskill-data--(\d+)--${collection}$`,
+  );
+  const versions = list
+    .map((d) => d.name)
+    .filter((n): n is string => typeof n === 'string')
+    .map((n) => pattern.exec(n))
+    .filter((m): m is RegExpExecArray => !!m)
+    .map((m) => Number(m[1]));
+  return versions.length > 0 ? Math.max(...versions) : 0;
+};
+
+export const recoverBrokenMigration = async (
+  collection: string,
+): Promise<void> => {
+  const currentVersion = await findCurrentSchemaVersion(collection);
+  await dropFromInternalStore(collection);
+  await wipeOldStorageVersions(collection, currentVersion);
+};
+
+/** @deprecated use {@link recoverBrokenMigration} with `'bookmarks'` */
+export const recoverBrokenBookmarksMigration = (): Promise<void> =>
+  recoverBrokenMigration('bookmarks');
+
+// Internal helpers reused by tests.
+export const __test__ = {
+  INTERNAL_IDB,
+  PRODUCTION_DB_NAME,
+};


### PR DESCRIPTION
## Summary

Some users (real-device IndexedDB carrying the v0.10.0 legacy bookmarks `gameId`-keyed shape, plus large accumulated app_meta replication history) hit `RxError DM4: RxStorageInstanceDexie is closed baseskill-data-<col>` during `addCollections` and could not open the app at all. The error surfaces on `bookmarks` first; once that's recovered, the same closed-instance race can fire on `app_meta` on the next boot — so the recovery has to be collection-agnostic and re-enterable.

`getOrCreateDatabase` now wraps the open path in a recovery loop (capped at 5 attempts). On a closed-instance DM4 it:

- deletes the failing collection's legacy `--<v>--<col>` IndexedDB(s) and its `rx-migration-state-meta-<col>-*` peer,
- removes the matching `collection|<col>-*` and `rx-migration-status|<col>-*` rows from every `_rxdb_internal` partition,
- retries `addCollections`.

Acceptable data loss: stale legacy-version docs that were already supposed to have migrated forward (e.g. v0 bookmarks with `gameId`, duplicate-singleton v0 app_meta).

## Tests

- [x] `src/db/bookmarks-migration.test.ts` — proves the v0 (gameId) → v1 (composite-key) migration strategy is correct in isolation against fake-indexeddb, using fixtures from a stuck device.
- [x] `src/db/recover-bookmarks-migration.test.ts` — 7 unit tests covering DM4 detection (`getMigrationFailureCollection`) and the wipe primitives (preserves the current schema version, leaves unrelated `_rxdb_internal` rows intact, no-op when there's nothing to recover).
- [x] `e2e/bookmarks-dm4-recovery.spec.ts` — Playwright Chromium spec that seeds the broken pre-#117 state and asserts the home + game routes load. Plus an opt-in test gated by `SEED_FROM_EXPORT=path/to.json` that seeds an entire DevTools IndexedDB export and verifies recovery against real-device data.
- [x] `yarn vitest run src/db` — 69/69 pass
- [x] `yarn typecheck`, `yarn lint`
- [x] Verified manually with the repro device's exported IndexedDB.

## Out of scope

A separate state-desync between WordSpell tiles and TTS prompt was discovered while debugging this fix — see the follow-up plan PR. It is independent of DM4 recovery and predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)