### PR TITLE
stories(root): audit controls + Playground for 5 files

### DIFF
--- a/src/components/Footer.stories.tsx
+++ b/src/components/Footer.stories.tsx
@@ -6,9 +6,17 @@ const meta: Meta<typeof Footer> = {
   component: Footer,
   tags: ['autodocs'],
   decorators: [withRouter],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Zero-prop app-shell footer: Settings link, Docs link, and a locale dropdown. Locale + navigation come from the router decorator (`/$locale` memory route), so there are no props for the Playground to drive — it simply mounts the component inside the Storybook router.',
+      },
+    },
+  },
 };
 export default meta;
 
 type Story = StoryObj<typeof Footer>;
 
-export const Default: Story = {};
+export const Playground: Story = {};

--- a/src/components/Header.stories.tsx
+++ b/src/components/Header.stories.tsx
@@ -1,3 +1,4 @@
+import { withDb } from '../../.storybook/decorators/withDb';
 import { withRouter } from '../../.storybook/decorators/withRouter';
 import { Header } from './Header';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -5,10 +6,18 @@ import type { Meta, StoryObj } from '@storybook/react';
 const meta: Meta<typeof Header> = {
   component: Header,
   tags: ['autodocs'],
-  decorators: [withRouter],
+  decorators: [withDb, withRouter],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Zero-prop app-shell header: app title, beta chip, version, docs link, debounced search input, ThemeToggle, and a menu sheet whose panel reads live settings + theme docs from RxDB. Both decorators are required — `withDb` for the sheet panel hooks (`useSettings`, `useRxDB`, `safeGetVoices`) and `withRouter` for the `Link` + `useNavigate` calls. No Playground controls: every visible affordance is either intrinsic to the component or driven by the global Theme + Viewport toolbars.',
+      },
+    },
+  },
 };
 export default meta;
 
 type Story = StoryObj<typeof Header>;
 
-export const Default: Story = {};
+export const Playground: Story = {};

--- a/src/components/OfflineIndicator.stories.tsx
+++ b/src/components/OfflineIndicator.stories.tsx
@@ -1,24 +1,66 @@
-import { OfflineIndicator } from './OfflineIndicator';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import { useEffect } from 'react';
 
-const withOffline: Decorator = (Story) => {
-  Object.defineProperty(navigator, 'onLine', {
-    value: false,
-    writable: true,
-  });
-  return <Story />;
+import { OfflineIndicator } from './OfflineIndicator';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentType } from 'react';
+
+interface StoryArgs {
+  isOffline: boolean;
+}
+
+const OfflineHarness = ({ isOffline }: StoryArgs) => {
+  useEffect(() => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis.navigator,
+      'onLine',
+    );
+    Object.defineProperty(globalThis.navigator, 'onLine', {
+      value: !isOffline,
+      writable: true,
+      configurable: true,
+    });
+    globalThis.dispatchEvent(
+      new Event(isOffline ? 'offline' : 'online'),
+    );
+    return () => {
+      if (originalDescriptor) {
+        Object.defineProperty(
+          globalThis.navigator,
+          'onLine',
+          originalDescriptor,
+        );
+      }
+    };
+  }, [isOffline]);
+
+  return <OfflineIndicator />;
 };
 
-const meta: Meta<typeof OfflineIndicator> = {
-  component: OfflineIndicator,
+const meta: Meta<StoryArgs> = {
+  component: OfflineIndicator as unknown as ComponentType<StoryArgs>,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Renders a polite-live-region yellow banner when `navigator.onLine` is false; renders null when online. The component is zero-prop — all state comes from the `online` / `offline` window events. The Playground exposes a single `isOffline` boolean that patches `navigator.onLine` and fires the matching event so the banner can be toggled in place. State-assertion coverage lives in `OfflineIndicator.test.tsx`.',
+      },
+    },
+  },
+  args: {
+    isOffline: true,
+  },
+  argTypes: {
+    isOffline: {
+      control: 'boolean',
+      description:
+        'Drives `navigator.onLine` and dispatches an `online`/`offline` event so the component toggles between rendering the banner and rendering `null`.',
+    },
+  },
+  render: ({ isOffline }) => <OfflineHarness isOffline={isOffline} />,
 };
 export default meta;
 
