### PR TITLE
stories(answer-game/InstructionsOverlay): collapse to Playground + derive custom-game mode

### DIFF
--- a/src/components/answer-game/InstructionsOverlay/InstructionsOverlay.stories.tsx
+++ b/src/components/answer-game/InstructionsOverlay/InstructionsOverlay.stories.tsx
@@ -1,4 +1,4 @@
-import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { fn } from 'storybook/test';
 
 import { withDb } from '../../../../.storybook/decorators/withDb';
 import { withRouter } from '../../../../.storybook/decorators/withRouter';
@@ -8,16 +8,17 @@ import type { GameColorKey } from '@/lib/game-colors';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { ComponentType } from 'react';
 
+type PlaygroundGameId = 'sort-numbers' | 'word-spell' | 'number-match';
+
 interface StoryArgs {
   text: string;
   gameTitle: string;
-  gameId: string;
+  gameId: PlaygroundGameId;
+  customGameName: string;
   customGameColor: GameColorKey;
   ttsEnabled: boolean;
   isBookmarked: boolean;
   totalRounds: number;
-  customGameId: string;
-  customGameName: string;
   onStart: () => void;
   onSaveCustomGame: (input: SaveCustomGameInput) => Promise<string>;
   onUpdateCustomGame: (
@@ -27,11 +28,13 @@ interface StoryArgs {
   ) => Promise<void>;
   onToggleBookmark: () => void;
   onConfigChange: (config: Record<string, unknown>) => void;
-  // Raw InstructionsOverlay props shadowed by StoryArgs above (config)
-  // or intentionally omitted. Declared here only to hide their
-  // react-docgen-inferred rows from the Controls panel.
+  // Raw InstructionsOverlay props intentionally hidden from the Controls
+  // panel — either shadowed above (config), derived from other controls
+  // (customGameId), or not meaningful in the playground (cover,
+  // onDeleteCustomGame, existingCustomGameNames).
   config?: never;
   cover?: never;
+  customGameId?: never;
   onDeleteCustomGame?: never;
   existingCustomGameNames?: never;
 }
@@ -51,22 +54,35 @@ const GAME_COLOR_OPTIONS = [
   'cyan',
 ] as const satisfies readonly GameColorKey[];
 
+const GAME_ID_OPTIONS = [
+  'sort-numbers',
+  'word-spell',
+  'number-match',
+] as const satisfies readonly PlaygroundGameId[];
+
 const meta: Meta<StoryArgs> = {
   component: InstructionsOverlay as unknown as ComponentType<StoryArgs>,
   title: 'answer-game/InstructionsOverlay',
   tags: ['autodocs'],
   decorators: [withDb, withRouter],
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Pre-game shell: cover, title, instructions, "Let\'s go!" button, inline simple-config form, bookmark + cog affordances. The three real gameIds (`sort-numbers`, `word-spell`, `number-match`) drive the cover art and the inline SimpleConfigForm — pick one to see the actual renderer a game loads at runtime.\n\n**Custom-game mode:** type a non-empty `customGameName` to flip the shell into custom-game mode — the custom name becomes the primary heading, the original gameTitle moves to a coloured subtitle, and the save-on-play dialog is skipped on "Let\'s go!". Leave `customGameName` blank to preview the default game flow (save-on-play dialog prompts for a name).\n\nPlay-flow assertions (save prompt, custom start, cog opens AdvancedConfigModal, bookmark toggle) live in `InstructionsOverlay.test.tsx`; this story is visual-only.',
+      },
+    },
+  },
   args: {
     text: 'Listen to each number and drag it into the correct slot to sort from smallest to biggest.',
     gameTitle: 'Sort Numbers',
     gameId: 'sort-numbers',
+    customGameName: '',
     customGameColor: 'indigo' as GameColorKey,
     ttsEnabled: false,
     isBookmarked: false,
     totalRounds: 5,
-    customGameId: '',
-    customGameName: '',
     onStart: fn(),
     onSaveCustomGame: fn(async () => 'stub-id'),
     onUpdateCustomGame: fn(async () => {}),
@@ -76,18 +92,28 @@ const meta: Meta<StoryArgs> = {
   argTypes: {
     text: { control: 'text' },
     gameTitle: { control: 'text' },
-    gameId: { control: 'text' },
+    gameId: {
+      control: { type: 'select' },
+      options: GAME_ID_OPTIONS,
+      description:
+        'Drives the GameCover art and the inline SimpleConfigForm renderer.',
+    },
+    customGameName: {
+      control: 'text',
+      description:
+        'Leave empty for default game flow. Non-empty value flips the shell into custom-game mode (custom name heading, gameTitle as coloured subtitle, save-on-play dialog skipped).',
+    },
     customGameColor: {
       control: { type: 'select' },
       options: GAME_COLOR_OPTIONS,
+      description:
+        'Colour applied to the custom-game heading + subtitle. Only visible when customGameName is non-empty.',
     },
     ttsEnabled: { control: 'boolean' },
     isBookmarked: { control: 'boolean' },
     totalRounds: {
       control: { type: 'range', min: 1, max: 20, step: 1 },
     },
-    customGameId: { control: 'text' },
-    customGameName: { control: 'text' },
     onStart: { table: { disable: true } },
     onSaveCustomGame: { table: { disable: true } },
     onUpdateCustomGame: { table: { disable: true } },
@@ -95,6 +121,7 @@ const meta: Meta<StoryArgs> = {
     onConfigChange: { table: { disable: true } },
     config: { table: { disable: true } },
     cover: { table: { disable: true } },
+    customGameId: { table: { disable: true } },
     onDeleteCustomGame: { table: { disable: true } },
     existingCustomGameNames: { table: { disable: true } },
   },
@@ -102,97 +129,43 @@ const meta: Meta<StoryArgs> = {
     text,
     gameTitle,
     gameId,
+    customGameName,
     customGameColor,
     ttsEnabled,
     isBookmarked,
     totalRounds,
-    customGameId,
-    customGameName,
     onStart,
     onSaveCustomGame,
     onUpdateCustomGame,
     onToggleBookmark,
     onConfigChange,
-  }) => (
-    <InstructionsOverlay
-      text={text}
-      gameTitle={gameTitle}
-      gameId={gameId}
-      customGameColor={customGameColor}
-      ttsEnabled={ttsEnabled}
-      isBookmarked={isBookmarked}
-      config={{ totalRounds }}
-      customGameId={customGameId || undefined}
-      customGameName={customGameName || undefined}
-      onStart={onStart}
-      onSaveCustomGame={onSaveCustomGame}
-      onUpdateCustomGame={onUpdateCustomGame}
-      onToggleBookmark={onToggleBookmark}
-      onConfigChange={onConfigChange}
-    />
-  ),
+  }) => {
+    const trimmedCustomName = customGameName.trim();
+    const derivedCustomGameId = trimmedCustomName
+      ? 'story-custom-id'
+      : undefined;
+    return (
+      <InstructionsOverlay
+        text={text}
+        gameTitle={gameTitle}
+        gameId={gameId}
+        customGameColor={customGameColor}
+        ttsEnabled={ttsEnabled}
+        isBookmarked={isBookmarked}
+        config={{ totalRounds }}
+        customGameId={derivedCustomGameId}
+        customGameName={trimmedCustomName || undefined}
+        onStart={onStart}
+        onSaveCustomGame={onSaveCustomGame}
+        onUpdateCustomGame={onUpdateCustomGame}
+        onToggleBookmark={onToggleBookmark}
+        onConfigChange={onConfigChange}
+      />
+    );
+  },
 };
 export default meta;
 
 type Story = StoryObj<StoryArgs>;
 
