### PR TITLE
stories(questions/text-question): audit controls + Playground

### DIFF
--- a/src/components/questions/TextQuestion/TextQuestion.stories.tsx
+++ b/src/components/questions/TextQuestion/TextQuestion.stories.tsx
@@ -2,7 +2,12 @@ import { withDb } from '../../../../.storybook/decorators/withDb';
 import { TextQuestion } from './TextQuestion';
 import type { AnswerGameConfig } from '@/components/answer-game/types';
 import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentType } from 'react';
 import { AnswerGameProvider } from '@/components/answer-game/AnswerGameProvider';
+
+interface StoryArgs {
+  text: string;
+}
 
 const storyConfig: AnswerGameConfig = {
   gameId: 'storybook',
@@ -13,8 +18,8 @@ const storyConfig: AnswerGameConfig = {
   ttsEnabled: true,
 };
 
-const meta: Meta<typeof TextQuestion> = {
-  component: TextQuestion,
+const meta: Meta<StoryArgs> = {
+  component: TextQuestion as unknown as ComponentType<StoryArgs>,
   tags: ['autodocs'],
   decorators: [
     withDb,
@@ -24,13 +29,28 @@ const meta: Meta<typeof TextQuestion> = {
       </AnswerGameProvider>
     ),
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Single-prop prompt button: renders `text` as a tappable label and plays TTS via `useGameTTS` on click. Use the `text` control to preview single words, long words, or sentence prompts with gap markers (e.g. `The ___ sat on the mat.`). Click/TTS + aria-label behaviour is covered by `TextQuestion.test.tsx`.',
+      },
+    },
+  },
+  args: {
+    text: 'three',
+  },
+  argTypes: {
+    text: {
+      control: 'text',
+      description:
+        'The prompt text rendered inside the button and spoken via TTS on click.',
+    },
+  },
+  render: ({ text }) => <TextQuestion text={text} />,
 };
 export default meta;
 
-type Story = StoryObj<typeof TextQuestion>;
+type Story = StoryObj<StoryArgs>;
 
-export const Default: Story = { args: { text: 'three' } };
-export const LongWord: Story = { args: { text: 'elephant' } };
-export const SentenceGap: Story = {
-  args: { text: 'The ___ sat on the mat.' },
-};
+export const Playground: Story = {};


### PR DESCRIPTION
## Summary

- Converge `TextQuestion.stories.tsx` to the Playground pattern from the Tier 1+2 audit.
- Introduce a `StoryArgs` interface (single `text` prop) with a described `text` control, and point `docs.description.component` at `TextQuestion.test.tsx` where the interactive behaviour (click → speak, aria-label) is already asserted.

## Playground shape

- **Deleted:** `Default`, `LongWord`, `SentenceGap` — all three were trivial prop toggles fully reachable from the `text` control.
- **Kept:** single `Playground` story. No auxiliary exports — stateful one-shot replay, pinned viewport/theme, and `play()` e2e-gap assertions all N/A for this single-button component.

## Skin wrapper cleanup

No inline wrapper found — the pre-existing story never wrapped with `classicSkin`, so there was nothing to remove. Global `withDefaultSkin` (PR #154) applies `game-container skin-classic` automatically, and the component reads `var(--skin-question-*)` tokens, so the Playground matches runtime.

## Real-game parity

Matches runtime: the component is a single prop button driven by `useGameTTS` context — the `AnswerGameProvider` + `withDb` decorators are preserved so the TTS hook resolves, just as it does inside Sort Numbers / Word Spell / Number Match at runtime.

## Verification

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:storybook --url http://127.0.0.1:6109` — 172/172 tests pass, including `TextQuestion.stories.tsx`
- [x] Real-game parity visual check

Refs #125.