### PR TITLE
feat(word-spell): toast when stale resumed draft is discarded

### DIFF
--- a/src/games/word-spell/WordSpell/WordSpell.test.tsx
+++ b/src/games/word-spell/WordSpell/WordSpell.test.tsx
@@ -1,9 +1,23 @@
 import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { WordSpell } from './WordSpell';
 import type { WordSpellConfig } from '../types';
+import type { AnswerGameDraftState } from '@/components/answer-game/types';
 import { createInMemorySeenWordsStore } from '@/data/words';
+
+const toastStub = vi.hoisted(() => vi.fn());
+vi.mock('sonner', () => ({
+  toast: toastStub,
+  Toaster: () => null,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
 
 vi.mock('@/db/hooks/useSeenWordsStore', () => ({
   useSeenWordsStore: () => createInMemorySeenWordsStore(),
@@ -68,6 +82,10 @@ const config: WordSpellConfig = {
   ],
 };
 
+beforeEach(() => {
+  toastStub.mockClear();
+});
+
 describe('WordSpell', () => {
   it('renders the game with letter tiles for the first round word', () => {
     render(<WordSpell config={config} />);
@@ -119,6 +137,60 @@ describe('WordSpell library levels recall', () => {
     // This smoke test exists only to pin the component compiles with
     // the new hook signature.
     expect(true).toBe(true);
+  });
+});
+
+describe('WordSpell stale-draft recovery toast', () => {
+  const staleInitialState: AnswerGameDraftState = {
+    allTiles: [
+      { id: 'a', label: 'X', value: 'x' },
+      { id: 'b', label: 'Y', value: 'y' },
+      { id: 'c', label: 'Z', value: 'z' },
+    ],
+    bankTileIds: ['a', 'b', 'c'],
+    zones: [],
+    activeSlotIndex: 0,
+    phase: 'playing',
+    roundIndex: 0,
+    retryCount: 0,
+    levelIndex: 0,
+  };
+
+  const alignedInitialState: AnswerGameDraftState = {
+    allTiles: [
+      { id: 'a', label: 'c', value: 'c' },
+      { id: 'b', label: 'a', value: 'a' },
+      { id: 't', label: 't', value: 't' },
+    ],
+    bankTileIds: ['a', 'b', 't'],
+    zones: [],
+    activeSlotIndex: 0,
+    phase: 'playing',
+    roundIndex: 0,
+    retryCount: 0,
+    levelIndex: 0,
+  };
+
+  it('fires toast when the resumed draft does not match the resolved round', () => {
+    render(
+      <WordSpell config={config} initialState={staleInitialState} />,
+    );
+    expect(toastStub).toHaveBeenCalledTimes(1);
+    expect(toastStub).toHaveBeenCalledWith(
+      'toasts.wordSpellStaleDraftRecovered',
+    );
+  });
+
+  it('does not fire toast when the resumed draft aligns with the round', () => {
+    render(
+      <WordSpell config={config} initialState={alignedInitialState} />,
+    );
+    expect(toastStub).not.toHaveBeenCalled();
+  });
+
+  it('does not fire toast for a fresh session (no initialState)', () => {
+    render(<WordSpell config={config} />);
+    expect(toastStub).not.toHaveBeenCalled();
   });
 });
 

--- a/src/games/word-spell/WordSpell/WordSpell.tsx
+++ b/src/games/word-spell/WordSpell/WordSpell.tsx
@@ -7,6 +7,8 @@ import {
   useRef,
   useState,
 } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { buildSentenceGapRound } from '../build-sentence-gap-round';
 import { LetterTileBank } from '../LetterTileBank/LetterTileBank';
 import { useLibraryRounds } from '../useLibraryRounds';
@@ -306,6 +308,7 @@ export const WordSpell = ({
   seed,
   persistedContent,
 }: WordSpellProps) => {
+  const { t } = useTranslation('common');
   const skin = useGameSkin('word-spell', config.skin);
   const [sessionEpoch, setSessionEpoch] = useState(0);
   const seenWordsStore = useSeenWordsStore();
@@ -429,9 +432,8 @@ export const WordSpell = ({
   // Safety net: detect a draft whose tiles don't match the round the resumed
   // index is pointing at. This covers legacy sessions (no persisted content,
   // draft authored against a different word pool) and any future divergence.
-  // When stale, we ignore the draft and start from round 0 — a silent recovery
-  // is a strict improvement over the "stuck game" symptom. A follow-up PR can
-  // surface a toast once `Toaster` is mounted at the app root.
+  // When stale, we ignore the draft and start from round 0, and surface a toast
+  // so the player knows why their saved progress vanished.
   const staleDraft = useMemo(() => {
     if (!initialState || sessionEpoch !== 0) return false;
     if (resolvedRounds.length === 0 || isLoading) return false;
@@ -443,7 +445,7 @@ export const WordSpell = ({
     if (!draftRound?.word) return true;
     if (draftRound.gaps && draftRound.gaps.length > 0) return false;
     return !isDraftAlignedWithRound({
-      draftTileValues: initialState.allTiles.map((t) => t.value),
+      draftTileValues: initialState.allTiles.map((tile) => tile.value),
       roundWord: draftRound.word,
     });
   }, [
@@ -470,6 +472,11 @@ export const WordSpell = ({
       cancellation.isCancelled = true;
     };
   }, [staleDraft, db, sessionId]);
+
+  useEffect(() => {
+    if (!staleDraft) return;
+    toast(t('toasts.wordSpellStaleDraftRecovered'));
+  }, [staleDraft, t]);
 
   const { tiles, zones } = useMemo(() => {
     if (!roundWord)

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -39,6 +39,9 @@
     "add": "Add bookmark",
     "remove": "Remove bookmark"
   },
+  "toasts": {
+    "wordSpellStaleDraftRecovered": "Saved progress couldn't be restored — starting a fresh round."
+  },
   "customGame": {
     "title": "Save configuration",
     "nameLabel": "Configuration name",

--- a/src/lib/i18n/locales/pt-BR/common.json
+++ b/src/lib/i18n/locales/pt-BR/common.json
@@ -39,6 +39,9 @@
     "add": "Adicionar marcador",
     "remove": "Remover marcador"
   },
+  "toasts": {
+    "wordSpellStaleDraftRecovered": "Não foi possível restaurar seu progresso — começando uma nova rodada."
+  },
   "customGame": {
     "title": "Salvar configuração",
     "nameLabel": "Nome da configuração",

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools';
 
 import appCss from '../styles.css?url';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { Toaster } from '@/components/ui/sonner';
 import { ServiceWorkerProvider } from '@/lib/service-worker/ServiceWorkerProvider';
 
 /** First paint only: class + color-scheme from system preference (no localStorage). */
@@ -24,6 +25,7 @@ const RootDocument = ({ children }: { children: React.ReactNode }) => (
       <ErrorBoundary>
         <ServiceWorkerProvider>{children}</ServiceWorkerProvider>
       </ErrorBoundary>
+      <Toaster />
       <TanStackDevtools
         config={{ position: 'bottom-right' }}
         plugins={[


### PR DESCRIPTION
## Summary

- Mounts `<Toaster />` (from `src/components/ui/sonner.tsx`) at the app root so toasts can be dispatched anywhere in the tree.
- Fires `toast(t('toasts.wordSpellStaleDraftRecovered'))` from the `staleDraft` effect in `WordSpell.tsx` so a player whose resumed draft had to be discarded sees a clear, localized message instead of a silent recovery.
- Adds the i18n key to `common.json` in `en` and `pt-BR`.
- Adds three unit tests: stale draft fires the toast, aligned draft does not, fresh session does not.

Resolves task 2 of #135 (WordSpell resume-desync follow-ups).

Refs PR #130 — this completes the TODO left at `WordSpell.tsx:434` ("A follow-up PR can surface a toast once `Toaster` is mounted at the app root").

## Test plan

- [x] Unit: `yarn vitest run src/games/word-spell/WordSpell/WordSpell.test.tsx` — 9/9 pass, including the three new stale-draft cases.
- [x] Full unit suite: `yarn vitest run` — 865/865 pass.
- [x] Typecheck: `yarn typecheck` — clean.
- [x] Lint on changed files — clean.
- [x] Manual local repro on `:3000`:
  - Start a WordSpell game, place a tile (persists draft).
  - In DevTools → Application → IndexedDB → `baseskill-data` → `session_history_index`, overwrite `draftState.allTiles[*].value` to letters that don't spell the round word.
  - Reload → toast appears ("Saved progress couldn't be restored — starting a fresh round."), game resumes from round 0, `draftState` is cleared.
- [ ] VR / E2E / Storybook jobs on this PR.

## Notes

- Toaster mount lives alongside the existing `<ErrorBoundary>` / `<ServiceWorkerProvider>` inside `__root.tsx`.
- Renamed a shadowed `t` → `tile` in `initialState.allTiles.map(...)` to avoid collision with the `useTranslation` `t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)