### PR TITLE
stories(components/GameNameChip): retrofit per single-Default Playground

### DIFF
--- a/src/components/GameNameChip.stories.tsx
+++ b/src/components/GameNameChip.stories.tsx
@@ -5,6 +5,14 @@ import { GAME_COLOR_KEYS } from '@/lib/game-colors';
 const meta: Meta<typeof GameNameChip> = {
   component: GameNameChip,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Coloured chip that renders a game's display name — used on GameCard, InstructionsOverlay, and across the app to identify a saved game. Set customGameName to flip the chip into custom-game mode (custom name as primary heading, gameTitle as a coloured subtitle). The AllColors auxiliary story surveys all 12 game-color keys.",
+      },
+    },
+  },
   args: {
     title: 'Word Spell',
   },
@@ -22,7 +30,7 @@ export default meta;
 
 type Story = StoryObj<typeof GameNameChip>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const AllColors: Story = {
   render: () => (

--- a/src/components/GameNameChip.stories.tsx
+++ b/src/components/GameNameChip.stories.tsx
@@ -1,12 +1,21 @@
-import { withDarkMode } from '../../.storybook/decorators';
 import { GameNameChip } from './GameNameChip';
 import type { Meta, StoryObj } from '@storybook/react';
+import { GAME_COLOR_KEYS } from '@/lib/game-colors';
 
 const meta: Meta<typeof GameNameChip> = {
   component: GameNameChip,
   tags: ['autodocs'],
   args: {
     title: 'Word Spell',
+  },
+  argTypes: {
+    title: { control: 'text' },
+    customGameName: { control: 'text' },
+    customGameColor: {
+      control: { type: 'select' },
+      options: GAME_COLOR_KEYS,
+    },
+    subject: { control: 'text' },
   },
 };
 export default meta;
@@ -15,53 +24,10 @@ type Story = StoryObj<typeof GameNameChip>;
 
 export const Default: Story = {};
 
-export const DefaultDark: Story = {
-  decorators: [withDarkMode],
-};
-
-export const WithCustomGame: Story = {
-  args: {
-    customGameName: 'Easy Mode',
-    customGameColor: 'indigo',
-  },
-};
-
-export const WithCustomGameDark: Story = {
-  args: {
-    customGameName: 'Easy Mode',
-    customGameColor: 'indigo',
-  },
-  decorators: [withDarkMode],
-};
-
-export const WithSubject: Story = {
-  args: { subject: 'reading' },
-};
-
-export const WithSubjectDark: Story = {
-  args: { subject: 'reading' },
-  decorators: [withDarkMode],
-};
-
 export const AllColors: Story = {
   render: () => (
     <div className="flex flex-col gap-2">
-      {(
-        [
-          'indigo',
-          'teal',
-          'rose',
-          'amber',
-          'sky',
-          'lime',
-          'purple',
-          'orange',
-          'pink',
-          'emerald',
-          'slate',
-          'cyan',
-        ] as const
-      ).map((color) => (
+      {GAME_COLOR_KEYS.map((color) => (
         <GameNameChip
           key={color}
           title="Word Spell"
@@ -71,9 +37,4 @@ export const AllColors: Story = {
       ))}
     </div>
   ),
-};
-
-export const AllColorsDark: Story = {
-  ...AllColors,
-  decorators: [withDarkMode],
 };


### PR DESCRIPTION
## Summary

Tier 3, file 3 of 5 — retrofits `src/components/GameNameChip.stories.tsx` to the single-Default Playground pattern and Controls Policy in issue #125.

- `customGameColor` → select from `GAME_COLOR_KEYS`; `title`, `customGameName`, `subject` → text controls.
- Collapse to `Default` + `AllColors` only. Drop `WithCustomGame`, `WithSubject` (reachable from Controls) and all `*Dark` variants (theme toolbar reproduces them).
- `AllColors` kept as a legitimate auxiliary — 12-colour palette survey not reachable from Controls in one click.
- Skin wrapping handled by the global `withDefaultSkin` decorator (PR #154); no per-file wrapper.

Closes part of #125.

## Test plan

- [ ] `yarn typecheck` green
- [ ] `yarn lint` green
- [ ] `yarn test:storybook` green (runs in CI)
- [ ] Controls panel drives customGameColor select across all keys