### PR TITLE
stories(components/GameGrid): retrofit per single-Default Playground

### DIFF
--- a/src/components/GameGrid.stories.tsx
+++ b/src/components/GameGrid.stories.tsx
@@ -1,52 +1,46 @@
+import { fn } from 'storybook/test';
+
 import { GameCard } from './GameCard';
 import { GameGrid } from './GameGrid';
 import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentType } from 'react';
 
-const SAMPLE_CARDS = [
-  <GameCard
-    key="wordspell"
-    variant="default"
-    gameId="word-spell"
-    title="Word Spell"
-    chips={['PK', 'K']}
-    onPlay={() => {}}
-    onOpenCog={() => {}}
-  />,
-  <GameCard
-    key="numbermatch"
-    variant="default"
-    gameId="number-match"
-    title="Match the Number"
-    chips={['1', '2']}
-    onPlay={() => {}}
-    onOpenCog={() => {}}
-  />,
-  <GameCard
-    key="sortnumbers"
-    variant="default"
-    gameId="sort-numbers"
-    title="Sort Numbers"
-    chips={['K', '1']}
-    onPlay={() => {}}
-    onOpenCog={() => {}}
-  />,
-];
+interface StoryArgs {
+  cardCount: number;
+  // Raw GameGrid prop shadowed by the cardCount bridge — hidden from Controls.
+  cards?: never;
+}
 
-const meta: Meta<typeof GameGrid> = {
-  component: GameGrid,
+const meta: Meta<StoryArgs> = {
+  component: GameGrid as unknown as ComponentType<StoryArgs>,
   tags: ['autodocs'],
   args: {
-    cards: SAMPLE_CARDS,
+    cardCount: 3,
   },
+  argTypes: {
+    cardCount: {
+      control: { type: 'range', min: 0, max: 12, step: 1 },
+    },
+    cards: { table: { disable: true } },
+  },
+  render: ({ cardCount }) => (
+    <GameGrid
+      cards={Array.from({ length: cardCount }, (_, i) => (
+        <GameCard
+          key={`card-${String(i)}`}
+          variant="default"
+          gameId="sort-numbers"
+          title={`Card ${String(i + 1)}`}
+          chips={['K', '1', '2']}
+          onPlay={fn()}
+          onOpenCog={fn()}
+        />
+      ))}
+    />
+  ),
 };
 export default meta;
 
-type Story = StoryObj<typeof GameGrid>;
+type Story = StoryObj<StoryArgs>;
 
 export const Default: Story = {};
-
-export const Empty: Story = {
-  args: {
-    cards: [],
-  },
-};

--- a/src/components/GameGrid.stories.tsx
+++ b/src/components/GameGrid.stories.tsx
@@ -5,8 +5,26 @@ import { GameGrid } from './GameGrid';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { ComponentType } from 'react';
 
+interface SampleCardSeed {
+  gameId: string;
+  title: string;
+  chips: string[];
+}
+
+const SAMPLE_CARD_SEEDS: readonly SampleCardSeed[] = [
+  { gameId: 'word-spell', title: 'Word Spell', chips: ['PK', 'K'] },
+  {
+    gameId: 'number-match',
+    title: 'Match the Number',
+    chips: ['1', '2'],
+  },
+  { gameId: 'sort-numbers', title: 'Sort Numbers', chips: ['K', '1'] },
+];
+
 interface StoryArgs {
   cardCount: number;
+  onPlay: () => void;
+  onOpenCog: () => void;
   // Raw GameGrid prop shadowed by the cardCount bridge — hidden from Controls.
   cards?: never;
 }
@@ -18,32 +36,41 @@ const meta: Meta<StoryArgs> = {
     docs: {
       description: {
         component:
-          'Responsive grid that lays GameCard children out in 2/3/4 columns at xs/lg/xl breakpoints. The cardCount range drives how many sample cards render — slide to 0 for the empty state, or up to 12 to see how the grid wraps.',
+          'Responsive grid that lays GameCard children out in 2/3/4 columns at xs/lg/xl breakpoints. The cardCount range drives how many sample cards render — slide to 0 for the empty state, or up to 12 to see how the grid wraps. Sample cards cycle through the three real game seeds (word-spell, number-match, sort-numbers) so the layout reflects realistic cover art.',
       },
     },
   },
   args: {
     cardCount: 3,
+    onPlay: fn(),
+    onOpenCog: fn(),
   },
   argTypes: {
     cardCount: {
       control: { type: 'range', min: 0, max: 12, step: 1 },
     },
+    onPlay: { table: { disable: true } },
+    onOpenCog: { table: { disable: true } },
     cards: { table: { disable: true } },
   },
-  render: ({ cardCount }) => (
+  render: ({ cardCount, onPlay, onOpenCog }) => (
     <GameGrid
-      cards={Array.from({ length: cardCount }, (_, i) => (
-        <GameCard
-          key={`card-${String(i)}`}
-          variant="default"
-          gameId="sort-numbers"
-          title={`Card ${String(i + 1)}`}
-          chips={['K', '1', '2']}
-          onPlay={fn()}
-          onOpenCog={fn()}
-        />
-      ))}
+      cards={Array.from({ length: cardCount }, (_, i) => {
+        // Modulo by a positive constant always yields a valid index;
+        // noUncheckedIndexedAccess can't see that, so assert it.
+        const seed = SAMPLE_CARD_SEEDS[i % SAMPLE_CARD_SEEDS.length]!;
+        return (
+          <GameCard
+            key={`${seed.gameId}-${String(i)}`}
+            variant="default"
+            gameId={seed.gameId}
+            title={seed.title}
+            chips={seed.chips}
+            onPlay={onPlay}
+            onOpenCog={onOpenCog}
+          />
+        );
+      })}
     />
   ),
 };

--- a/src/components/GameGrid.stories.tsx
+++ b/src/components/GameGrid.stories.tsx
@@ -14,6 +14,14 @@ interface StoryArgs {
 const meta: Meta<StoryArgs> = {
   component: GameGrid as unknown as ComponentType<StoryArgs>,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Responsive grid that lays GameCard children out in 2/3/4 columns at xs/lg/xl breakpoints. The cardCount range drives how many sample cards render — slide to 0 for the empty state, or up to 12 to see how the grid wraps.',
+      },
+    },
+  },
   args: {
     cardCount: 3,
   },
@@ -43,4 +51,4 @@ export default meta;
 
 type Story = StoryObj<StoryArgs>;
 
-export const Default: Story = {};
+export const Playground: Story = {};


### PR DESCRIPTION
## Summary

Tier 3, file 1 of 5 — retrofits \`src/components/GameGrid.stories.tsx\` to the single-Default Playground pattern and Controls Policy in issue #125.

- \`cardCount\` range (0–12) drives how many GameCards render.
- \`cards\` is shadowed (\`?: never\` + \`table: { disable: true }\`) — never meaningful as a control.
- Sample cards wire \`onPlay\` / \`onOpenCog\` to \`fn()\` spies.
- Single \`Default\` story — the \`cardCount\` range reaches every prior state (0, 3, 12).
- Skin wrapping is handled by the global \`withDefaultSkin\` decorator (PR #154); no per-file wrapper.

Closes part of #125.

## Test plan

- [ ] \`yarn typecheck\` green
- [ ] \`yarn lint\` green
- [ ] \`yarn test:storybook\` green (runs in CI)
- [ ] Controls panel drives the single \`Default\` export (cardCount slider reaches 0, 3, and 12 cards visibly)