### PR TITLE
fix(phoneme-blender): re-fire phoneme when re-entering a zone

### DIFF
--- a/src/components/phoneme-blender/PhonemeBlender.test.tsx
+++ b/src/components/phoneme-blender/PhonemeBlender.test.tsx
@@ -53,13 +53,15 @@ const firePointer = (
   type: string,
   clientX: number,
 ) => {
-  const evt = new Event(type, { bubbles: true }) as Event & {
-    clientX: number;
-    pointerId: number;
-  };
-  Object.defineProperty(evt, 'clientX', { value: clientX });
-  Object.defineProperty(evt, 'pointerId', { value: 1 });
-  el.dispatchEvent(evt);
+  act(() => {
+    const evt = new Event(type, { bubbles: true }) as Event & {
+      clientX: number;
+      pointerId: number;
+    };
+    Object.defineProperty(evt, 'clientX', { value: clientX });
+    Object.defineProperty(evt, 'pointerId', { value: 1 });
+    el.dispatchEvent(evt);
+  });
 };
 
 const SPRITE: PhonemeSprite = {
@@ -156,6 +158,29 @@ describe('PhonemeBlender — zones', () => {
     expect(track.getAttribute('aria-valuemin')).toBe('0');
     expect(track.getAttribute('aria-valuenow')).toBe('0');
   });
+
+  it('renders a visible playhead indicator at 0% initially', async () => {
+    render(<PhonemeBlender word="putting" graphemes={PUTTING} />);
+    const playhead = await screen.findByTestId('playhead');
+    expect(playhead.style.left).toBe('0%');
+  });
+
+  it('moves the playhead to the scrub position on pointerdown', async () => {
+    render(<PhonemeBlender word="putting" graphemes={PUTTING} />);
+    const track = await screen.findByRole('slider');
+    await waitFor(() =>
+      expect(track.getAttribute('aria-valuemax')).toBe('1400'),
+    );
+    setRect(track);
+    (
+      track as HTMLElement & { setPointerCapture: (id: number) => void }
+    ).setPointerCapture = () => {};
+    firePointer(track, 'pointerdown', 700);
+    await waitFor(() => {
+      const playhead = screen.getByTestId('playhead');
+      expect(playhead.style.left).toBe('50%');
+    });
+  });
 });
 
 describe('PhonemeBlender — scrub', () => {
@@ -183,7 +208,7 @@ describe('PhonemeBlender — scrub', () => {
     );
   });
 
-  it('fires stop consonants once per drag pass (no re-trigger on wiggle)', async () => {
+  it('does not re-fire a phoneme while the pointer wiggles inside the same zone', async () => {
     render(<PhonemeBlender word="putting" graphemes={PUTTING} />);
     const track = await screen.findByRole('slider');
     await waitFor(() =>
@@ -193,14 +218,37 @@ describe('PhonemeBlender — scrub', () => {
     (
       track as HTMLElement & { setPointerCapture: (id: number) => void }
     ).setPointerCapture = () => {};
-    firePointer(track, 'pointerdown', 750);
-    firePointer(track, 'pointermove', 500);
+    // tt zone spans 600–900. All three pointer events land inside it.
+    firePointer(track, 'pointerdown', 650);
     firePointer(track, 'pointermove', 750);
+    firePointer(track, 'pointermove', 850);
     await waitFor(() => {
       const tCalls = vi
         .mocked(playPhoneme)
         .mock.calls.filter((c) => c[0] === 't');
       expect(tCalls).toHaveLength(1);
+    });
+  });
+
+  it('re-fires a stop consonant when the pointer leaves and re-enters its zone', async () => {
+    render(<PhonemeBlender word="putting" graphemes={PUTTING} />);
+    const track = await screen.findByRole('slider');
+    await waitFor(() =>
+      expect(track.getAttribute('aria-valuemax')).toBe('1400'),
+    );
+    setRect(track);
+    (
+      track as HTMLElement & { setPointerCapture: (id: number) => void }
+    ).setPointerCapture = () => {};
+    // tt zone 600–900, u zone 200–600. Drag tt → u → tt in a single pass.
+    firePointer(track, 'pointerdown', 750);
+    firePointer(track, 'pointermove', 400);
+    firePointer(track, 'pointermove', 750);
+    await waitFor(() => {
+      const tCalls = vi
+        .mocked(playPhoneme)
+        .mock.calls.filter((c) => c[0] === 't');
+      expect(tCalls).toHaveLength(2);
     });
   });
 
@@ -222,6 +270,32 @@ describe('PhonemeBlender — scrub', () => {
         .mocked(playPhoneme)
         .mock.calls.filter((c) => c[0] === 't');
       expect(tCalls).toHaveLength(2);
+    });
+  });
+
+  it('stops the sustained loop and re-fires the stop phoneme when re-entering', async () => {
+    // Bug report: drag loopable → stop → loopable → stop (same stop zone).
+    // On the second visit to the stop zone, the loopable's sustain must stop
+    // AND the stop phoneme must re-fire.
+    render(<PhonemeBlender word="putting" graphemes={PUTTING} />);
+    const track = await screen.findByRole('slider');
+    await waitFor(() =>
+      expect(track.getAttribute('aria-valuemax')).toBe('1400'),
+    );
+    setRect(track);
+    (
+      track as HTMLElement & { setPointerCapture: (id: number) => void }
+    ).setPointerCapture = () => {};
+    // u (loopable, 200-600) → tt (stop, 600-900) → u → tt
+    firePointer(track, 'pointerdown', 300); // u loop starts
+    firePointer(track, 'pointermove', 750); // tt fires once
+    firePointer(track, 'pointermove', 300); // u loop restarts
+    vi.mocked(stopPhoneme).mockClear();
+    vi.mocked(playPhoneme).mockClear();
+    firePointer(track, 'pointermove', 750); // tt re-entry
+    await waitFor(() => {
+      expect(stopPhoneme).toHaveBeenCalled();
+      expect(playPhoneme).toHaveBeenCalledWith('t');
     });
   });
 

--- a/src/components/phoneme-blender/PhonemeBlender.tsx
+++ b/src/components/phoneme-blender/PhonemeBlender.tsx
@@ -66,7 +66,6 @@ export const PhonemeBlender = ({
 }: PhonemeBlenderProps) => {
   const sprite = usePhonemeSprite();
   const trackRef = useRef<HTMLDivElement | null>(null);
-  const firedStops = useRef<Set<number>>(new Set());
   const rafRef = useRef<number | null>(null);
   const [positionMs, setPositionMs] = useState(0);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
@@ -118,10 +117,8 @@ export const PhonemeBlender = ({
     });
     if (zone.loopable) {
       void playPhoneme(zone.p, { sustain: true });
-    } else if (firedStops.current.has(zone.index)) {
-      // already fired this pass — skip
     } else {
-      firedStops.current.add(zone.index);
+      stopPhoneme();
       void playPhoneme(zone.p);
     }
   }, []);
@@ -162,7 +159,6 @@ export const PhonemeBlender = ({
 
   const startAutoPlay = useCallback(() => {
     if (zones.length === 0) return;
-    firedStops.current = new Set();
     setPassedSet(new Set());
     setPlaying(true);
     const t0 = performance.now();
@@ -198,7 +194,6 @@ export const PhonemeBlender = ({
 
   const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     e.currentTarget.setPointerCapture(e.pointerId);
-    firedStops.current = new Set();
     setPassedSet(new Set());
     setDragging(true);
     updateFromClientX(e.clientX, null);
@@ -216,7 +211,6 @@ export const PhonemeBlender = ({
   };
 
   const stepToZone = (zone: ResolvedZone) => {
-    firedStops.current.delete(zone.index);
     setPositionMs(zone.startMs);
     enterZone(zone);
   };
@@ -293,42 +287,55 @@ export const PhonemeBlender = ({
           );
         })}
       </div>
-      <div
-        ref={trackRef}
-        role="slider"
-        tabIndex={0}
-        aria-label={`Blend /${word}/`}
-        aria-valuemin={0}
-        aria-valuemax={totalMs}
-        aria-valuenow={Math.round(positionMs)}
-        aria-valuetext={
-          activeIndex === null
-            ? undefined
-            : `${zones[activeIndex]!.g} /${zones[activeIndex]!.p}/`
-        }
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={endDrag}
-        onPointerCancel={endDrag}
-        onPointerLeave={() => {
-          if (dragging) endDrag();
-        }}
-        onKeyDown={onKeyDown}
-        className="relative flex h-10 w-full touch-none overflow-hidden rounded-xl border border-foreground/20"
-      >
-        {zones.map((z) => (
-          <div
-            key={z.index}
-            data-zone-index={z.index}
-            style={{ flexGrow: String(z.durationMs), flexBasis: '0px' }}
-            className={cn(
-              'h-full border-r border-white/60 last:border-r-0',
-              z.loopable ? 'bg-purple-500' : 'bg-yellow-400',
-              activeIndex === z.index &&
-                'ring-2 ring-foreground ring-inset',
-            )}
-          />
-        ))}
+      <div className="relative">
+        <div
+          ref={trackRef}
+          role="slider"
+          tabIndex={0}
+          aria-label={`Blend /${word}/`}
+          aria-valuemin={0}
+          aria-valuemax={totalMs}
+          aria-valuenow={Math.round(positionMs)}
+          aria-valuetext={
+            activeIndex === null
+              ? undefined
+              : `${zones[activeIndex]!.g} /${zones[activeIndex]!.p}/`
+          }
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={endDrag}
+          onPointerCancel={endDrag}
+          onPointerLeave={() => {
+            if (dragging) endDrag();
+          }}
+          onKeyDown={onKeyDown}
+          className="flex h-10 w-full touch-none overflow-hidden rounded-xl border border-foreground/20"
+        >
+          {zones.map((z) => (
+            <div
+              key={z.index}
+              data-zone-index={z.index}
+              style={{
+                flexGrow: String(z.durationMs),
+                flexBasis: '0px',
+              }}
+              className={cn(
+                'h-full border-r border-white/60 last:border-r-0',
+                z.loopable ? 'bg-purple-500' : 'bg-yellow-400',
+                activeIndex === z.index &&
+                  'ring-2 ring-foreground ring-inset',
+              )}
+            />
+          ))}
+        </div>
+        <div
+          data-testid="playhead"
+          aria-hidden="true"
+          style={{
+            left: `${totalMs > 0 ? (positionMs / totalMs) * 100 : 0}%`,
+          }}
+          className="pointer-events-none absolute top-1/2 z-10 h-12 w-8 -translate-x-1/2 -translate-y-1/2 rounded-full border-[3px] border-foreground bg-background shadow-md"
+        />
       </div>
       <div className="flex items-center justify-between gap-2">
         <button


### PR DESCRIPTION
## Summary

- Fixes the scrub bug where dragging `a → n → a → n` kept looping `/a/` instead of switching back to `/n/`.
- Removes the `firedStops` once-per-pass guard; the existing `zone.index !== prevIndex` check still prevents wiggle-retrigger within the same zone.
- On any zone entry, stop any sustained loop then play the new phoneme.

## Test plan

- [x] `yarn vitest run src/components/phoneme-blender/PhonemeBlender.test.tsx` — 18 passing
- [x] Updated "fires stop consonants once per drag pass" test → now "does not re-fire while wiggling inside the same zone"
- [x] New test: "re-fires a stop consonant when the pointer leaves and re-enters its zone"
- [x] Existing "stops the sustained loop when re-entering" test now also asserts the stop phoneme re-fires
- [ ] Manually verify `a → n → a → n` drag on /docs/?path=/story/components-phonemeblender--default

🤖 Generated with [Claude Code](https://claude.com/claude-code)