### PR TITLE
chore(mcp): drop storybook MCP from committed config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.mcp.local.json
 .env
 .env.local
 .nitro

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,9 +3,6 @@
     "playwright": {
       "command": "npx",
       "args": ["@playwright/mcp@latest"]
-    },
-    "storybook": {
-      "url": "http://localhost:6006/mcp"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,37 @@ VR tests use Docker to ensure screenshots match CI exactly (Linux/Chromium).
 **Requires Docker running.** If Docker is not available, the VR check is skipped
 with a warning.
 
+## MCP Servers
+
+The committed `.mcp.json` only includes servers that work out of the box. Extras
+that depend on a local service live in `.mcp.local.json` (gitignored) so each
+developer can opt in.
+
+### Storybook MCP (optional)
+
+The Storybook MCP connects to `http://localhost:6006/mcp` and only works while
+`yarn storybook` is running. If you want it, create `.mcp.local.json` in the
+repo root:
+
+```json
+{
+  "mcpServers": {
+    "storybook": {
+      "url": "http://localhost:6006/mcp"
+    }
+  }
+}
+```
+
+Then start Storybook in a separate terminal before your Claude session:
+
+```bash
+yarn storybook
+```
+
+Without the dev server running the MCP will fail to connect on session start —
+this is why it is not in the committed config.
+
 ## Architecture Documentation
 
 When modifying game state logic — any file in `src/components/answer-game/`,


### PR DESCRIPTION
## Summary

- Removed the `storybook` entry from `.mcp.json`. It points at `http://localhost:6006/mcp` and fails on every new Claude session where `yarn storybook` isn't already running, which is most of the time across worktrees.
- Added `.mcp.local.json` to `.gitignore` so each developer can opt back in locally without re-introducing the connection error for everyone else.
- Added a **MCP Servers** section to `CLAUDE.md` explaining how to enable the Storybook MCP locally (create `.mcp.local.json`, run `yarn storybook` first).

Playwright stays in the committed config because it runs stdio on demand (`npx @playwright/mcp@latest`) and has no long-running service requirement.

## Why

The broken MCP was firing an error on session start in every worktree. Moving it out of the committed config removes the noise while still letting anyone who wants Storybook tooling opt in with a three-line local file.

## Test plan

- [x] `yarn lint:md` passes
- [x] `npx prettier --check CLAUDE.md` passes
- [x] Pre-push hooks ran green (lint, typecheck, unit, markdownlint)
- [ ] Open a fresh Claude session in a worktree — confirm no storybook MCP connection error on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)