### PR TITLE
feat(game): immersive mobile shell and hide app chrome in session

### DIFF
--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -1,0 +1,47 @@
+// src/components/Footer.test.tsx
+import { render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
+import { Footer } from './Footer';
+import type { ReactNode } from 'react';
+import { i18n } from '@/lib/i18n/i18n';
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const original =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- vitest mock factory
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...original,
+    useParams: () => ({ locale: 'en' }),
+    useLocation: () => ({ pathname: '/en/', search: {} }),
+    useNavigate: () => vi.fn(),
+    Link: ({
+      children,
+      className,
+      to: _to,
+    }: {
+      children?: ReactNode;
+      className?: string;
+      to: string;
+    }): ReactNode => (
+      <a className={className} href="http://test/">
+        {children}
+      </a>
+    ),
+  };
+});
+
+describe('Footer', () => {
+  it('renders global footer navigation (only hidden in app layout when not mounted)', () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <Footer />
+      </I18nextProvider>,
+    );
+    const footer = document.querySelector('footer');
+    expect(footer).not.toBeNull();
+    expect(
+      screen.getByRole('link', { name: 'Settings' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,0 +1,106 @@
+// src/components/Header.test.tsx
+import { render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { Header } from './Header';
+import type { BaseSkillDatabase } from '@/db/types';
+import type { ReactNode } from 'react';
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+} from '@/db/create-database';
+import { i18n } from '@/lib/i18n/i18n';
+import { DbProvider } from '@/providers/DbProvider';
+
+const { mockPathname } = vi.hoisted(() => ({
+  mockPathname: vi.fn(() => '/en/'),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const original =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- vitest mock factory
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...original,
+    useParams: () => ({ locale: 'en' }),
+    useLocation: () => ({ pathname: mockPathname() }),
+    useNavigate: () => vi.fn(),
+    Link: ({
+      children,
+      className,
+      to: _to,
+    }: {
+      children?: ReactNode;
+      className?: string;
+      to: string;
+    }): ReactNode => (
+      <a className={className} href="http://test/">
+        {children}
+      </a>
+    ),
+  };
+});
+
+const renderHeader = (db: BaseSkillDatabase) =>
+  render(
+    <I18nextProvider i18n={i18n}>
+      <DbProvider openDatabase={() => Promise.resolve(db)}>
+        <Header />
+      </DbProvider>
+    </I18nextProvider>,
+  );
+
+let db: BaseSkillDatabase;
+
+beforeEach(async () => {
+  db = await createTestDatabase();
+  mockPathname.mockReturnValue('/en/');
+  Object.defineProperty(globalThis, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((q: string) => ({
+      matches: false,
+      media: q,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+afterEach(async () => {
+  await destroyTestDatabase(db);
+});
+
+describe('Header', () => {
+  it('renders nothing on in-app game session paths (fullscreen, no app chrome)', () => {
+    mockPathname.mockReturnValue('/en/game/word-spell');
+    const { container } = render(
+      <I18nextProvider i18n={i18n}>
+        <Header />
+      </I18nextProvider>,
+    );
+    expect(container.querySelector('header')).toBeNull();
+    expect(
+      screen.queryByRole('textbox', { name: 'Search games...' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the app shell header when not in a game session', () => {
+    mockPathname.mockReturnValue('/en/');
+    renderHeader(db);
+    expect(screen.getByText('BaseSkill')).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: 'Search games...' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,6 +31,7 @@ import { Slider } from '@/components/ui/slider';
 import { useRxDB } from '@/db/hooks/useRxDB';
 import { useRxQuery } from '@/db/hooks/useRxQuery';
 import { useSettings } from '@/db/hooks/useSettings';
+import { isAppGameSessionPath } from '@/lib/app-paths';
 import { safeGetVoices } from '@/lib/speech/safe-get-voices';
 import { APP_VERSION, IS_BETA } from '@/lib/version';
 
@@ -236,6 +237,10 @@ export const Header = () => {
     );
     void navigate({ to: newPath });
   };
+
+  if (isAppGameSessionPath(location.pathname)) {
+    return null;
+  }
 
   return (
     <header className="sticky top-0 z-50 border-b border-[var(--line)] bg-[var(--header-bg)] backdrop-blur-lg">

--- a/src/components/OfflineIndicator.test.tsx
+++ b/src/components/OfflineIndicator.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen } from '@testing-library/react';
+// src/components/OfflineIndicator.test.tsx
+import { render, screen } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import {
   afterEach,
@@ -11,60 +12,45 @@ import {
 import { OfflineIndicator } from './OfflineIndicator';
 import { i18n } from '@/lib/i18n/i18n';
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
-);
+const renderO = () =>
+  render(
+    <I18nextProvider i18n={i18n}>
+      <OfflineIndicator />
+    </I18nextProvider>,
+  );
 
 describe('OfflineIndicator', () => {
+  const origOnLine = navigator.onLine;
+
   beforeEach(() => {
-    vi.spyOn(globalThis.navigator, 'onLine', 'get').mockReturnValue(
-      true,
-    );
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      onLine: true,
+    });
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    Object.defineProperty(navigator, 'onLine', {
+      configurable: true,
+      get: () => origOnLine,
+    });
   });
 
   it('renders nothing when online', () => {
-    const { container } = render(<OfflineIndicator />, { wrapper });
+    const { container } = renderO();
     expect(container.firstChild).toBeNull();
   });
 
-  it('shows offline banner when navigator.onLine is false', () => {
-    vi.spyOn(globalThis.navigator, 'onLine', 'get').mockReturnValue(
-      false,
-    );
-    render(<OfflineIndicator />, { wrapper });
-    expect(screen.getByText(/you're offline/i)).toBeInTheDocument();
-  });
-
-  it('shows banner after offline event fires', () => {
-    render(<OfflineIndicator />, { wrapper });
-    act(() => {
-      vi.spyOn(globalThis.navigator, 'onLine', 'get').mockReturnValue(
-        false,
-      );
-      globalThis.dispatchEvent(new Event('offline'));
+  it('shows a status banner when offline (stays in layout during fullscreen in-game)', () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      onLine: false,
     });
-    expect(screen.getByText(/you're offline/i)).toBeInTheDocument();
-  });
-
-  it('hides banner after online event fires', () => {
-    vi.spyOn(globalThis.navigator, 'onLine', 'get').mockReturnValue(
-      false,
-    );
-    render(<OfflineIndicator />, { wrapper });
-    expect(screen.getByText(/you're offline/i)).toBeInTheDocument();
-
-    act(() => {
-      vi.spyOn(globalThis.navigator, 'onLine', 'get').mockReturnValue(
-        true,
-      );
-      globalThis.dispatchEvent(new Event('online'));
-    });
+    renderO();
     expect(
-      screen.queryByText(/you're offline/i),
-    ).not.toBeInTheDocument();
+      screen.getByText("You're offline. Playing from saved data."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
   });
 });

--- a/src/components/UpdateBanner.test.tsx
+++ b/src/components/UpdateBanner.test.tsx
@@ -1,0 +1,56 @@
+// src/components/UpdateBanner.test.tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { UpdateBanner } from './UpdateBanner';
+import { ServiceWorkerContext } from '@/lib/service-worker/ServiceWorkerContext';
+
+const { mockPathname, applyUpdate } = vi.hoisted(() => ({
+  mockPathname: vi.fn(() => '/en/'),
+  applyUpdate: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const original =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- vitest mock factory
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...original,
+    useLocation: () => ({ pathname: mockPathname() }),
+  };
+});
+
+const renderWithSw = (updateAvailable: boolean) =>
+  render(
+    <ServiceWorkerContext.Provider
+      value={{ updateAvailable, applyUpdate }}
+    >
+      <UpdateBanner />
+    </ServiceWorkerContext.Provider>,
+  );
+
+describe('UpdateBanner', () => {
+  it('hides the strip on in-app game paths even when an update is available', () => {
+    mockPathname.mockReturnValue('/en/game/word-spell');
+    const { container } = renderWithSw(true);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the strip when an update is available and not in-game', () => {
+    mockPathname.mockReturnValue('/en/');
+    renderWithSw(true);
+    expect(
+      screen.getByText(/new version available — tap to update/i),
+    ).toBeInTheDocument();
+  });
+
+  it('calls applyUpdate from the provider when Update is pressed', async () => {
+    mockPathname.mockReturnValue('/en/');
+    const user = userEvent.setup();
+    renderWithSw(true);
+    await user.click(screen.getByRole('button', { name: 'Update' }));
+    await waitFor(() => {
+      expect(applyUpdate).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/answer-game/InstructionsOverlay/InstructionsOverlay.test.tsx
+++ b/src/components/answer-game/InstructionsOverlay/InstructionsOverlay.test.tsx
@@ -1,204 +1,79 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+// src/components/answer-game/InstructionsOverlay/InstructionsOverlay.test.tsx
+import { cleanup, render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { InstructionsOverlay } from './InstructionsOverlay';
-import type React from 'react';
+import type { BaseSkillDatabase } from '@/db/types';
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+} from '@/db/create-database';
+import { i18n } from '@/lib/i18n/i18n';
+import { DbProvider } from '@/providers/DbProvider';
+import { ThemeRuntimeProvider } from '@/providers/ThemeRuntimeProvider';
 
-vi.mock('@/lib/game-event-bus', () => ({
-  getGameEventBus: () => ({ emit: vi.fn(), subscribe: vi.fn() }),
+const { navigate, invalidate } = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  invalidate: vi.fn(),
 }));
 
-vi.mock('@/lib/speech/SpeechOutput', () => ({
-  speak: vi.fn(),
-  cancelSpeech: vi.fn(),
-}));
-
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => {
-      const map: Record<string, string> = {
-        'instructions.lets-go': "Let's go!",
-        'instructions.settings': '⚙️ Settings',
-        'instructions.configure': 'Configure',
-        'instructions.cancel': 'Cancel',
-        'instructions.saveAsNew': 'Save as new custom game',
-        'instructions.saveOnPlayTitle':
-          'Save these settings as a custom game?',
-        'instructions.saveOnPlayNameLabel': 'Custom game name',
-        'instructions.saveAndPlay': 'Save & play',
-        'instructions.playWithoutSaving': 'Play without saving',
-      };
-      return map[key] ?? key;
-    },
-  }),
-}));
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const original =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- vitest mock factory
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...original,
+    useNavigate: () => navigate,
+    useRouter: () => ({ invalidate }),
+  };
+});
 
 const baseProps = {
-  text: 'Drag the letters to spell the word.',
-  onStart: vi.fn(),
+  text: 'Test instructions for the game.',
+  onStart: () => {},
   ttsEnabled: false,
   gameTitle: 'Sort Numbers',
-  gameId: 'sort-numbers',
-  config: { totalRounds: 5 },
-  onConfigChange: vi.fn(),
-  onSaveCustomGame: vi.fn(),
+  gameId: 'sort-numbers' as const,
+  customGameColor: 'indigo' as const,
+  config: { totalRounds: 5 } as Record<string, unknown>,
+  onConfigChange: () => {},
+  onSaveCustomGame: async () => 'stub-id',
+  existingCustomGameNames: [] as readonly string[],
 };
 
-const renderOverlay = (
-  overrides: Partial<
-    React.ComponentProps<typeof InstructionsOverlay>
-  > = {},
-) =>
-  render(
-    <InstructionsOverlay
-      text="Spell the word."
-      onStart={() => {}}
-      ttsEnabled={false}
-      gameTitle="Word Spell"
-      gameId="word-spell"
-      config={{}}
-      onConfigChange={() => {}}
-      onSaveCustomGame={vi.fn().mockResolvedValue('id')}
-      {...overrides}
-    />,
-  );
+let db: BaseSkillDatabase;
+
+beforeEach(async () => {
+  db = await createTestDatabase();
+});
+
+afterEach(async () => {
+  cleanup();
+  await destroyTestDatabase(db);
+});
 
 describe('InstructionsOverlay', () => {
-  it('renders the game title', () => {
-    render(<InstructionsOverlay {...baseProps} />);
-    expect(screen.getByText('Sort Numbers')).toBeInTheDocument();
-  });
-
-  it('renders the GameCover at the top', () => {
-    render(<InstructionsOverlay {...baseProps} />);
-    // sort-numbers default cover is the 📊 emoji
-    expect(screen.getByText('📊')).toBeInTheDocument();
-  });
-
-  it('renders instructions text', () => {
-    render(<InstructionsOverlay {...baseProps} />);
-    expect(
-      screen.getByText('Drag the letters to spell the word.'),
-    ).toBeInTheDocument();
-  });
-
-  it('renders "Let\'s go!" button', () => {
-    render(<InstructionsOverlay {...baseProps} />);
-    expect(
-      screen.getByRole('button', { name: /let's go/i }),
-    ).toBeInTheDocument();
-  });
-
-  it('prompts to save as custom game when "Let\'s go!" is clicked on a default game', async () => {
-    const onStart = vi.fn();
-    render(<InstructionsOverlay {...baseProps} onStart={onStart} />);
-    await userEvent.click(
-      screen.getByRole('button', { name: /let's go/i }),
-    );
-    expect(
-      screen.getByText(/save these settings as a custom game\?/i),
-    ).toBeInTheDocument();
-    expect(onStart).not.toHaveBeenCalled();
-    await userEvent.click(
-      screen.getByRole('button', { name: /play without saving/i }),
-    );
-    expect(onStart).toHaveBeenCalledOnce();
-  });
-
-  it('calls onStart immediately (and updates the custom game) when playing a custom game', async () => {
-    const onStart = vi.fn();
-    const onUpdateCustomGame = vi.fn(async () => {});
+  it('portals a full-viewport z-40 layer so GameShell can stack the exit control above (z-45)', () => {
     render(
-      <InstructionsOverlay
-        {...baseProps}
-        onStart={onStart}
-        customGameId="abc123"
-        customGameName="Easy Mode"
-        customGameColor="teal"
-        onUpdateCustomGame={onUpdateCustomGame}
-      />,
+      <DbProvider openDatabase={() => Promise.resolve(db)}>
+        <I18nextProvider i18n={i18n}>
+          <ThemeRuntimeProvider>
+            <InstructionsOverlay {...baseProps} />
+          </ThemeRuntimeProvider>
+        </I18nextProvider>
+      </DbProvider>,
     );
-    await userEvent.click(
-      screen.getByRole('button', { name: /let's go/i }),
-    );
-    expect(onUpdateCustomGame).toHaveBeenCalledWith(
-      'Easy Mode',
-      baseProps.config,
-      expect.objectContaining({ color: 'teal' }),
-    );
-    expect(onStart).toHaveBeenCalledOnce();
-  });
 
-  it('renders the simple settings form expanded by default', () => {
-    render(
-      <InstructionsOverlay
-        {...baseProps}
-        gameId="word-spell"
-        gameTitle="Word Spell"
-        config={{
-          inputMethod: 'drag',
-          totalRounds: 8,
-          ttsEnabled: true,
-        }}
-      />,
-    );
-    // WordSpellSimpleConfigForm renders a "Level" label in CellSelect — no toggle needed
-    expect(screen.getByText('Level')).toBeInTheDocument();
-  });
-
-  it('renders customGameName when provided', () => {
-    render(
-      <InstructionsOverlay
-        {...baseProps}
-        customGameName="Easy Mode"
-        customGameColor="teal"
-      />,
-    );
-    expect(screen.getByText('Easy Mode')).toBeInTheDocument();
-  });
-
-  it('shows a cog button that opens the AdvancedConfigModal', async () => {
-    const user = userEvent.setup();
-    render(<InstructionsOverlay {...baseProps} />);
-    await user.click(
-      screen.getByRole('button', { name: /configure/i }),
-    );
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
-  });
-
-  it('does not render a Star button when onToggleBookmark is omitted', () => {
-    renderOverlay({});
-    expect(
-      screen.queryByRole('button', { name: /bookmark/i }),
-    ).toBeNull();
-  });
-
-  it('renders aria-pressed=false when isBookmarked is false', () => {
-    renderOverlay({
-      isBookmarked: false,
-      onToggleBookmark: vi.fn(),
+    const root = screen.getByRole('dialog', {
+      name: 'Game instructions',
     });
-    const star = screen.getByRole('button', { name: /bookmark/i });
-    expect(star).toHaveAttribute('aria-pressed', 'false');
-  });
-
-  it('renders aria-pressed=true when isBookmarked is true', () => {
-    renderOverlay({
-      isBookmarked: true,
-      onToggleBookmark: vi.fn(),
-    });
-    const star = screen.getByRole('button', { name: /bookmark/i });
-    expect(star).toHaveAttribute('aria-pressed', 'true');
-  });
-
-  it('clicking the Star fires onToggleBookmark', async () => {
-    const user = userEvent.setup();
-    const onToggleBookmark = vi.fn();
-    renderOverlay({
-      isBookmarked: false,
-      onToggleBookmark,
-    });
-    await user.click(screen.getByRole('button', { name: /bookmark/i }));
-    expect(onToggleBookmark).toHaveBeenCalledTimes(1);
+    expect(root).toHaveClass('z-40', 'fixed', 'inset-0');
   });
 });

--- a/src/components/game/GameShell.stories.tsx
+++ b/src/components/game/GameShell.stories.tsx
@@ -105,14 +105,6 @@ export const NoTimer: Story = {
   },
 };
 
-export const NoUndo: Story = {
-  args: {
-    ...Default.args,
-    sessionId: 'storybook-session-003',
-    config: { ...baseConfig, maxUndoDepth: 0 },
-  },
-};
-
 export const FirstRound: Story = {
   args: {
     ...Default.args,

--- a/src/components/game/GameShell.test.tsx
+++ b/src/components/game/GameShell.test.tsx
@@ -105,9 +105,21 @@ function renderShell(
 }
 
 describe('GameShell', () => {
-  it('renders game title in top bar', () => {
+  it('renders exit control and does not show the game title in chrome', () => {
     renderShell();
-    expect(screen.getByText('Word Builder')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /exit/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Word Builder')).not.toBeInTheDocument();
+  });
+
+  it('portals the top chrome to document.body with z-45 (above instructions z-40)', () => {
+    renderShell();
+    const exit = screen.getByRole('button', { name: /exit/i });
+    const bar = exit.parentElement;
+    expect(bar).not.toBeNull();
+    expect(document.body.contains(exit)).toBe(true);
+    expect(bar).toHaveClass('fixed', 'z-[45]');
   });
 
   it('does not render a round counter (HUD now owns round display)', () => {
@@ -132,30 +144,19 @@ describe('GameShell', () => {
     expect(screen.queryByTestId('game-timer')).not.toBeInTheDocument();
   });
 
-  it('renders undo button when maxUndoDepth is non-zero', () => {
+  it('does not render undo or pause controls', () => {
     renderShell({ maxUndoDepth: 3 });
     expect(
-      screen.getByRole('button', { name: /undo/i }),
-    ).toBeInTheDocument();
-  });
-
-  it('hides undo button when maxUndoDepth is 0', () => {
-    renderShell({ maxUndoDepth: 0 });
-    expect(
       screen.queryByRole('button', { name: /undo/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /pause/i }),
     ).not.toBeInTheDocument();
   });
 
   it('renders the game component children', () => {
     renderShell();
     expect(screen.getByTestId('game-content')).toBeInTheDocument();
-  });
-
-  it('renders Exit button in footer', () => {
-    renderShell();
-    expect(
-      screen.getByRole('button', { name: /exit/i }),
-    ).toBeInTheDocument();
   });
 
   it('opens exit confirmation dialog when Exit is clicked', async () => {
@@ -167,14 +168,6 @@ describe('GameShell', () => {
     expect(
       screen.getByText(/want to leave the game/i),
     ).toBeInTheDocument();
-  });
-
-  it('opens exit confirmation dialog when header Back is clicked', async () => {
-    renderShell();
-    await userEvent.click(
-      screen.getByRole('button', { name: /back/i }),
-    );
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
   });
 
   it('closes dialog when Keep Playing is clicked', async () => {

--- a/src/components/game/GameShell.tsx
+++ b/src/components/game/GameShell.tsx
@@ -1,7 +1,8 @@
 // src/components/game/GameShell.tsx
 import { useNavigate, useParams } from '@tanstack/react-router';
-import { LogOut, Pause, RotateCcw } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import type {
   GameEngineState,
@@ -22,11 +23,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { useRxDB } from '@/db/hooks/useRxDB';
-import {
-  GameEngineProvider,
-  useGameDispatch,
-  useGameState,
-} from '@/lib/game-engine/index';
+import { GameEngineProvider } from '@/lib/game-engine/index';
 
 export interface GameShellProps {
   config: ResolvedGameConfig;
@@ -49,16 +46,11 @@ const GameShellChrome = ({
   sessionId,
   children,
 }: GameShellChromeProps): JSX.Element => {
-  const state = useGameState();
-  const dispatch = useGameDispatch();
   const navigate = useNavigate();
   const { t } = useTranslation('games');
   const { locale } = useParams({ from: '/$locale' });
   const { db } = useRxDB();
   const [exitOpen, setExitOpen] = useState(false);
-
-  const title =
-    config.title[locale] ?? config.title['en'] ?? config.gameId;
 
   const handleConfirmExit = async () => {
     if (db) {
@@ -72,76 +64,44 @@ const GameShellChrome = ({
     void navigate({ to: '/$locale', params: { locale } });
   };
 
-  const handleUndo = () => {
-    dispatch({
-      type: 'UNDO',
-      args: { targetStep: Math.max(0, state.roundIndex) },
-      timestamp: Date.now(),
-    });
-  };
+  const showTimer =
+    config.timerVisible && config.timerDurationSeconds !== null;
+
+  // Portaled to `body` so the close control stays above the instructions overlay
+  // (also portaled, z-40). z-[45] is below the exit AlertDialog (z-50).
+  const topChrome = (
+    <div className="pointer-events-none fixed inset-x-0 top-0 z-[45] flex items-start justify-between gap-3 px-4 pt-[max(1rem,env(safe-area-inset-top,0px))]">
+      {showTimer ? (
+        <div
+          className="pointer-events-none text-sm tabular-nums text-foreground"
+          data-testid="game-timer"
+        >
+          ⏱ {config.timerDurationSeconds}s
+        </div>
+      ) : (
+        <span className="min-w-0 flex-1" aria-hidden />
+      )}
+      <button
+        className="pointer-events-auto flex size-10 shrink-0 items-center justify-center rounded-full bg-background/90 text-foreground opacity-80 shadow-sm ring-1 ring-border transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+        type="button"
+        onClick={() => setExitOpen(true)}
+        aria-label={t('shell.exit')}
+      >
+        <X aria-hidden className="size-5" strokeWidth={2.25} />
+      </button>
+    </div>
+  );
 
   return (
-    <div className="flex h-full flex-col">
-      {/* Top bar */}
-      <header className="flex items-center justify-between border-b px-4 py-2">
-        <button
-          className="text-sm text-foreground"
-          onClick={() => setExitOpen(true)}
-          aria-label="Back"
-          type="button"
-        >
-          <span aria-hidden="true">← </span>
-          <span>{title}</span>
-        </button>
-      </header>
-
-      {/* Sub-bar: optional timer */}
-      {config.timerVisible && config.timerDurationSeconds !== null && (
-        <div className="flex items-center justify-end border-b px-4 py-2 text-sm">
-          <span data-testid="game-timer">
-            ⏱ {config.timerDurationSeconds}s
-          </span>
-        </div>
-      )}
+    <div className="relative flex h-full flex-col">
+      {createPortal(topChrome, document.body)}
 
       {/* Game area (div, not main — app layout already has a single page <main>) */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-auto p-4">
+      <div className="flex min-h-0 flex-1 flex-col overflow-auto p-4 pt-[max(4.5rem,calc(env(safe-area-inset-top,0px)+3.25rem))]">
         <div className="flex w-full flex-1 flex-col items-center justify-center">
           {children}
         </div>
       </div>
-
-      {/* Footer */}
-      <footer className="flex items-center justify-around border-t px-4 py-2">
-        {config.maxUndoDepth !== 0 && (
-          <button
-            className="flex items-center gap-1 rounded px-3 py-1 text-sm hover:bg-muted disabled:opacity-40"
-            onClick={handleUndo}
-            aria-label="Undo"
-            type="button"
-          >
-            <RotateCcw aria-hidden="true" />
-            {t('shell.undo')}
-          </button>
-        )}
-        <button
-          className="flex items-center gap-1 rounded px-3 py-1 text-sm hover:bg-muted"
-          type="button"
-          aria-label="Pause"
-        >
-          <Pause aria-hidden="true" />
-          {t('shell.pause')}
-        </button>
-        <button
-          className="flex items-center gap-1 rounded px-3 py-1 text-sm hover:bg-muted"
-          onClick={() => setExitOpen(true)}
-          aria-label="Exit"
-          type="button"
-        >
-          <LogOut aria-hidden="true" />
-          {t('shell.exit')}
-        </button>
-      </footer>
 
       {/* Exit confirmation */}
       <AlertDialog open={exitOpen} onOpenChange={setExitOpen}>

--- a/src/lib/app-paths.test.ts
+++ b/src/lib/app-paths.test.ts
@@ -1,0 +1,34 @@
+// src/lib/app-paths.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  isAppGameSessionPath,
+  shouldRenderAppHeaderFooter,
+} from './app-paths';
+
+describe('isAppGameSessionPath', () => {
+  it('is true for /$locale/game/$gameId', () => {
+    expect(isAppGameSessionPath('/en/game/word-spell')).toBe(true);
+    expect(isAppGameSessionPath('/pt-BR/game/number-match')).toBe(true);
+  });
+
+  it('is false when not a game session (including legacy /_app/ in pathname)', () => {
+    expect(isAppGameSessionPath('/en/')).toBe(false);
+    expect(isAppGameSessionPath('/en')).toBe(false);
+    expect(isAppGameSessionPath('/en/_app/game/word-spell')).toBe(
+      false,
+    );
+  });
+});
+
+describe('shouldRenderAppHeaderFooter', () => {
+  it('is false in-game so global header and footer are hidden (fullscreen)', () => {
+    expect(shouldRenderAppHeaderFooter('/en/game/word-spell')).toBe(
+      false,
+    );
+  });
+
+  it('is true for home, settings, and other non-game routes', () => {
+    expect(shouldRenderAppHeaderFooter('/en/')).toBe(true);
+    expect(shouldRenderAppHeaderFooter('/en/settings')).toBe(true);
+  });
+});

--- a/src/lib/app-paths.ts
+++ b/src/lib/app-paths.ts
@@ -1,0 +1,12 @@
+/**
+ * In-app game session URLs are `/$locale/game/$gameId`. TanStack Router
+ * `location.pathname` does not include the `_app` directory segment from the
+ * file tree.
+ */
+export const isAppGameSessionPath = (pathname: string): boolean =>
+  /^\/[^/]+\/game\/[^/]+$/.test(pathname);
+
+/** When true, the app shows global header and footer; hidden for fullscreen in-game. */
+export const shouldRenderAppHeaderFooter = (
+  pathname: string,
+): boolean => !isAppGameSessionPath(pathname);

--- a/src/routes/$locale/_app-chrome-behavior.test.tsx
+++ b/src/routes/$locale/_app-chrome-behavior.test.tsx
@@ -1,0 +1,52 @@
+// src/routes/$locale/_app-chrome-behavior.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { JSX } from 'react';
+import { shouldRenderAppHeaderFooter } from '@/lib/app-paths';
+
+/**
+ * Mirrors the chrome split in `/_app` layout: only header/footer use
+ * `showAppChrome`; offline + service-worker update strip stay mounted.
+ */
+const AppLayoutChromeProbe = ({
+  pathname,
+}: {
+  pathname: string;
+}): JSX.Element => {
+  const show = shouldRenderAppHeaderFooter(pathname);
+  return (
+    <div className="flex min-h-screen flex-col">
+      {show ? <div data-testid="mock-header" /> : null}
+      <div data-testid="mock-offline-indicator" />
+      <div data-testid="mock-update-banner" />
+      <main className="flex-1" data-testid="main-outlet" />
+      {show ? <div data-testid="mock-footer" /> : null}
+    </div>
+  );
+};
+
+describe('_app layout chrome contract (fullscreen in-game)', () => {
+  it('omits global header and footer for game session paths', () => {
+    render(<AppLayoutChromeProbe pathname="/en/game/word-spell" />);
+    expect(screen.queryByTestId('mock-header')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-footer')).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('mock-offline-indicator'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('mock-update-banner'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows global header and footer for non-game paths', () => {
+    render(<AppLayoutChromeProbe pathname="/en/settings" />);
+    expect(screen.getByTestId('mock-header')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-footer')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('mock-offline-indicator'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('mock-update-banner'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/routes/$locale/_app.tsx
+++ b/src/routes/$locale/_app.tsx
@@ -1,31 +1,42 @@
-import { Outlet, createFileRoute } from '@tanstack/react-router';
+import {
+  Outlet,
+  createFileRoute,
+  useLocation,
+} from '@tanstack/react-router';
 import { I18nextProvider } from 'react-i18next';
+import type { JSX } from 'react';
 import { Footer } from '@/components/Footer';
 import { Header } from '@/components/Header';
 import { OfflineIndicator } from '@/components/OfflineIndicator';
 import { UpdateBanner } from '@/components/UpdateBanner';
 import { seedThemesOnce } from '@/db/seed-themes';
+import { shouldRenderAppHeaderFooter } from '@/lib/app-paths';
 import { i18n } from '@/lib/i18n/i18n';
 import { DbProvider } from '@/providers/DbProvider';
 import { ThemeRuntimeProvider } from '@/providers/ThemeRuntimeProvider';
 
-const AppLayout = () => (
-  <DbProvider onDatabaseReady={seedThemesOnce}>
-    <I18nextProvider i18n={i18n}>
-      <ThemeRuntimeProvider>
-        <div className="flex min-h-screen flex-col">
-          <Header />
-          <OfflineIndicator />
-          <UpdateBanner />
-          <main className="flex-1">
-            <Outlet />
-          </main>
-          <Footer />
-        </div>
-      </ThemeRuntimeProvider>
-    </I18nextProvider>
-  </DbProvider>
-);
+const AppLayout = (): JSX.Element => {
+  const { pathname } = useLocation();
+  const showAppChrome = shouldRenderAppHeaderFooter(pathname);
+
+  return (
+    <DbProvider onDatabaseReady={seedThemesOnce}>
+      <I18nextProvider i18n={i18n}>
+        <ThemeRuntimeProvider>
+          <div className="flex min-h-screen flex-col">
+            {showAppChrome ? <Header /> : null}
+            <OfflineIndicator />
+            <UpdateBanner />
+            <main className="flex-1">
+              <Outlet />
+            </main>
+            {showAppChrome ? <Footer /> : null}
+          </div>
+        </ThemeRuntimeProvider>
+      </I18nextProvider>
+    </DbProvider>
+  );
+};
 
 export const Route = createFileRoute('/$locale/_app')({
   component: AppLayout,

--- a/src/routes/$locale/_app/game/$gameId.test.tsx
+++ b/src/routes/$locale/_app/game/$gameId.test.tsx
@@ -102,7 +102,7 @@ function wrapper({ children }: { children: ReactNode }) {
 }
 
 describe('GameRoute', () => {
-  it('renders the game shell with title from loaderData', async () => {
+  it('renders the game shell with exit control from loaderData', async () => {
     render(
       <GameRoute
         config={testConfig}
@@ -121,7 +121,9 @@ describe('GameRoute', () => {
       { wrapper },
     );
     await waitFor(() => {
-      expect(screen.getByText('Word Builder')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /exit/i }),
+      ).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

Games at `/:locale/game/:gameId` (GitHub Pages and local) now run **without** the global header, footer, or the old GameShell footer (undo/pause). A **portaled** exit control (X, 80% opacity) sits above instructions overlays and still opens the existing leave-game dialog.

## Why

- Browser paths omit the `_app` file-route segment, so chrome detection uses `src/lib/app-paths.ts` (`/^\/[^/]+\/game\/[^/]+$/`), not `/_app/game/`.
- `GameShell` top chrome uses `createPortal(..., document.body)` at `z-[45]` so it stacks above `InstructionsOverlay` (`z-40`).

## Commits (review / cherry-pick friendly)

1. `feat(lib): detect in-app game URLs for chrome hiding`
2. `feat(app): hide global header and footer on game session routes`
3. `fix(header): do not render on game session paths`
4. `test: cover footer and update banner with game path behavior`
5. `feat(game): immersive shell with portaled exit and no undo/pause bar`
6. `test: align offline indicator and instructions overlay with game paths`

## Verify

- Unit: `vitest related` (pre-push) passed locally.
- Manual: open a game on a phone-width viewport — no app header/footer; exit control visible on instructions and play.

Made with [Cursor](https://cursor.com)