### PR TITLE
docs(agents): AGENTS.md, CLAUDE pointer, and worktree git gate

### DIFF
--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -46,6 +46,12 @@ git check-ignore -q worktrees || git check-ignore -q .worktrees
 - Open **Cursor’s workspace folder** as `./worktrees/<name>` when possible so tools default to the correct tree.
 - After merge to `master`, remove the worktree: `git worktree remove ./worktrees/<name>`.
 
+## Commits (baby steps)
+
+- When a logical unit of work is **done and good** (tests pass, lint clean for touched files), **commit** before starting the next unit.
+- **One PR may contain many commits** — that is fine. Smaller commits make review, `git cherry-pick`, and targeted `git revert` easier.
+- If the user says “baby steps” (or similar), default to **frequent small commits** on the current branch unless they opt out.
+
 ## Relationship to AGENTS.md
 
 [AGENTS.md](../../AGENTS.md) is the project-level agent entrypoint; keep it in sync with this workflow for models that read `AGENTS.md` first.

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -1,14 +1,51 @@
 ---
-description: Git workflow rules — enforce branch-based development via worktrees
+description: >-
+  Git workflow — mandatory worktrees; block edits from main repo checkout unless
+  user explicitly opts out
 globs: ["**/*"]
 alwaysApply: true
 ---
 
-# Git Workflow
+# Git workflow (all agents and models)
 
-See [CLAUDE.md](../../CLAUDE.md) for the full rules. Summary:
+Full policy: [CLAUDE.md](../../CLAUDE.md). This file repeats the **non-negotiable steps** so Cursor and other tools behave the same as Claude Code.
 
-- **Never commit directly to `master`**
-- All work must happen in a worktree: `git worktree add ./worktrees/<branch-name> -b <branch-name>`
-- Run `yarn install` inside the new worktree before starting work
-- PRs merge into `master`; remove the worktree after merge
+## Hard gate before editing tracked files
+
+Do **not** create, modify, delete, or run formatters against project source from the **main repository checkout** (the clone whose workspace root is `.../base-skill` and **not** under `.../base-skill/worktrees/<name>/`).
+
+**Before your first edit in a session:**
+
+1. Run: `pwd` (or infer workspace root from the environment).
+2. Confirm the working directory for edits is **inside** `./worktrees/<something>/` relative to the repo root (path should contain `/worktrees/` followed by a worktree directory name).
+3. If you are on the main tree and the user did **not** explicitly say to work in the root checkout (e.g. “hotfix on main”, “skip worktree”): **stop and create a worktree first** — do not patch `src/`, config, or docs in the root.
+
+## Starting work (mandatory sequence)
+
+From the **repository root** (main checkout), not from inside an existing worktree:
+
+```bash
+git fetch origin master
+git worktree add ./worktrees/<short-name> -b <branch-name> origin/master
+cd ./worktrees/<short-name>
+yarn install
+```
+
+Use a concrete branch name (e.g. `feat/game-no-menu`, `fix/login`). Match worktree folder to the task (`./worktrees/game-no-menu`).
+
+Verify the directory is ignored before relying on `./worktrees/`:
+
+```bash
+git check-ignore -q worktrees || git check-ignore -q .worktrees
+```
+
+## Rules
+
+- **Never commit directly to `master`.**
+- **Every task** (code, tests, Storybook, **plans, specs, markdown docs**) goes through a branch in a worktree unless the user opts out in the message.
+- Open **Cursor’s workspace folder** as `./worktrees/<name>` when possible so tools default to the correct tree.
+- After merge to `master`, remove the worktree: `git worktree remove ./worktrees/<name>`.
+
+## Relationship to AGENTS.md
+
+[AGENTS.md](../../AGENTS.md) is the project-level agent entrypoint; keep it in sync with this workflow for models that read `AGENTS.md` first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,12 @@ This file is for **any** coding agent (Cursor, Claude Code, Copilot, etc.). Pref
 - Never commit to `master`. Branch → PR → merge.
 - Project rules also live in `.cursor/rules/` (see `git-workflow.mdc`); this file and those rules should agree.
 
