### PR TITLE
stories(questions/dot-group-question): audit controls + Playground

### DIFF
--- a/src/components/questions/DotGroupQuestion/DotGroupQuestion.stories.tsx
+++ b/src/components/questions/DotGroupQuestion/DotGroupQuestion.stories.tsx
@@ -3,7 +3,13 @@ import { withRouter } from '../../../../.storybook/decorators/withRouter';
 import { DotGroupQuestion } from './DotGroupQuestion';
 import type { AnswerGameConfig } from '@/components/answer-game/types';
 import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentType } from 'react';
 import { AnswerGameProvider } from '@/components/answer-game/AnswerGameProvider';
+
+interface StoryArgs {
+  count: number;
+  prompt: string;
+}
 
 const storyConfig: AnswerGameConfig = {
   gameId: 'storybook',
@@ -14,8 +20,8 @@ const storyConfig: AnswerGameConfig = {
   ttsEnabled: true,
 };
 
-const meta: Meta<typeof DotGroupQuestion> = {
-  component: DotGroupQuestion,
+const meta: Meta<StoryArgs> = {
+  component: DotGroupQuestion as unknown as ComponentType<StoryArgs>,
   tags: ['autodocs'],
   decorators: [
     withDb,
@@ -30,16 +36,31 @@ const meta: Meta<typeof DotGroupQuestion> = {
     docs: {
       description: {
         component:
-          'Renders a group of individually tappable dots. Tapping a dot assigns it the next sequential count (1, 2, 3…), overlays the number on the dot, and speaks the cardinal word aloud. Resets when `count` changes.',
+          'Renders a group of individually tappable dots. Tapping a dot assigns it the next sequential count (1, 2, 3…), overlays the number on the dot, and speaks the cardinal word aloud. Resets when `count` changes.\n\nTap-assignment, re-speak on an already-numbered dot, and reset-on-count-change flows live in `DotGroupQuestion.test.tsx`; this story is visual-only.',
       },
     },
   },
+  args: {
+    count: 3,
+    prompt: 'three',
+  },
+  argTypes: {
+    count: {
+      control: { type: 'range', min: 1, max: 20, step: 1 },
+      description:
+        'Number of dots in the group. Changing this resets all dot assignments.',
+    },
+    prompt: {
+      control: 'text',
+      description: 'Accessible label for the dot group container.',
+    },
+  },
+  render: ({ count, prompt }) => (
+    <DotGroupQuestion count={count} prompt={prompt} />
+  ),
 };
 export default meta;
 
-type Story = StoryObj<typeof DotGroupQuestion>;
+type Story = StoryObj<StoryArgs>;
 
-export const OneDot: Story = { args: { count: 1, prompt: 'one' } };
-export const ThreeDots: Story = { args: { count: 3, prompt: 'three' } };
-export const FiveDots: Story = { args: { count: 5, prompt: 'five' } };
-export const NineDots: Story = { args: { count: 9, prompt: 'nine' } };
+export const Playground: Story = {};


### PR DESCRIPTION
## Summary

- Collapsed the four snapshot-style named stories (`OneDot`, `ThreeDots`, `FiveDots`, `NineDots`) into a single `Playground` driven by proper Controls — a `count` range slider (1–20) and a `prompt` text input.
- Added a `StoryArgs` interface + `render` function, aligning the file with the canonical Playground pattern (`InstructionsOverlay.stories.tsx`).
- Pointed the MDX description at `DotGroupQuestion.test.tsx` for interaction coverage (tap-assignment, re-speak, reset-on-count-change).

## Playground shape

- Kept: `Playground` (single story).
- Deleted: `OneDot`, `ThreeDots`, `FiveDots`, `NineDots` — all were per-value snapshots fully covered by the new `count` range control.

## Skin wrapper cleanup

No inline classic-skin wrapper was present; global `withDefaultSkin` from PR #154 handles it. No orphaned imports to remove.

## Real-game parity

Component renders identically to runtime — the question mounts inside `AnswerGameProvider` (same cascade as the game shell) and relies only on `--skin-question-dot-*` tokens which the global `withDefaultSkin` already supplies. Runtime route: `/en/game/number-match` (DotGroupQuestion is used inside NumberMatch rounds).

## Verification

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:storybook --url http://127.0.0.1:6110` (171/171 pass)
- [x] Real-game parity visual check

Refs #125.