### PR TITLE
feat(skills): handoff skill for session continuity

### DIFF
--- a/.claude/commands/continue.md
+++ b/.claude/commands/continue.md
@@ -1,0 +1,7 @@
+---
+description: Alias for /handoff — create a session handoff document so work can continue in a new session
+---
+
+Invoke the `handoff` skill.
+
+See [`.claude/skills/handoff/SKILL.md`](../skills/handoff/SKILL.md) for the full workflow. This command exists so `/continue` and `/handoff` are both discoverable via the `/` fuzzy-search menu.

--- a/.claude/handoffs/2026-04-22-handoff-skill.md
+++ b/.claude/handoffs/2026-04-22-handoff-skill.md
@@ -1,0 +1,60 @@
+# Handoff: handoff skill
+
+**Date:** 2026-04-22
+**Branch:** claude/priceless-faraday-54ad0d
+**Worktree:** worktrees/priceless-faraday-54ad0d
+**Worktree path:** /Users/leocaseiro/Sites/base-skill/.claude/worktrees/priceless-faraday-54ad0d
+**Git status:** 1 uncommitted (`.claude/settings.local.json` — unrelated, gitignored-ish churn)
+**Last commit:** 505c58e2 docs(agents): point agents at the handoff skill
+**PR:** [#164](https://github.com/leocaseiro/base-skill/pull/164) — open
+
+## Resume command
+
+```text
+/resync
+cd .claude/worktrees/priceless-faraday-54ad0d
+gh pr view 164 --web   # review feedback; address and push, or approve + merge
+```
+
+## Current state
+
+**Task:** Ship the `handoff` skill (session-continuity skill) + `/continue` alias + Cursor mirror.
+**Phase:** review
+**Progress:** ~95% — implementation done, PR open, awaiting review / merge.
+
+## What we did
+
+Brainstormed the skill from scratch (surveyed Cult of Claude, softaworks, ykdojo variants), wrote the spec, then implemented directly from it (skipped the plan since scope was small). Produced five files — canonical SKILL.md, `/continue` alias, Cursor rule, handoffs README, AGENTS.md pointer — each as its own baby-step commit. Opened [PR #164](https://github.com/leocaseiro/base-skill/pull/164). This file is the dogfood test: running the skill on its own branch.
+
+## Decisions made
+
+- **Copyable markdown _and_ saved file** — earlier I thought copyable-only, but the path reference is useful (you can paste it back into a new session). Lands in `.claude/handoffs/YYYY-MM-DD-<slug>.md`.
+- **Committed, not gitignored** — baby-step `docs(handoff): …` commits. Matches project workflow; cherry-pickable; survives worktree removal.
+- **Shared source of truth for cross-agent** — `.claude/skills/handoff/SKILL.md` is canonical; Cursor rule is a thin pointer (same pattern as existing `git-workflow.mdc` → `CLAUDE.md`).
+- **No plan file** — spec was prescriptive enough for five markdown files. Skipped the writing-plans step.
+- **No Python scripts / validators / chaining / quality scoring** — softaworks variant was too heavy. Kept surface minimal.
+
+## Spec / Plan
+
+- [docs/superpowers/specs/2026-04-22-handoff-skill-design.md](../../docs/superpowers/specs/2026-04-22-handoff-skill-design.md)
+- _(no plan — skipped intentionally)_
+
+## Key files
+
+- `.claude/skills/handoff/SKILL.md` — canonical skill; auto-detect commands, template, quality check, commit step
+- `.claude/commands/continue.md` — `/continue` alias
+- `.cursor/rules/handoff.mdc` — Cursor mirror, points at canonical SKILL.md
+- `.claude/handoffs/README.md` — directory intro + naming/commit conventions
+- `AGENTS.md` — one-line pointer under "Where to look next"
+
+## Next steps
+
+1. [ ] Review feedback on [PR #164](https://github.com/leocaseiro/base-skill/pull/164); address any comments.
+2. [ ] Merge PR; remove worktree: `git worktree remove .claude/worktrees/priceless-faraday-54ad0d`.
+3. [ ] After some real-world usage, consider forking a generalised publishable version for [skill.fish](https://www.skill.fish/) (strip BaseSkill-specific bits, parameterise worktree/`/resync` references).
+
+## Context to remember
+
+- Auto-invoke triggers in the description: "just saved a plan/spec", "just raised/merged a PR", "hand this off", "continue in a new session", "pick this up later", "end of session", "wrap up".
+- Future enhancement ideas (deliberately out of scope now): RESUME workflow skill, handoff chaining, staleness detection, auto-invoke on context threshold.
+- Respect the worktree gate — skill never writes on `master`.

--- a/.claude/handoffs/README.md
+++ b/.claude/handoffs/README.md
@@ -1,0 +1,17 @@
+# Handoffs
+
+Dated handoff documents produced by the `handoff` skill (see [`.claude/skills/handoff/SKILL.md`](../skills/handoff/SKILL.md)).
+
+Each file captures enough context — branch, worktree, PR status, next steps, key files — for a fresh Claude Code or Cursor session to resume work without re-explanation.
+
+## Naming
+
+`YYYY-MM-DD-<brief-slug>.md` — slug is the branch topic in 2–5 hyphenated lowercase words.
+
+## Commit policy
+
+Committed to the branch as `docs(handoff): …` baby-step commits. Reviewable in PRs, cherry-pickable, droppable independently, easy to squash on merge.
+
+## How to resume
+
+Paste the handoff's file path into a fresh session. The `Resume command` block at the top of each handoff is everything needed to get going.

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: handoff
+description:
+  Create a session handoff document so work can continue in a new session or
+  with another agent. Use when just saved a plan or spec, just raised or
+  merged a PR, ending a work session, context-switching, or explicitly told
+  to hand off / continue later. Triggers on phrases like "hand this off",
+  "continue in a new session", "pick this up later", "end of session",
+  "wrap up".
+---
+
+# Handoff
+
+Adapted from the [Cult of Claude handoff skill](https://cultofclaude.com/skills/handoff/) ([source](https://github.com/robertguss/claude-code-toolkit/blob/main/skills/handoff/SKILL.md)), tailored for BaseSkill's worktree + `/resync` + baby-step commit workflow.
+
+## When to use
+
+- Just saved a plan or spec (→ next session executes it)
+- Just raised or merged a PR (→ next session starts follow-up work)
+- Ending a work session or context-switching
+- User says "hand this off", "continue in a new session", "pick this up later"
+
+Explicit invocation: `/handoff` or `/continue`.
+
+## Worktree rule
+
+Handoffs are written inside the **active worktree**, never on `master`. If the current working directory is not under `worktrees/<name>/`, stop and ask the user whether to create a worktree first (see [CLAUDE.md](../../../CLAUDE.md) worktree gate).
+
+## Process
+
+### Step 1 — Auto-detect context
+
+Run these commands and keep the output for the template:
+
+```bash
+git branch --show-current
+git worktree list | grep "$(pwd)"
+git status --porcelain | wc -l
+git rev-list --count @{u}..HEAD 2>/dev/null || echo 0
+git log -1 --pretty=format:"%h %s"
+gh pr view --json number,state,url 2>/dev/null || true
+```
+
+Also scan `docs/superpowers/specs/` and `docs/superpowers/plans/` for recently-modified files whose slug matches the current branch or task (optional — include only if clearly relevant).
+
+### Step 2 — Ask one question
+
+> "Anything specific you want captured? (key decisions, gotchas, things you'll forget)"
+
+Single prompt, no follow-up loop. The user can answer briefly or skip.
+
+### Step 3 — Generate the document
+
+Fill in this template. **Omit any section with no content** — keep the document scannable.
+
+````markdown
+# Handoff: <brief description>
+
+**Date:** YYYY-MM-DD
+**Branch:** <branch-name>
+**Worktree:** worktrees/<name>
+**Worktree path:** <absolute path>
+**Git status:** clean | N uncommitted | N unpushed commits ahead of origin
+**Last commit:** <sha> <subject>
+**PR:** #NNN — open|merged|closed (omit if none)
+
+## Resume command
+
+```
+/resync
+cd worktrees/<name>
+<next action — e.g., execute plan docs/…md, open PR, resume debugging>
+```
+
+## Current state
+
+**Task:** <what we're working on>
+**Phase:** exploration | planning | implementation | debugging | review | shipped
+**Progress:** <milestone or %>
+
+## What we did
+
+<2–3 sentences>
+
+## Decisions made
+
+- **<decision>** — <why>
+
+## Spec / Plan
+
+- docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md
+- docs/superpowers/plans/YYYY-MM-DD-<topic>.md
+
+## Key files
+
+- src/…/foo.ts:42 — <what and why>
+
+## Open questions / blockers
+
+- [ ] <question>
+
+## Next steps
+
+1. [ ] <first action>
+2. [ ] <second>
+
+## Context to remember
+
+<constraints, user preferences, domain knowledge not obvious from the code>
+````
+
+### Step 4 — Write the file
+
+Save to `.claude/handoffs/YYYY-MM-DD-<brief-slug>.md`. Slug is 2–5 lowercase words joined by hyphens, matching the branch topic.
+
+### Step 5 — Commit as a baby step
+
+```bash
+git add .claude/handoffs/YYYY-MM-DD-<slug>.md
+git commit -m "docs(handoff): <brief description>"
+```
+
+### Step 6 — Print the resume hint
+
+Tell the user:
+
+> Saved handoff: `.claude/handoffs/YYYY-MM-DD-<slug>.md` — paste that path in a new session to resume.
+
+## Quality check (before writing)
+
+Mental pass — no validation script:
+
+1. Could a fresh Claude (or Cursor) pick up from this?
+2. Are decisions traceable (the "why", not just the "what")?
+3. Are next steps actionable and specific?
+4. Are file paths anchored (`foo.ts:42`, not "that function")?
+
+If any answer is "no", tighten the relevant section before saving.
+
+## What to capture
+
+### Always
+
+- Decisions with reasoning — the "why"
+- File paths touched, with intent
+- Current progress — where we stopped
+- Actionable next steps
+- User context — constraints, preferences, domain knowledge
+
+### When relevant
+
+- Errors hit and how they resolved (or didn't)
+- Dead ends — approaches tried that didn't work (saves re-exploration)
+
+### Skip
+
+- Verbose tool output
+- Intermediate reasoning that reached conclusions
+- Information obvious from the code

--- a/.cursor/rules/handoff.mdc
+++ b/.cursor/rules/handoff.mdc
@@ -1,0 +1,15 @@
+---
+description: >-
+  Create a session handoff document so work can continue in a new session or
+  with another agent. Use when just saved a plan or spec, just raised or
+  merged a PR, ending a session, context-switching, or told to hand off /
+  continue later.
+globs: []
+alwaysApply: false
+---
+
+# Handoff (Cursor mirror)
+
+Follow the handoff workflow defined in [`.claude/skills/handoff/SKILL.md`](../../.claude/skills/handoff/SKILL.md). Same document template, same commit policy, same worktree rule.
+
+This file exists so Cursor picks up the same cues as Claude Code — the canonical instructions live in the `.claude/skills/handoff/SKILL.md` file referenced above. See [`AGENTS.md`](../../AGENTS.md) for the cross-agent entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,4 @@ This file is for **any** coding agent (Cursor, Claude Code, Copilot, etc.). Pref
 
 - [CLAUDE.md](./CLAUDE.md) — React/ESLint expectations, TDD, markdown, CI buckets, VR tests.
 - `.cursor/rules/` — Cursor-specific always-on rules.
+- [.claude/skills/handoff/SKILL.md](./.claude/skills/handoff/SKILL.md) — session handoff workflow (also available as `/handoff` or `/continue` in Claude Code, mirrored as `.cursor/rules/handoff.mdc` for Cursor).

--- a/docs/superpowers/specs/2026-04-22-handoff-skill-design.md
+++ b/docs/superpowers/specs/2026-04-22-handoff-skill-design.md
@@ -1,0 +1,273 @@
+# Handoff Skill — Design
+
+**Date:** 2026-04-22
+**Status:** Draft for review
+**Adapted from:** [Cult of Claude `handoff` skill](https://cultofclaude.com/skills/handoff/)
+(source: [robertguss/claude-code-toolkit](https://github.com/robertguss/claude-code-toolkit/blob/main/skills/handoff/SKILL.md))
+
+## Problem
+
+Sessions don't persist. After saving a plan, saving a spec, or raising/merging
+a PR, the next session starts cold — re-explaining branch, worktree, PR state,
+next steps, and key files costs tokens and attention.
+
+`/compact` merges history into the same session. What we need is the opposite:
+a clean handoff artifact that lets us start a **fresh** session with minimal
+prompt, preserving only what matters.
+
+## Goal
+
+A project-scoped skill that, on demand or when it detects handoff cues,
+generates a short structured document at
+`.claude/handoffs/YYYY-MM-DD-<slug>.md` with everything a fresh session needs to
+resume work — git state, spec/plan paths, PR status, next steps.
+
+## Non-goals
+
+- Not a conversation summarizer (that's `/compact`).
+- No Python scripts, validators, quality scoring, chaining, or staleness
+  detection. Keep the surface area small.
+- No automatic trigger on context thresholds. Trigger is explicit (`/handoff`,
+  `/continue`) or description-cue based only.
+- No generalized publish-to-skill.fish version. That's a future fork.
+
+## Installation footprint
+
+- `.claude/skills/handoff/SKILL.md` — the canonical skill definition
+  (instructions, template, process). Single source of truth.
+- `.claude/commands/continue.md` — one-line alias that invokes the `handoff`
+  skill so `/continue` is also discoverable via `/` fuzzy search in Claude Code
+- `.cursor/rules/handoff.mdc` — Cursor rule that mirrors the auto-invoke
+  description cues and points Cursor at
+  `.claude/skills/handoff/SKILL.md` as the source of truth (same pattern as
+  the existing `.cursor/rules/git-workflow.mdc` → `CLAUDE.md`)
+- `AGENTS.md` — add a one-line pointer under "Where to look next" so
+  tool-agnostic agents discover the skill
+- `.claude/handoffs/` — directory where generated handoffs land (created on
+  first use)
+
+## Cross-agent support (Claude Code + Cursor)
+
+The project already supports both agents via a shared-source-of-truth pattern
+(see `.cursor/rules/git-workflow.mdc` mirroring `CLAUDE.md`). We follow the
+same convention:
+
+- **Claude Code** reads `.claude/skills/handoff/SKILL.md` directly. Invoked
+  via the `Skill` tool, `/handoff`, or `/continue`.
+- **Cursor** reads `.cursor/rules/handoff.mdc`, which contains the same
+  auto-invoke cues in its `description` field and a short pointer:
+  > "Follow the handoff workflow defined in
+  > `.claude/skills/handoff/SKILL.md`. Same document template, same commit
+  > policy, same worktree rule."
+
+Cursor's `.mdc` frontmatter:
+
+```yaml
+---
+description: >-
+  Create a session handoff document so work can continue in a new session or
+  with another agent. Use when just saved a plan or spec, just raised or
+  merged a PR, ending a session, context-switching, or told to hand off /
+  continue later.
+globs: []
+alwaysApply: false
+---
+```
+
+This keeps the skill body in one file (no duplication, no drift) while both
+tools detect the same cues through their native mechanisms.
+
+Other agents (Copilot, Gemini, generic) pick it up via `AGENTS.md` pointer,
+which is the project's cross-agent entrypoint.
+
+## Skill metadata
+
+```yaml
+name: handoff
+description:
+  Create a session handoff document so work can continue in a new session. Use
+  when just saved a plan or spec, just raised or merged a PR, ending a session,
+  context-switching, or explicitly told to hand off / continue later.
+```
+
+The description carries the auto-invoke cues. Explicit invocation is
+`/handoff` or `/continue`.
+
+## Process
+
+When invoked, the skill instructs Claude to:
+
+1. **Auto-detect context** via shell/`gh`:
+   - `git branch --show-current` — branch name
+   - `git worktree list` — current worktree path
+   - `git status --porcelain` — count uncommitted files
+   - `git rev-list --count @{u}..HEAD` — unpushed commit count
+   - `git log -1 --pretty=format:"%h %s"` — last commit sha + subject
+   - `gh pr view --json number,state,url` — open PR for current branch (skip
+     silently if none)
+   - Recently-saved specs/plans in `docs/superpowers/specs/` and
+     `docs/superpowers/plans/` (optional — include if a recent one matches the
+     current branch's topic)
+2. **Ask one question:** "Anything specific you want captured? (key decisions,
+   gotchas, things you'll forget)". Single prompt, no follow-up loop.
+3. **Generate the document** from the template below, pre-filled with detected
+   values.
+4. **Write to** `.claude/handoffs/YYYY-MM-DD-<brief-slug>.md` in the **active
+   worktree** (never master — enforced by the project's worktree gate).
+5. **Commit the handoff** as its own baby-step commit, message
+   `docs(handoff): <brief description>`.
+6. **Print** the file path and a one-line resume hint:
+   `Saved handoff: .claude/handoffs/…md — paste that path in a new session to resume.`
+
+## Document template
+
+```markdown
+# Handoff: <brief description>
+
+**Date:** YYYY-MM-DD
+**Branch:** <branch-name>
+**Worktree:** worktrees/<name>
+**Worktree path:** /Users/leocaseiro/Sites/base-skill/worktrees/<name>
+**Git status:** clean | N uncommitted | N unpushed commits ahead of origin
+**Last commit:** <sha> <subject>
+**PR:** #NNN — open/merged/closed (omit line if none)
+
+## Resume command
+
+\`\`\`
+/resync
+cd worktrees/<name>
+<next action — e.g., execute plan docs/…md, open PR, resume debugging, etc.>
+\`\`\`
+
+## Current state
+
+**Task:** <what we're working on>
+**Phase:** exploration | planning | implementation | debugging | review | shipped
+**Progress:** <milestone or %>
+
+## What we did
+
+<2–3 sentences>
+
+## Decisions made
+
+- **<decision>** — <why>
+
+## Spec / Plan
+
+- docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md
+- docs/superpowers/plans/YYYY-MM-DD-<topic>.md (if exists)
+
+## Key files
+
+- src/…/foo.ts:42 — <what and why>
+
+## Open questions / blockers
+
+- [ ] <question>
+
+## Next steps
+
+1. [ ] <first action>
+2. [ ] <second>
+
+## Context to remember
+
+<constraints, user preferences, domain knowledge not obvious from code>
+```
+
+Sections with no content are **omitted**, not left empty — keeps the document
+scannable.
+
+## Commit policy
+
+Handoffs are committed to the branch in their own baby-step commits
+(`docs(handoff): <description>`). This matches the project's baby-step commit
+workflow:
+
+- Reviewable as part of the PR.
+- Cherry-pickable or droppable independently.
+- Easy to squash on merge if noisy.
+- Survives memory resets and worktree removal.
+
+Alternative considered: gitignore. Rejected because handoffs are genuinely
+useful history — future you, teammates, and future Claude sessions all benefit
+from reading past handoffs to understand how a branch got to its current state.
+
+## Worktree rule
+
+Handoffs are always written inside the active worktree. Never on master. The
+SKILL.md states this explicitly and the project's existing worktree gate in
+CLAUDE.md enforces it.
+
+## Quality check (self-check before writing)
+
+Before saving, the skill checks:
+
+1. Could a fresh Claude pick up from this?
+2. Are decisions traceable (the "why")?
+3. Are next steps actionable?
+4. Are file paths anchored (no vague "that function")?
+
+No quality score, no validation script — just a mental pass.
+
+## Trigger cues (auto-invoke description)
+
+The description includes these natural-language cues so Claude offers the skill
+proactively:
+
+- "just saved a plan"
+- "just saved a spec"
+- "just raised a PR"
+- "just merged a PR"
+- "continue in a new session"
+- "hand this off"
+- "end of session" / "wrap up"
+- "pick this up later"
+
+## Alias command
+
+`.claude/commands/continue.md` contains a thin slash-command wrapper that
+invokes the `handoff` skill. This lets both `/handoff` and `/continue` work as
+explicit triggers in the `/` fuzzy-search menu.
+
+Content is minimal — it just references the skill so Claude knows to run it.
+
+## Existing skills surveyed (and why not adopt directly)
+
+| Skill                                                                                          | Why not a direct fit                                                                                     |
+| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| [ykdojo/handoff](https://github.com/ykdojo/claude-code-tips/blob/main/skills/handoff/SKILL.md) | Writes single `HANDOFF.md` at repo root, not dated archive. No git metadata, no PR, no worktree support. |
+| [softaworks/session-handoff](https://github.com/softaworks/agent-toolkit)                      | Requires Python scripts, 10 sections, quality scoring, chaining — heavy for our needs.                   |
+| [Cult of Claude handoff](https://cultofclaude.com/skills/handoff/) **(chosen base)**           | Good template and process. Missing worktree/PR/resync awareness — added here.                            |
+
+## Out of scope (future work)
+
+- Generalized publishable version for skill.fish (strip BaseSkill-specific bits,
+  parameterize worktree/resync references).
+- RESUME workflow skill (read a handoff, verify staleness, begin work) — may
+  not be needed; pasting the path into a new session is usually enough.
+- Handoff chaining (linking sequential handoffs) — add if the handoff volume
+  justifies it.
+- Auto-invoke on context thresholds.
+
+## Acceptance criteria
+
+- `/handoff` (Claude Code) invoked from any branch worktree produces a dated
+  handoff at `.claude/handoffs/YYYY-MM-DD-<slug>.md` with git state,
+  worktree, PR (if any), spec/plan references, and a resume command block.
+- `/continue` produces the same result as `/handoff` in Claude Code.
+- Cursor detects the same cues via `.cursor/rules/handoff.mdc` and performs
+  the same workflow by reading `.claude/skills/handoff/SKILL.md`.
+- Description cues cause both Claude Code and Cursor to proactively offer the
+  skill after a plan, spec, or PR event.
+- The handoff is committed as a `docs(handoff): …` commit in the active
+  worktree.
+- Pasting the handoff's file path into a fresh session (in either agent) is
+  enough to resume work without further context from the user.
+- `AGENTS.md` has a pointer so tool-agnostic agents discover the skill.
+
+```
+
+```


### PR DESCRIPTION
## Summary

- Adds a project-scoped `handoff` skill that generates structured session-handoff documents so work continues cleanly across sessions.
- Includes `/continue` slash alias and a Cursor mirror so both Claude Code and Cursor pick up the same auto-invoke cues.
- Adapted from the [Cult of Claude handoff skill](https://cultofclaude.com/skills/handoff/), tailored for BaseSkill's worktree + `/resync` + baby-step commit workflow.

## Spec

[docs/superpowers/specs/2026-04-22-handoff-skill-design.md](docs/superpowers/specs/2026-04-22-handoff-skill-design.md) — implementation is directly from the spec (no separate plan; scope was small enough).

## Files

- `.claude/skills/handoff/SKILL.md` — canonical skill
- `.claude/commands/continue.md` — `/continue` alias
- `.cursor/rules/handoff.mdc` — Cursor mirror (points at the canonical file)
- `.claude/handoffs/README.md` — seeds the directory with usage notes
- `AGENTS.md` — one-line pointer for tool-agnostic agents

## Test plan

- [ ] `yarn lint:md` passes locally and in CI
- [ ] `/handoff` in Claude Code produces a dated file at `.claude/handoffs/…md` with git/worktree/PR metadata pre-filled
- [ ] `/continue` produces the same result as `/handoff`
- [ ] Cursor detects the handoff cues via `.cursor/rules/handoff.mdc`
- [ ] Dogfood handoff committed in this PR demonstrates the output shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)