### PR TITLE
chore: add specstory-sync script and `yarn specstory`

### DIFF
--- a/docs/specstory-sync.md
+++ b/docs/specstory-sync.md
@@ -1,0 +1,76 @@
+# SpecStory History Sync
+
+`yarn specstory` (a.k.a. `scripts/specstory-sync.sh`) consolidates every
+`.specstory/history/*.md` file from every branch and every linked worktree
+into a single PR against `master`, so the GitHub repo always holds the full
+SpecStory archive.
+
+## What it does
+
+1. Fetches `origin/master`.
+2. Picks the next free branch name in the form
+   `chore/specstory-sync-YYYY-MM-DD_N`.
+3. Creates a fresh worktree at `worktrees/specstory-sync-YYYY-MM-DD_N/`
+   from `origin/master` (your current worktree is **not** the source).
+4. Pass 1 — for every branch under `refs/heads/*` and
+   `refs/remotes/origin/*`, reads `.specstory/history/*.md` straight from
+   the git object database via `git ls-tree` + `git show` (no checkout).
+5. Pass 2 — for every linked worktree, copies any `.specstory/history/*.md`
+   off disk so uncommitted history files are captured too.
+6. Commits the union, pushes the branch, and opens a PR via `gh`.
+7. Removes the temporary worktree (the remote branch stays for the PR).
+
+### Collision policy
+
+When the same filename exists in multiple sources with different content,
+the **longest content wins**. SpecStory writes history files
+append-only per session, so longest == most complete.
+
+## Safety guarantees
+
+The script is read-only against your existing worktrees. It never:
+
+- runs `git stash`, `git checkout`, `git reset`, or `git add` outside its
+  own temporary worktree;
+- mutates the index or working tree of any other worktree;
+- deletes branches it didn't just create.
+
+This means staged, unstaged, untracked, mid-rebase, and mid-merge state in
+every other worktree is preserved exactly as-is. Uncommitted history files
+**do** get included in the PR (their working-tree contents are copied), but
+the source files themselves are not moved or modified.
+
+## Usage
+
+```bash
+# Full run: branch + commit + push + PR
+yarn specstory
+
+# Commit locally on the new branch but skip push and PR
+yarn specstory --no-pr
+
+# Leave the temporary worktree on disk for inspection
+yarn specstory --keep-worktree
+
+# Help
+yarn specstory --help
+```
+
+You can run `yarn specstory` from any worktree — it auto-locates the
+primary checkout and creates the temporary worktree under the primary
+`worktrees/` directory.
+
+## Requirements
+
+- A clean-enough environment: `gh` authenticated against the repo (only
+  needed for the default mode that opens a PR).
+- Network access for `git fetch origin master` and `git push`.
+
+## When to run it
+
+There is no automation. Run `yarn specstory` whenever you want to
+checkpoint the SpecStory archive into `master` — typically before pruning
+old branches or worktrees, or on a cadence (weekly is plenty).
+
+If nothing has changed since the last sync, the script exits cleanly,
+removes the empty worktree, deletes the empty branch, and opens no PR.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "word:seed": "tsx scripts/seed-word-library.ts",
     "word:phonemes": "tsx scripts/generate-phoneme-sprite.ts",
     "words:import": "tsx scripts/words-import.ts",
+    "specstory": "bash scripts/specstory-sync.sh",
     "lint": "eslint . --max-warnings 0 && knip --no-config-hints",
     "lint:css": "stylelint 'src/**/*.css'",
     "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules' '#.specstory' '#.cursor' '#dist' '#worktrees'",

