### PR TITLE
test(word-spell): e2e regression for drifted-draft safety-net recovery

### DIFF
--- a/e2e/wordspell-resume-desync.spec.ts
+++ b/e2e/wordspell-resume-desync.spec.ts
@@ -1,6 +1,139 @@
 import { expect, test } from '@playwright/test';
 import { seedMathRandom } from './seed-math-random';
 import { startGame } from './start-game';
+import type { Page } from '@playwright/test';
+
+const SESSION_HISTORY_INDEX_IDB =
+  'rxdb-dexie-baseskill-data--2--session_history_index';
+
+/**
+ * Seeds a pre-#130 drift scenario into the WordSpell in-progress session:
+ *
+ * 1. Strips `wordSpellRounds` / `roundOrder` from `initialContent` — the
+ *    shape a session would have had before PR #130 started persisting them.
+ * 2. Overwrites `draftState` with tiles and a `roundIndex` that cannot
+ *    possibly align with any round in the current default pool (see
+ *    `WORD_SPELL_ROUND_POOL` in `$gameId.tsx`). This mirrors the real-world
+ *    capture from the plan fixture: tiles spelling `pant` while the resumed
+ *    roundIndex points at a different word entirely.
+ *
+ * Returns the in-progress sessionId so the test can correlate assertions.
+ */
+const seedDriftedInProgressSession = async (
+  page: Page,
+): Promise<string> =>
+  page.evaluate(async (dbName) => {
+    const open = () =>
+      new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open(dbName);
+        request.addEventListener('success', () =>
+          resolve(request.result),
+        );
+        request.addEventListener('error', () => reject(request.error));
+      });
+    const getAllDocs = (store: IDBObjectStore) =>
+      new Promise<unknown[]>((resolve, reject) => {
+        const request = store.getAll();
+        request.addEventListener('success', () =>
+          resolve(request.result as unknown[]),
+        );
+        request.addEventListener('error', () => reject(request.error));
+      });
+
+    const db = await open();
+    const tx = db.transaction('docs', 'readwrite');
+    const store = tx.objectStore('docs');
+    const docs = await getAllDocs(store);
+
+    let targetSessionId = '';
+    for (const raw of docs as Record<string, unknown>[]) {
+      if (
+        raw['gameId'] !== 'word-spell' ||
+        raw['status'] !== 'in-progress'
+      ) {
+        continue;
+      }
+      targetSessionId = String(raw['sessionId'] ?? '');
+      const initialContent: Record<string, unknown> = {
+        ...(raw['initialContent'] as
+          | Record<string, unknown>
+          | undefined),
+      };
+      delete initialContent['wordSpellRounds'];
+      delete initialContent['roundOrder'];
+
+      const existingMeta = raw['_meta'] as
+        | Record<string, number>
+        | undefined;
+      const mutated = {
+        ...raw,
+        initialContent,
+        draftState: {
+          allTiles: [
+            { id: 't0', label: 'p', value: 'p' },
+            { id: 't1', label: 'a', value: 'a' },
+            { id: 't2', label: 'n', value: 'n' },
+            { id: 't3', label: 't', value: 't' },
+          ],
+          bankTileIds: ['t0', 't1', 't2', 't3'],
+          zones: [],
+          activeSlotIndex: 0,
+          phase: 'playing',
+          roundIndex: 2,
+          retryCount: 0,
+          levelIndex: 0,
+        },
+        _meta: { ...existingMeta, lwt: Date.now() + 1 },
+      };
+
+      // `session_history_index` uses in-line keys (`sessionId`) — the IDB
+      // entry holds the key inside the doc, so we must NOT pass an explicit
+      // key argument to `put`.
+      store.put(mutated);
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      tx.addEventListener('complete', () => resolve());
+      tx.addEventListener('error', () => reject(tx.error));
+    });
+    db.close();
+
+    return targetSessionId;
+  }, SESSION_HISTORY_INDEX_IDB);
+
+/** Reads `draftState` for the in-progress WordSpell session straight out of IDB. */
+const readDraftState = async (
+  page: Page,
+): Promise<Record<string, unknown> | null | undefined> =>
+  page.evaluate(async (dbName) => {
+    const open = () =>
+      new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open(dbName);
+        request.addEventListener('success', () =>
+          resolve(request.result),
+        );
+        request.addEventListener('error', () => reject(request.error));
+      });
+    const db = await open();
+    const tx = db.transaction('docs', 'readonly');
+    const store = tx.objectStore('docs');
+    const docs = await new Promise<unknown[]>((resolve, reject) => {
+      const request = store.getAll();
+      request.addEventListener('success', () =>
+        resolve(request.result as unknown[]),
+      );
+      request.addEventListener('error', () => reject(request.error));
+    });
+    db.close();
+    const match = (docs as Record<string, unknown>[]).find(
+      (d) =>
+        d['gameId'] === 'word-spell' && d['status'] === 'in-progress',
+    );
+    return (match?.['draftState'] ?? null) as Record<
+      string,
+      unknown
+    > | null;
+  }, SESSION_HISTORY_INDEX_IDB);
 
 test.beforeEach(async ({ page }) => {
   await seedMathRandom(page);
@@ -55,6 +188,123 @@ test('WordSpell resume keeps tiles aligned across app reloads', async ({
   // reload. A diverging set would mean the re-render used a regenerated
   // `roundOrder` that the AudioButton prompt also follows — i.e. the desync.
   expect(tileLabelsAfter).toEqual(tileLabelsBefore);
+  await expect(
+    page.getByRole('button', { name: 'Hear the question' }),
+  ).toBeVisible();
+});
+
+/**
+ * Specifically reproduces the desync the smoke test above cannot: the default
+ * WordSpell config in `$gameId.tsx` uses `roundsInOrder: true` with a
+ * hardcoded 8-word pool, so `buildRoundOrder` is deterministic and a plain
+ * reload never produces drift on its own.
+ *
+ * To trigger the pre-#130 bug we seed a real drift scenario directly into the
+ * persisted session: strip `wordSpellRounds` / `roundOrder` from
+ * `initialContent` (simulating a legacy session that predates the fix) and
+ * overwrite `draftState` with tiles that cannot align with any round in the
+ * current pool. After reload, the safety net in `WordSpell.tsx` must detect
+ * the stale draft and recover to round 0 — tiles must spell `cat`, not the
+ * seeded `pant`.
+ */
+test('WordSpell resume discards a drifted draft and recovers to round 0', async ({
+  page,
+}) => {
+  await page.goto('/en/game/word-spell');
+  await page.getByRole('main').waitFor({ state: 'visible' });
+  await startGame(page);
+
+  const tiles = page.getByRole('button', { name: /^Letter /i });
+  await expect(tiles.first()).toBeVisible();
+
+  const sortedLabels = async () => {
+    const labels = await tiles.evaluateAll((nodes) =>
+      nodes.map((n) =>
+        (n.getAttribute('aria-label') ?? '').replace(/^Letter /i, ''),
+      ),
+    );
+    return labels.map((label) => label.toLowerCase()).toSorted();
+  };
+
+  // Drag the `c` tile into slot 1 so we have a realistic mid-round draft
+  // before we inject drift. This proves the reset path actually clears
+  // placements (not just tile labels) on recovery — a clean-slate test
+  // would pass even if the safety net forgot to reset zones.
+  const cTile = page.getByRole('button', { name: 'Letter c' });
+  const slot1Empty = page.getByRole('listitem', {
+    name: /^Slot 1, empty/i,
+  });
+  const tileBox = await cTile.boundingBox();
+  const slotBox = await slot1Empty.boundingBox();
+  if (!tileBox || !slotBox) {
+    throw new Error('tile or slot bounding box not resolved');
+  }
+  await page.mouse.move(
+    tileBox.x + tileBox.width / 2,
+    tileBox.y + tileBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    slotBox.x + slotBox.width / 2,
+    slotBox.y + slotBox.height / 2,
+    { steps: 10 },
+  );
+  await page.mouse.up();
+
+  await expect(
+    page.getByRole('listitem', { name: /^Slot 1, filled with c/i }),
+  ).toBeVisible();
+
+  // Wait past useAnswerGameDraftSync's 500 ms debounce + the initialContent
+  // patch that fires once useLibraryRounds settles — both must complete
+  // before we can meaningfully mutate the persisted document.
+  await page.waitForTimeout(900);
+
+  const sessionId = await seedDriftedInProgressSession(page);
+  expect(
+    sessionId,
+    'seed helper should find an in-progress session',
+  ).not.toBe('');
+
+  await page.reload();
+  await page.getByRole('main').waitFor({ state: 'visible' });
+  await expect(tiles.first()).toBeVisible();
+
+  // Round 0 of the default pool is `cat` → sorted letters [a, c, t]. The
+  // drifted draft carried [a, n, p, t] at roundIndex 2 — if the safety net
+  // failed we would see those letters on the bank instead.
+  await expect
+    .poll(async () => await sortedLabels(), {
+      message: 'tiles should recover to round 0 letters after drift',
+    })
+    .toEqual(['a', 'c', 't']);
+
+  // Every slot must be empty — the safety net has to drop the drifted
+  // placements, not just relabel them.
+  await expect(
+    page.getByRole('listitem', { name: /^Slot 1, empty/i }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('listitem', { name: /^Slot 2, empty/i }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('listitem', { name: /^Slot 3, empty/i }),
+  ).toBeVisible();
+
+  // User-facing signal from the safety-net toast (see PR #136).
+  await expect(
+    page.getByText(/Saved progress couldn't be restored/i),
+  ).toBeVisible();
+
+  // Persisted side-effect: WordSpell.tsx:459-474 null-patches the stale
+  // draft. Poll because the patch is async after the safety net fires.
+  await expect
+    .poll(async () => await readDraftState(page), {
+      message:
+        'draftState in IDB should be cleared once the safety net fires',
+    })
+    .toBeNull();
+
   await expect(
     page.getByRole('button', { name: 'Hear the question' }),
   ).toBeVisible();


### PR DESCRIPTION
## Summary

The existing `e2e/wordspell-resume-desync.spec.ts` is a smoke test: with the default `roundsInOrder: true` + hardcoded 8-word pool in `\$gameId.tsx`, `buildRoundOrder` is deterministic across reloads, so a plain reload cannot reproduce the desync on its own — the tiles happen to match anyway.

This PR adds a second test that **directly reproduces the pre-#130 bug** by mutating the persisted session in IndexedDB between a real user action and a reload, and then checks every surface the safety net touches:

1. Navigate to WordSpell, start the game, **drag the `c` tile into slot 1** so the draft is in a realistic mid-round state (not just "fresh start").
2. Strip `wordSpellRounds` / `roundOrder` from `initialContent` — the exact legacy shape a pre-PR #130 session would have had.
3. Overwrite `draftState` with tiles spelling `pant` at `roundIndex: 2`, mirroring the real-world fixture captured in the plan (tiles for one word, audio for another).
4. Reload.
5. Assert all four downstream effects of the safety-net:
   - **Tiles** spell `cat` (sorted `[a, c, t]`), not the seeded `[a, n, p, t]`.
   - **Slots 1–3 are empty** — the drifted placements were dropped, not just relabeled.
   - **Toast is visible** — the user sees *"Saved progress couldn't be restored — starting a fresh round."* (wiring added in #136).
   - **`draftState` in IDB is `null`** — `WordSpell.tsx:459-474` patched the stale draft away.

Each assertion guards a different code path — if the safety net partially regressed (e.g. cleared tiles but forgot slots, or patched IDB but forgot to toast), at least one of these would fail.

Resolves task 3 of #135 (WordSpell resume-desync follow-ups).

Refs PRs #130 (fix) and #136 (toast + Toaster mount).

## Implementation notes

- Uses the same `page.evaluate` IDB pattern as `e2e/bookmarks-dm4-recovery.spec.ts`.
- `session_history_index` uses **in-line** keys (`sessionId` is embedded in the doc), so `store.put(mutated)` is called without an explicit key argument — documented inline with a comment so the next person doesn't hit the same `DataError` I did.
- Drag uses `mouse.down/move/up` (same pattern as `visual.spec.ts:409`) because the default config is `inputMethod: 'drag'`.
- `readDraftState()` helper queries IDB in read-only mode; paired with `expect.poll` because the null-patch happens asynchronously after the safety net fires.

## Test plan

- [x] `yarn test:e2e e2e/wordspell-resume-desync.spec.ts --project=chromium` — 2/2 pass (existing smoke + new drift-recovery with drag + 4 assertions).
- [x] `yarn typecheck` — clean.
- [x] `yarn eslint e2e/wordspell-resume-desync.spec.ts` — clean.
- [x] `yarn vitest run` — 865/865 pass (ran by pre-push hook).
- [ ] CI: Lint / Typecheck / Unit / Storybook / Build / E2E — chromium / VR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)