### PR TITLE
stories(data/words/word-library-explorer): audit controls + Playground

### DIFF
--- a/src/data/words/WordLibraryExplorer.stories.tsx
+++ b/src/data/words/WordLibraryExplorer.stories.tsx
@@ -1,17 +1,26 @@
 import { WordLibraryExplorer } from './WordLibraryExplorer';
 import type { Meta, StoryObj } from '@storybook/react';
 
+// WordLibraryExplorer is a zero-prop dev-only tool that owns all of its
+// filter state internally via `useState`. There is nothing meaningful to
+// externalise as a Controls-panel arg — every user-configurable dial
+// (region, levels, syllables, fallback, advanced grapheme/phoneme filters)
+// is already a live form control inside the rendered component. The
+// Playground therefore exposes zero controls and renders the component
+// directly. Logic coverage for the helper collectors lives in
+// `WordLibraryExplorer.test.ts`.
 const meta: Meta<typeof WordLibraryExplorer> = {
-  title: 'Data/WordLibraryExplorer',
   component: WordLibraryExplorer,
-  parameters: { layout: 'fullscreen' },
-};
-export default meta;
-
-type Story = StoryObj<typeof WordLibraryExplorer>;
-
-export const Default: Story = {
+  title: 'Data/WordLibraryExplorer',
+  tags: ['autodocs'],
   parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Developer-only word-library explorer. Zero-prop — the component owns region / level / syllable / grapheme-phoneme filter state internally, so the Playground exposes no Controls. Interact with the in-canvas filter sidebar to exercise behaviour. Helper collector assertions (`collectGraphemePairs`, `collectGraphemeStrings`, `collectPhonemeStrings`) live in `WordLibraryExplorer.test.ts`.',
+      },
+    },
     a11y: {
       config: {
         rules: [
@@ -34,3 +43,8 @@ export const Default: Story = {
   },
   render: () => <WordLibraryExplorer />,
 };
+export default meta;
+
+type Story = StoryObj<typeof WordLibraryExplorer>;
+
+export const Playground: Story = {};


### PR DESCRIPTION
## Summary

Audit `src/data/words/WordLibraryExplorer.stories.tsx` against the Tier 1 + 2 audit spec (`docs/superpowers/specs/2026-04-22-stories-tier1-2-audit-design.md`). Rename `Default` to `Playground`, add `tags: ['autodocs']`, and attach a `docs.description.component` that explains the zero-prop shape and points at `WordLibraryExplorer.test.ts` for helper-collector coverage. The existing a11y suppressions (`button-name` for Radix Select triggers, `color-contrast` for dev-only colour tokens) move onto `meta.parameters` so they apply to the Playground story.

## Playground shape

- **Kept:** `Playground` (the single canonical story). Zero Controls — `WordLibraryExplorer` exposes no props; every filter dial (region / levels / syllables / fallback / advanced grapheme-phoneme filters) is an interactive form control inside the component itself, so a `StoryArgs` interface would be empty. Users exercise behaviour via the in-canvas sidebar.
- **Deleted:** none (`Default` was renamed, not removed).
- **No decorators:** `filterWords` is pure; no DB, router, or provider dependency.

## Skin wrapper cleanup

No inline wrapper found — the component uses only theme tokens (`bg-background`, `text-foreground`, `muted-foreground`) and never reads `--skin-*` or `classicSkin.tokens`. Global `withDefaultSkin` from `.storybook/preview.tsx` (PR #154) is a harmless no-op for this story.

## Real-game parity

No runtime parity target exists — `grep -rn WordLibraryExplorer src/routes` returns zero hits. This component is a Storybook-only dev tool by design (the explorer lives only at `Data/WordLibraryExplorer` in the sidebar). No drift to report.

## Verification

- [x] `yarn typecheck` (0 errors)
- [x] `yarn lint` (0 errors, 0 warnings, knip clean)
- [x] `yarn test:storybook --url http://127.0.0.1:6111` (44 suites / 174 tests passed, including `src/data/words/WordLibraryExplorer.stories.tsx`)
- [x] Real-game parity visual check — N/A, Storybook is the only mount

Refs #125.