### PR TITLE
stories(questions/audio-button): audit controls + Playground

### DIFF
--- a/src/components/questions/AudioButton/AudioButton.stories.tsx
+++ b/src/components/questions/AudioButton/AudioButton.stories.tsx
@@ -2,31 +2,60 @@ import { withDb } from '../../../../.storybook/decorators/withDb';
 import { AudioButton } from './AudioButton';
 import type { AnswerGameConfig } from '@/components/answer-game/types';
 import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentType } from 'react';
 import { AnswerGameProvider } from '@/components/answer-game/AnswerGameProvider';
 
-const storyConfig: AnswerGameConfig = {
-  gameId: 'storybook',
-  inputMethod: 'drag',
-  wrongTileBehavior: 'lock-auto-eject',
-  tileBankMode: 'exact',
-  totalRounds: 1,
-  ttsEnabled: true,
-};
+interface StoryArgs {
+  prompt: string;
+  ttsEnabled: boolean;
+}
 
-const meta: Meta<typeof AudioButton> = {
-  component: AudioButton,
+const meta: Meta<StoryArgs> = {
+  component: AudioButton as unknown as ComponentType<StoryArgs>,
   tags: ['autodocs'],
-  decorators: [
-    withDb,
-    (Story) => (
-      <AnswerGameProvider config={storyConfig}>
-        <Story />
+  decorators: [withDb],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Round-question audio affordance — a circular Volume2 button that speaks the current prompt via `useGameTTS`. Rendered by `WordSpell` and `NumberMatch` when the round exposes a TTS prompt; returns `null` when the surrounding game config has `ttsEnabled: false`.\n\nThe Playground toggles `ttsEnabled` on the `AnswerGameProvider` config (flip it off to confirm the button disappears) and lets you edit the `prompt` text. Click handling routes through `speakPrompt()` inside `useGameTTS`; rendering + click-routing assertions live in `AudioButton.test.tsx`.',
+      },
+    },
+  },
+  args: {
+    prompt: 'cat',
+    ttsEnabled: true,
+  },
+  argTypes: {
+    prompt: {
+      control: 'text',
+      description:
+        'Text passed to `speakPrompt()` when the button is clicked.',
+    },
+    ttsEnabled: {
+      control: 'boolean',
+      description:
+        'Surfaced from the surrounding `AnswerGameConfig`. Flip off to confirm the button hides itself (returns `null`).',
+    },
+  },
+  render: ({ prompt, ttsEnabled }) => {
+    const config: AnswerGameConfig = {
+      gameId: 'storybook',
+      inputMethod: 'drag',
+      wrongTileBehavior: 'lock-auto-eject',
+      tileBankMode: 'exact',
+      totalRounds: 1,
+      ttsEnabled,
+    };
+    return (
+      <AnswerGameProvider config={config}>
+        <AudioButton prompt={prompt} />
       </AnswerGameProvider>
-    ),
-  ],
+    );
+  },
 };
 export default meta;
 
-type Story = StoryObj<typeof AudioButton>;
+type Story = StoryObj<StoryArgs>;
 
-export const Default: Story = { args: { prompt: 'cat' } };
+export const Playground: Story = {};


### PR DESCRIPTION
## Summary

Converge `AudioButton.stories.tsx` on the single-Playground controls pattern: expose `prompt` (text) and `ttsEnabled` (boolean) via a `StoryArgs` interface, wire `ttsEnabled` through an `AnswerGameProvider` config inside `render()` so flipping it off demonstrates the component's `null`-return branch, and drop the legacy `Default` story.

## Playground shape

Controls exposed:

- `prompt` — text, passed to `speakPrompt()` on click
- `ttsEnabled` — boolean, toggles the surrounding `AnswerGameConfig.ttsEnabled`

No auxiliary stories kept — the legacy `Default` export is collapsed into `Playground`. `AudioButton` has no `on*` props (the click handler is internal via `useGameTTS`), so no `fn()` wiring is required. Rendering + click-routing assertions live in `AudioButton.test.tsx`.

## Skin wrapper cleanup

No inline wrapper found — the previous file never declared a classic-skin wrapper. Global `withDefaultSkin` (PR #154) covers it. No orphan imports to remove.

## Real-game parity

Matches: `WordSpell.tsx` and `NumberMatch.tsx` both render `<AudioButton prompt={...} />` inside `AnswerGameProvider` where `config.ttsEnabled` gates visibility. The Playground mirrors that mount exactly.

## Verification

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:storybook --url http://127.0.0.1:6107` (44 suites / 174 tests green)
- [x] Real-game parity visual check (matches `WordSpell` + `NumberMatch` mounts)

Refs #125.