+## Commits (baby steps)
+
+- After each **coherent** chunk of work (feature slice, bugfix + test, doc section, rule tweak), **commit** with a clear message. Do not wait until the end of a large task to make one giant commit.
+- **Multiple commits in one PR are expected and preferred.** Reviewers can follow the story; you or the user can **cherry-pick** or **revert** a single commit without unpicking everything.
+- If the user asks for “baby step” commits, treat that as the default for the rest of the branch.
+
 ## Where to look next
 
 - [CLAUDE.md](./CLAUDE.md) — React/ESLint expectations, TDD, markdown, CI buckets, VR tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent instructions (BaseSkill)
+
+This file is for **any** coding agent (Cursor, Claude Code, Copilot, etc.). Prefer it as the first stop for **process**; implementation detail lives in [CLAUDE.md](./CLAUDE.md).
+
+## Git and worktrees (mandatory)
+
+- Do **not** edit the codebase from the main repo checkout unless the user explicitly asks to work in the root tree (e.g. “skip worktree”, “patch main directly”).
+- **Before the first file change in a session**, confirm the workspace path is under `worktrees/<task-name>/`. If it is not, create a worktree from `origin/master` and continue there:
+
+  ```bash
+  git fetch origin master
+  git worktree add ./worktrees/<task-name> -b feat/<task-name> origin/master
+  cd ./worktrees/<task-name>
+  yarn install
+  ```
+
+- Never commit to `master`. Branch → PR → merge.
+- Project rules also live in `.cursor/rules/` (see `git-workflow.mdc`); this file and those rules should agree.
+
+## Where to look next
+
+- [CLAUDE.md](./CLAUDE.md) — React/ESLint expectations, TDD, markdown, CI buckets, VR tests.
+- `.cursor/rules/` — Cursor-specific always-on rules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Name branches after the milestone or feature, e.g. `milestone-3-app-shell`, `fea
 
 - `master` is protected — no direct commits, no direct file edits
 - Every task starts with `git worktree add ./worktrees/<name>` from the project root — **this includes writing docs, specs, and plans**
+- **Baby-step commits:** When a slice of work is in good shape, commit it. **Multiple commits per PR are preferred** so reviewers can follow the history and you can cherry-pick or revert one change without undoing the rest. See [AGENTS.md](./AGENTS.md).
 - PRs merge into `master`; worktrees are removed after merge
 
 > **Why this matters for docs/specs/plans:** Planning files committed directly to master bypass the PR review process. Even non-code changes belong on a branch so they can be reviewed, revised, and merged cleanly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Claude Code Rules for BaseSkill
 
+Agents using Cursor or other tools: read [AGENTS.md](./AGENTS.md) first for the mandatory worktree gate; this file is the full project handbook.
+
 ## React Best Practices
 
 Analyse the [eslint.config.js](./eslint.config.js) to decide what approach to write the code. For example we don't use functions, but const(react/function-component-definition)


### PR DESCRIPTION
## Summary

Adds a single place for **cross-tool agent instructions** so Claude Code, Cursor, and other agents read the same rules.

- **`AGENTS.md`**: project-wide agent context (worktree policy, when to use `worktrees/feat-*` branches, and pointers for tooling).
- **`CLAUDE.md`**: first lines now point to `AGENTS.md` so the canonical doc is obvious from Claude’s default entry file.
- **`.cursor/rules/git-workflow.mdc`**: hardens the git workflow rule with an explicit **worktree gate** so changes land on a dedicated worktree/branch (reduces mixed-topic commits and foot-guns on `main`).

## Why

Small, documentation-only change set that aligns agent behavior and makes the worktree gate explicit in Cursor rules, without bundling product or test changes.

## See also

- [CLAUDE.md](CLAUDE.md) → [AGENTS.md](AGENTS.md)


Made with [Cursor](https://cursor.com)