-type Story = StoryObj<typeof OfflineIndicator>;
+type Story = StoryObj<StoryArgs>;
 
-export const Online: Story = {};
-
-export const Offline: Story = {
-  decorators: [withOffline],
-};
+export const Playground: Story = {};

--- a/src/components/ThemeToggle.stories.tsx
+++ b/src/components/ThemeToggle.stories.tsx
@@ -4,9 +4,17 @@ import type { Meta, StoryObj } from '@storybook/react';
 const meta: Meta<typeof ThemeToggle> = {
   component: ThemeToggle,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Zero-prop round button that flips the document-root `light`/`dark` class. All state lives inside the component (`useState` + `matchMedia`) — there are no props to drive, so the Playground exposes no controls. Use the global Theme toolbar to preview light vs dark visuals.',
+      },
+    },
+  },
 };
 export default meta;
 
 type Story = StoryObj<typeof ThemeToggle>;
 
-export const Default: Story = {};
+export const Playground: Story = {};

--- a/src/components/UpdateBanner.stories.tsx
+++ b/src/components/UpdateBanner.stories.tsx
@@ -1,40 +1,64 @@
+import { fn } from 'storybook/test';
+
 import { withRouter } from '../../.storybook/decorators/withRouter';
 import { UpdateBanner } from './UpdateBanner';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentType, ReactNode } from 'react';
 import { ServiceWorkerContext } from '@/lib/service-worker/ServiceWorkerContext';
 
-const withUpdateAvailable: Decorator = (Story) => (
+interface StoryArgs {
+  updateAvailable: boolean;
+  applyUpdate: () => void;
+}
+
+const ServiceWorkerHarness = ({
+  updateAvailable,
+  applyUpdate,
+  children,
+}: StoryArgs & { children: ReactNode }) => (
   <ServiceWorkerContext.Provider
-    value={{ updateAvailable: true, applyUpdate: () => {} }}
+    value={{ updateAvailable, applyUpdate }}
   >
-    <Story />
+    {children}
   </ServiceWorkerContext.Provider>
 );
 
-const meta: Meta<typeof UpdateBanner> = {
-  component: UpdateBanner,
+const meta: Meta<StoryArgs> = {
+  component: UpdateBanner as unknown as ComponentType<StoryArgs>,
   tags: ['autodocs'],
-  decorators: [withUpdateAvailable, withRouter],
-  parameters: { layout: 'fullscreen' },
+  decorators: [withRouter],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Renders a primary-coloured "New version available" banner when `ServiceWorkerContext.updateAvailable` is true, the route is not a `/game/` path, and the banner has not been dismissed. The Playground exposes `updateAvailable` and the `applyUpdate` callback via the `ServiceWorkerContext` provider wrapped around the component; the internal `dismissed` state is reachable by clicking the "✕" button. Use the global Theme toolbar to preview the banner across `light` / `dark` / `forest-light` / `forest-dark` / `high-contrast`.',
+      },
+    },
+  },
+  args: {
+    updateAvailable: true,
+    applyUpdate: fn(),
+  },
+  argTypes: {
+    updateAvailable: {
+      control: 'boolean',
+      description:
+        'Toggles `ServiceWorkerContext.updateAvailable`. Banner only renders when true.',
+    },
+    applyUpdate: { table: { disable: true } },
+  },
+  render: ({ updateAvailable, applyUpdate }) => (
+    <ServiceWorkerHarness
+      updateAvailable={updateAvailable}
+      applyUpdate={applyUpdate}
+    >
+      <UpdateBanner />
+    </ServiceWorkerHarness>
+  ),
 };
 export default meta;
 
-type Story = StoryObj<typeof UpdateBanner>;
+type Story = StoryObj<StoryArgs>;
 
-export const Default: Story = {};
-
-export const OceanLight: Story = {
-  parameters: { globals: { theme: 'light' } },
-};
-
-export const OceanDark: Story = {
-  parameters: { globals: { theme: 'dark' } },
-};
-
-export const ForestLight: Story = {
-  parameters: { globals: { theme: 'forest-light' } },
-};
-
-export const ForestDark: Story = {
-  parameters: { globals: { theme: 'forest-dark' } },
-};
+export const Playground: Story = {};