--- a/scripts/specstory-sync.sh
+++ b/scripts/specstory-sync.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Sync .specstory/history/*.md from every branch (local + origin) and every
+# linked worktree into a fresh chore/specstory-sync-<DATE>_<N> branch off
+# origin/master, then open a PR against master.
+#
+# Read-only against your existing worktrees: never stashes, checks out, or
+# stages anything anywhere outside the temporary worktree it creates itself.
+# Uncommitted, staged, untracked, and mid-rebase state in any worktree is
+# preserved exactly as-is.
+#
+# Collision policy: longest file content wins. SpecStory history files are
+# append-only per session, so longest == most complete.
+#
+# Usage:
+#   scripts/specstory-sync.sh                 # full run: branch + commit + push + PR
+#   scripts/specstory-sync.sh --no-pr         # commit locally; skip push/PR
+#   scripts/specstory-sync.sh --keep-worktree # leave temp worktree on disk
+#   scripts/specstory-sync.sh --help
+
+set -euo pipefail
+
+NO_PR=false
+KEEP_WORKTREE=false
+
+usage() {
+  cat <<'EOF'
+Usage: specstory-sync.sh [--no-pr] [--keep-worktree] [-h|--help]
+
+  Unions .specstory/history/*.md from every branch (local + origin/*) and
+  every linked worktree into a new chore/specstory-sync-<DATE>_<N> branch
+  off origin/master, commits, pushes, and opens a PR against master.
+
+  --no-pr           Commit locally; do not push or open a PR.
+  --keep-worktree   Leave the temporary worktree on disk for inspection.
+  -h, --help        Show this help.
+
+Safe to run while other worktrees have uncommitted, staged, or mid-rebase
+state — the script only ever reads from them.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-pr) NO_PR=true ;;
+    --keep-worktree) KEEP_WORKTREE=true ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+# Locate primary checkout (so relative `worktrees/...` lands in the right place).
+repo_root=$(git rev-parse --show-toplevel)
+common_dir=$(git rev-parse --git-common-dir)
+[[ "$common_dir" = /* ]] || common_dir=$(cd "$repo_root/$common_dir" && pwd -P)
+primary_root=$(dirname "$common_dir")
+
+cd "$primary_root"
+
+# Make sure we have an up-to-date origin/master to branch from.
+echo "→ fetching origin (quiet)"
+git fetch origin master --quiet || {
+  echo "warning: git fetch origin master failed; using local refs as-is" >&2
+}
+
+today=$(date +%Y-%m-%d)
+branch_prefix="chore/specstory-sync-${today}"
+
+existing_refs=$(git for-each-ref --format='%(refname:short)' \
+  "refs/heads/${branch_prefix}_*" \
+  "refs/remotes/origin/${branch_prefix}_*" 2>/dev/null || true)
+
+n=1
+while printf '%s\n' "$existing_refs" | grep -qE "^(origin/)?${branch_prefix}_${n}\$"; do
+  n=$((n + 1))
+done
+new_branch="${branch_prefix}_${n}"
+new_worktree="worktrees/specstory-sync-${today}_${n}"
+
+# Capture the branch list BEFORE creating the new worktree, so pass 1 doesn't
+# scan the (initially empty) new branch.
+mapfile -t branches < <(
+  git for-each-ref --format='%(refname)' refs/heads refs/remotes/origin \
+    | grep -v '/HEAD$' || true
+)
+
+tmp=$(mktemp -d)
+
+cleanup() {
+  local code=$?
+  if [[ "$KEEP_WORKTREE" = true ]]; then
+    echo "→ keeping worktree at $new_worktree (per --keep-worktree)"
+  else
+    cd "$primary_root" 2>/dev/null || true
+    git worktree remove --force "$new_worktree" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmp" 2>/dev/null || true
+  exit "$code"
+}
+trap cleanup EXIT
+
+echo "→ creating worktree $new_worktree on $new_branch (from origin/master)"
+git worktree add "$new_worktree" -b "$new_branch" origin/master >/dev/null
+
+dest_rel="$new_worktree/.specstory/history"
+mkdir -p "$dest_rel"
+dest=$(cd "$dest_rel" && pwd -P)
+new_wt_abs=$(cd "$new_worktree" && pwd -P)
+
+# Adopt $source as $target if (a) target missing, or (b) source is strictly
+# longer than current target. Append-only history → longest == most complete.
+adopt_if_longer() {
+  local target=$1 source=$2
+  if [[ ! -f "$target" ]]; then
+    cp "$source" "$target"
+    return
+  fi
+  local cur new
+  cur=$(wc -c <"$target" | tr -d ' ')
+  new=$(wc -c <"$source" | tr -d ' ')
+  if ((new > cur)); then
+    cp "$source" "$target"
+  fi
+}
+
+# --- Pass 1: every branch (local heads + origin remote-tracking) ---
+# Emit `<size>\t<sha>\t<basename>` rows from every ref via one `git ls-tree`
+# per ref (no per-file forks), then keep the largest blob per filename.
+branch_count=${#branches[@]}
+{
+  for ref in "${branches[@]}"; do
+    git ls-tree -r --long "$ref" -- .specstory/history 2>/dev/null || true
+  done
+} | awk -F'\t' '
+  {
+    # ls-tree --long: "<mode> blob <sha> <size>\t<path>"
+    split($1, hdr, " ");
+    if (hdr[2] != "blob") next;
+    sha = hdr[3]; size = hdr[4] + 0;
+    path = $2;
+    n = split(path, parts, "/"); fname = parts[n];
+    if (!(fname in best) || size > best[fname]) {
+      best[fname] = size; sha_of[fname] = sha;
+    }
+  }
+  END {
+    for (f in sha_of) print sha_of[f] "\t" f;
+  }
+' >"$tmp/winners.tsv"
+
+blob_count=$(wc -l <"$tmp/winners.tsv" | tr -d ' ')
+
+# Materialize the winning blobs. ~hundreds of files → loop is fine.
+while IFS=$'\t' read -r sha fname; do
+  [[ -z "$sha" || -z "$fname" ]] && continue
+  git cat-file blob "$sha" >"$dest/$fname"
+done <"$tmp/winners.tsv"
+echo "→ pass 1: scanned $branch_count branches, picked $blob_count winning history blobs"
+
+# --- Pass 2: every linked worktree's filesystem (catches uncommitted) ---
+wt_count=0
+wt_files=0
+while IFS= read -r wt_path; do
+  [[ -z "$wt_path" ]] && continue
+  wt_abs=$(cd "$wt_path" 2>/dev/null && pwd -P) || continue
+  [[ "$wt_abs" = "$new_wt_abs" ]] && continue
+  hist_dir="$wt_abs/.specstory/history"
+  [[ -d "$hist_dir" ]] || continue
+  wt_count=$((wt_count + 1))
+  shopt -s nullglob
+  for f in "$hist_dir"/*.md; do
+    fname=$(basename "$f")
+    adopt_if_longer "$dest/$fname" "$f"
+    wt_files=$((wt_files + 1))
+  done
+  shopt -u nullglob
+done < <(git worktree list --porcelain | awk '/^worktree /{ $1=""; sub(/^ /,""); print }')
+echo "→ pass 2: scanned $wt_count worktrees, considered $wt_files history files"
+
+# --- Stage & commit ---
+cd "$primary_root/$new_worktree"
+git add .specstory/history
+
+if git diff --cached --quiet; then
+  echo "✓ nothing new to sync — every history file already at origin/master"
+  cd "$primary_root"
+  git worktree remove --force "$new_worktree" >/dev/null 2>&1 || true
+  git branch -D "$new_branch" >/dev/null 2>&1 || true
+  KEEP_WORKTREE=true # prevent trap from re-running remove
+  exit 0
+fi
+
+added=$(git diff --cached --name-only | wc -l | tr -d ' ')
+git commit -m "chore(specstory): sync history from all branches and worktrees
+
+Aggregates .specstory/history/*.md from every local + origin branch and every
+linked worktree into a single PR. Longest-content wins on filename collisions.
+
+Files added/updated: $added" >/dev/null
+
+if [[ "$NO_PR" = true ]]; then
+  echo "✓ committed locally on $new_branch ($added files). --no-pr set; not pushing."
+  exit 0
+fi
+
+echo "→ pushing $new_branch to origin"
+git push -u origin "$new_branch" >/dev/null
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "warning: gh CLI not found. Branch pushed; open PR manually." >&2
+  exit 0
+fi
+
+echo "→ opening PR via gh"
+gh pr create --base master --head "$new_branch" \
+  --title "chore(specstory): sync history ${today}_${n}" \
+  --body "$(
+    cat <<EOF
+Aggregates \`.specstory/history/*.md\` from every branch (local + \`origin/*\`)
+and every linked worktree into one branch.
+
+- Sources: $branch_count branches + $wt_count worktrees scanned
+- Files added/updated: $added
+- Collision policy: longest-content wins (history files are append-only)
+
+Generated by \`scripts/specstory-sync.sh\` (\`yarn specstory\`).
+EOF
+  )"
+
+echo "✓ PR opened for $new_branch"


### PR DESCRIPTION
## Summary

- Adds `scripts/specstory-sync.sh` and a `yarn specstory` shortcut that unions
  `.specstory/history/*.md` from every branch (local + `origin/*`) and every
  linked worktree into a fresh `chore/specstory-sync-<DATE>_<N>` branch off
  `origin/master`, commits, pushes, and opens a PR via `gh`.
- Adds `docs/specstory-sync.md` explaining usage, safety guarantees, and the
  longest-content-wins collision policy.

## Why

Keeps the GitHub repo's `master` as the single source of truth for the
SpecStory archive without anyone having to remember to commit history files
from feature branches.

## How it works

- **Pass 1** — for every ref under `refs/heads` and `refs/remotes/origin`, run
  one `git ls-tree -r --long <ref> -- .specstory/history`, aggregate results
  with `awk` (largest-blob-per-filename), then materialise winners with
  `git cat-file blob`. ~311 branches → ~30 seconds (an earlier per-file
  `git show` version took >15 minutes).
- **Pass 2** — copy any uncommitted `.specstory/history/*.md` files from each
  linked worktree's filesystem, applying the same longest-wins rule.

## Safety

The script is read-only against existing worktrees. It never runs `git stash`,
`git checkout`, `git reset`, or `git add` anywhere outside the temporary
worktree it creates. Staged, unstaged, untracked, mid-rebase, and mid-merge
state in every other worktree is preserved exactly as-is. Uncommitted history
files **do** get included in the resulting PR (their working-tree contents are
read), but the source files themselves are never moved or modified.

## Usage

```bash
yarn specstory                  # full run: branch + commit + push + PR
yarn specstory --no-pr          # commit locally; skip push/PR
yarn specstory --keep-worktree  # leave temp worktree on disk
yarn specstory --help
```

## Test plan

- [x] `bash -n scripts/specstory-sync.sh` syntax-clean
- [x] `yarn lint:md` passes (new `docs/specstory-sync.md`)
- [x] End-to-end dry-run with `--no-pr --keep-worktree`: 311 branches +
      15 worktrees scanned, 246 winning blobs picked, 139 files committed
      to the temp branch in 29 seconds.
- [x] Verified primary checkout and other worktrees were not modified by
      the script (mtimes of pre-existing modified files predate every run).
- [ ] Reviewer to spot-check `docs/specstory-sync.md` for accuracy.
- [ ] Reviewer to run `yarn specstory --no-pr` locally and inspect the
      resulting branch before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)