-export const Default: Story = {};
-
-export const WithCustomGame: Story = {
-  args: {
-    customGameId: 'abc123',
-    customGameName: 'Easy Mode',
-    customGameColor: 'teal' as GameColorKey,
-  },
-};
-
-export const StartsGame: Story = {
-  args: {
-    customGameId: 'abc123',
-    customGameName: 'Easy Mode',
-  },
-  play: async ({ args }) => {
-    const portal = within(document.body);
-    await userEvent.click(
-      await portal.findByRole('button', { name: /let/i }),
-    );
-    await waitFor(() => {
-      expect(args.onStart).toHaveBeenCalled();
-    });
-  },
-};
-
-export const TogglesBookmark: Story = {
-  args: { isBookmarked: false },
-  play: async ({ args }) => {
-    const portal = within(document.body);
-    const bookmarkButton = await portal.findByRole('button', {
-      name: /bookmark/i,
-    });
-    await userEvent.click(bookmarkButton);
-    await waitFor(() => {
-      expect(args.onToggleBookmark).toHaveBeenCalledTimes(1);
-    });
-  },
-};
-
-export const OpensSettings: Story = {
-  play: async () => {
-    const portal = within(document.body);
-    const settingsButton = await portal.findByRole('button', {
-      name: /configure/i,
-    });
-    await userEvent.click(settingsButton);
-    await waitFor(() => {
-      expect(
-        portal.getByRole('dialog', { name: /advanced settings/i }),
-      ).toBeVisible();
-    });
-    await userEvent.keyboard('{Escape}');
-    await waitFor(() => {
-      expect(
-        portal.queryByRole('dialog', { name: /advanced settings/i }),
-      ).toBeNull();
-    });
-  },
-};
+export const Playground: Story = {};


### PR DESCRIPTION
## Summary

- Collapses InstructionsOverlay stories from 5 (Default, WithCustomGame, StartsGame, TogglesBookmark, OpensSettings) to a single `Playground`. Play-flow assertions were redundant with `InstructionsOverlay.test.tsx`.
- Drops the `customGameId` control — the id itself is never rendered; non-empty `customGameName` now auto-supplies a stub id, so typing a name is the single control that flips the shell into custom-game mode.
- Promotes `gameId` from free-text to a select across the 3 real ids (`sort-numbers`, `word-spell`, `number-match`) so the Playground exercises the actual `GameCover` art and inline `SimpleConfigForm` a game loads at runtime — both visible.
- No skin-wrapper — `InstructionsOverlay` uses theme tokens (`bg-background`, `bg-card`, `bg-primary`, …), not `--skin-*` custom properties. Confirmed via grep + visual inspection.

Follows the controls policy from #134. Part of the audit tracked in #125.

## Test plan

- [x] yarn typecheck — 0 errors
- [x] yarn lint — 0 errors
- [x] yarn test:storybook — 44 suites / 174 tests green against a local Storybook
- [x] Visual inspection via Playwright of 4 variants (default Sort Numbers; custom-game teal Easy Mode; Word Spell bookmarked; Number Match custom rose Dice Dash) — each shows the correct cover + SimpleConfigForm + heading colour
- [ ] CI green

## Follow-up

Per-game \`<Game>InstructionsOverlay\` wrapper refactor tracked separately (issue filed).