### PR DESCRIPTION
## Summary

Applies the single-Playground audit to the five root `src/components/*.stories.tsx` Tier 1 files. Each file now has a single `Playground` export (renamed from `Default`), removes redundant auxiliary stories that the Theme toolbar or other global controls already cover, and gains a `parameters.docs.description.component` narrative.

- `ThemeToggle.stories.tsx` — zero-prop component; renamed `Default` -> `Playground`, added docs description.
- `Footer.stories.tsx` — zero-prop component; renamed `Default` -> `Playground`, added docs description pointing at the `withRouter` decorator.
- `Header.stories.tsx` — added missing `withDb` decorator (HeaderMenuPanel reads `useSettings` + `useRxDB` through the Sheet subtree), renamed `Default` -> `Playground`, added docs description.
- `OfflineIndicator.stories.tsx` — collapsed `Online` + `Offline` into a single `Playground` driven by a new `isOffline` boolean; a harness patches `navigator.onLine` + dispatches `online`/`offline` events in a `useEffect` with cleanup. `OfflineIndicator.test.tsx` already asserts both states.
- `UpdateBanner.stories.tsx` — deleted `OceanLight` / `OceanDark` / `ForestLight` / `ForestDark` (the global Theme toolbar already previews all five themes), replaced the outer `withUpdateAvailable` decorator with a per-render `ServiceWorkerContext.Provider` driven by a new `updateAvailable` boolean control, and wired `applyUpdate` to `fn()` so the Actions panel logs invocations. Internal `dismissed` state is reachable by clicking the ✕ button.

## Playground shape

- **ThemeToggle** — no controls (zero-prop component). Global Theme toolbar previews light/dark.
- **Footer** — no controls (zero-prop component). Global Theme toolbar + `withRouter` decorator provide context.
- **Header** — no controls (zero-prop component). `withDb` + `withRouter` decorators provide context.
- **OfflineIndicator** — `isOffline: boolean` (default `true`). Toggling rewrites `navigator.onLine` and dispatches `online`/`offline`.
- **UpdateBanner** — `updateAvailable: boolean` (default `true`), `applyUpdate: fn()`. Click ✕ in-canvas to exercise the `dismissed` state.

No auxiliary stories kept on any of the five files — every variant the deleted stories covered is reachable by flipping a control or changing the Theme toolbar.

## Skin wrapper cleanup

- `ThemeToggle.stories.tsx` — no inline wrapper found.
- `Footer.stories.tsx` — no inline wrapper found.
- `Header.stories.tsx` — no inline wrapper found.
- `OfflineIndicator.stories.tsx` — no inline wrapper found.
- `UpdateBanner.stories.tsx` — no inline wrapper found.

None of the five files wrapped the component in `game-container skin-classic` or imported `classicSkin`, so no cleanup was required. The global `withDefaultSkin` decorator (PR #154) supplies the classic tokens for any `--skin-*` consumers transitively rendered.

## Real-game parity

All five components mount from `src/routes/$locale/_app.tsx`. Mounted structure: `<Header />` + `<OfflineIndicator />` + `<UpdateBanner />` above the outlet, `<Footer />` below. `ThemeToggle` is mounted inside `Header` (top-right, `sm:flex`) and inside the menu sheet. Playground renders for each target file match the live mount visually (same tokens, same DOM), with only the expected single-pixel wrapper-div offset from the global `withDefaultSkin` decorator.

- `ThemeToggle.stories.tsx` — match (renders inside Header on `/en`).
- `Footer.stories.tsx` — match (renders under outlet on `/en`).
- `Header.stories.tsx` — match (renders above outlet on `/en`).
- `OfflineIndicator.stories.tsx` — match (renders between Header and outlet; `_app.tsx` mount is the same component).
- `UpdateBanner.stories.tsx` — match (renders between Header and outlet; `_app.tsx` mount receives the same `ServiceWorkerContext` value from the root provider).

## Verification

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:storybook --url http://127.0.0.1:6106` — 44 suites, 169 tests, all green
- [x] Real-game parity visual check

Refs #125.