### PR TITLE
stories(components/GameCard): retrofit per single-Default Playground

### DIFF
--- a/src/components/GameCard.stories.tsx
+++ b/src/components/GameCard.stories.tsx
@@ -1,79 +1,115 @@
-import { GameCard } from './GameCard';
-import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
 
-const meta: Meta<typeof GameCard> = {
-  component: GameCard,
+import { GameCard } from './GameCard';
+import type { GameColorKey } from '@/lib/game-colors';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentType } from 'react';
+import { GAME_COLOR_KEYS } from '@/lib/game-colors';
+
+type Variant = 'default' | 'customGame';
+
+interface StoryArgs {
+  variant: Variant;
+  gameId: string;
+  title: string;
+  chipsText: string;
+  customGameName: string;
+  customGameColor: GameColorKey;
+  bookmarkable: boolean;
+  isBookmarked: boolean;
+  // Shadowed raw props — driven by StoryArgs above; hidden from Controls.
+  chips?: never;
+  cover?: never;
+  onPlay?: never;
+  onOpenCog?: never;
+  onToggleBookmark?: never;
+}
+
+const meta: Meta<StoryArgs> = {
+  component: GameCard as unknown as ComponentType<StoryArgs>,
   tags: ['autodocs'],
+  parameters: { layout: 'centered' },
   args: {
+    variant: 'default',
     gameId: 'sort-numbers',
     title: 'Count in Order',
-    chips: ['🚀 Up', '5 numbers', '2s'],
+    chipsText: '🚀 Up, 5 numbers, 2s',
+    customGameName: 'Skip by 2',
+    customGameColor: 'indigo',
+    bookmarkable: false,
+    isBookmarked: false,
   },
   argTypes: {
-    onPlay: { action: 'played' },
-    onOpenCog: { action: 'cogOpened' },
-    onToggleBookmark: { action: 'bookmarkToggled' },
+    variant: {
+      control: { type: 'radio' },
+      options: ['default', 'customGame'] satisfies Variant[],
+    },
+    gameId: { control: 'text' },
+    title: { control: 'text' },
+    chipsText: { control: 'text' },
+    customGameName: { control: 'text' },
+    customGameColor: {
+      control: { type: 'select' },
+      options: GAME_COLOR_KEYS,
+    },
+    bookmarkable: { control: 'boolean' },
+    isBookmarked: { control: 'boolean' },
+    chips: { table: { disable: true } },
+    cover: { table: { disable: true } },
+    onPlay: { table: { disable: true } },
+    onOpenCog: { table: { disable: true } },
+    onToggleBookmark: { table: { disable: true } },
+  },
+  render: ({
+    variant,
+    gameId,
+    title,
+    chipsText,
+    customGameName,
+    customGameColor,
+    bookmarkable,
+    isBookmarked,
+  }) => {
+    const chips = chipsText
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const bookmarkProps = bookmarkable
+      ? { isBookmarked, onToggleBookmark: fn() }
+      : {};
+
+    return (
+      <div className="w-64">
+        {variant === 'customGame' ? (
+          <GameCard
+            variant="customGame"
+            gameId={gameId}
+            title={title}
+            chips={chips}
+            customGameName={customGameName || 'Custom'}
+            customGameColor={customGameColor}
+            onPlay={fn()}
+            onOpenCog={fn()}
+            {...bookmarkProps}
+          />
+        ) : (
+          <GameCard
+            variant="default"
+            gameId={gameId}
+            title={title}
+            chips={chips}
+            onPlay={fn()}
+            onOpenCog={fn()}
+            {...bookmarkProps}
+          />
+        )}
+      </div>
+    );
   },
 };
 export default meta;
 
-type Story = StoryObj<typeof GameCard>;
+type Story = StoryObj<StoryArgs>;
 
-export const Default: Story = {
-  args: {
-    variant: 'default',
-  },
-};
-
-export const CustomGame: Story = {
-  args: {
-    variant: 'customGame',
-    customGameName: 'Skip by 2',
-    customGameColor: 'amber',
-  },
-};
-
-export const CustomGamePurple: Story = {
-  args: {
-    variant: 'customGame',
-    customGameName: 'Big to Small',
-    customGameColor: 'purple',
-    chips: ['⬇️ Down', '10 numbers', '3s'],
-  },
-};
-
-export const NotBookmarked: Story = {
-  args: {
-    variant: 'default',
-    isBookmarked: false,
-    onToggleBookmark: () => {},
-  },
-};
-
-export const Bookmarked: Story = {
-  args: {
-    variant: 'default',
-    isBookmarked: true,
-    onToggleBookmark: () => {},
-  },
-};
-
-export const NotBookmarkedCustomGame: Story = {
-  args: {
-    variant: 'customGame',
-    customGameName: 'Skip by 2',
-    customGameColor: 'amber',
-    isBookmarked: false,
-    onToggleBookmark: () => {},
-  },
-};
-
-export const BookmarkedCustomGame: Story = {
-  args: {
-    variant: 'customGame',
-    customGameName: 'Skip by 2',
-    customGameColor: 'amber',
-    isBookmarked: true,
-    onToggleBookmark: () => {},
-  },
-};
+export const Default: Story = {};

--- a/src/components/GameCard.stories.tsx
+++ b/src/components/GameCard.stories.tsx
@@ -4,9 +4,12 @@ import { GameCard } from './GameCard';
 import type { GameColorKey } from '@/lib/game-colors';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { ComponentType } from 'react';
+import { GAME_CATALOG } from '@/games/registry';
 import { GAME_COLOR_KEYS } from '@/lib/game-colors';
 
 type Variant = 'default' | 'customGame';
+
+const GAME_IDS = GAME_CATALOG.map((g) => g.id);
 
 interface StoryArgs {
   variant: Variant;
@@ -17,12 +20,12 @@ interface StoryArgs {
   customGameColor: GameColorKey;
   bookmarkable: boolean;
   isBookmarked: boolean;
+  onPlay: () => void;
+  onOpenCog: () => void;
+  onToggleBookmark: () => void;
   // Shadowed raw props — driven by StoryArgs above; hidden from Controls.
   chips?: never;
   cover?: never;
-  onPlay?: never;
-  onOpenCog?: never;
-  onToggleBookmark?: never;
 }
 
 const meta: Meta<StoryArgs> = {
@@ -33,7 +36,7 @@ const meta: Meta<StoryArgs> = {
     docs: {
       description: {
         component:
-          'Bookmark-aware game tile used on the homepage and saved-games view. The variant radio toggles between the default cover and the customGame coloured chip; bookmarkable + isBookmarked expose the full bookmark matrix. The card is wrapped in a w-64 container to mimic GameGrid cell width at xl/2xl breakpoints.',
+          'Bookmark-aware game tile used on the homepage and saved-games view. The variant radio toggles between the default cover and the customGame coloured chip; bookmarkable + isBookmarked expose the full bookmark matrix. gameId is a select over the real GAME_CATALOG so the default cover swaps between the three shipped games. The card is wrapped in a w-64 container to mimic GameGrid cell width at xl/2xl breakpoints.',
       },
     },
   },
@@ -46,13 +49,19 @@ const meta: Meta<StoryArgs> = {
     customGameColor: 'indigo',
     bookmarkable: false,
     isBookmarked: false,
+    onPlay: fn(),
+    onOpenCog: fn(),
+    onToggleBookmark: fn(),
   },
   argTypes: {
     variant: {
       control: { type: 'radio' },
       options: ['default', 'customGame'] satisfies Variant[],
     },
-    gameId: { control: 'text' },
+    gameId: {
+      control: { type: 'select' },
+      options: GAME_IDS,
+    },
     title: { control: 'text' },
     chipsText: { control: 'text' },
     customGameName: { control: 'text' },
@@ -64,9 +73,6 @@ const meta: Meta<StoryArgs> = {
     isBookmarked: { control: 'boolean' },
     chips: { table: { disable: true } },
     cover: { table: { disable: true } },
-    onPlay: { table: { disable: true } },
-    onOpenCog: { table: { disable: true } },
-    onToggleBookmark: { table: { disable: true } },
   },
   render: ({
     variant,
@@ -77,6 +83,9 @@ const meta: Meta<StoryArgs> = {
     customGameColor,
     bookmarkable,
     isBookmarked,
+    onPlay,
+    onOpenCog,
+    onToggleBookmark,
   }) => {
     const chips = chipsText
       .split(',')
@@ -84,7 +93,7 @@ const meta: Meta<StoryArgs> = {
       .filter(Boolean);
 
     const bookmarkProps = bookmarkable
-      ? { isBookmarked, onToggleBookmark: fn() }
+      ? { isBookmarked, onToggleBookmark }
       : {};
 
     return (
@@ -97,8 +106,8 @@ const meta: Meta<StoryArgs> = {
             chips={chips}
             customGameName={customGameName || 'Custom'}
             customGameColor={customGameColor}
-            onPlay={fn()}
-            onOpenCog={fn()}
+            onPlay={onPlay}
+            onOpenCog={onOpenCog}
             {...bookmarkProps}
           />
         ) : (
@@ -107,8 +116,8 @@ const meta: Meta<StoryArgs> = {
             gameId={gameId}
             title={title}
             chips={chips}
-            onPlay={fn()}
-            onOpenCog={fn()}
+            onPlay={onPlay}
+            onOpenCog={onOpenCog}
             {...bookmarkProps}
           />
         )}

--- a/src/components/GameCard.stories.tsx
+++ b/src/components/GameCard.stories.tsx
@@ -28,7 +28,15 @@ interface StoryArgs {
 const meta: Meta<StoryArgs> = {
   component: GameCard as unknown as ComponentType<StoryArgs>,
   tags: ['autodocs'],
-  parameters: { layout: 'centered' },
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Bookmark-aware game tile used on the homepage and saved-games view. The variant radio toggles between the default cover and the customGame coloured chip; bookmarkable + isBookmarked expose the full bookmark matrix. The card is wrapped in a w-64 container to mimic GameGrid cell width at xl/2xl breakpoints.',
+      },
+    },
+  },
   args: {
     variant: 'default',
     gameId: 'sort-numbers',
@@ -112,4 +120,4 @@ export default meta;
 
 type Story = StoryObj<StoryArgs>;
 
-export const Default: Story = {};
+export const Playground: Story = {};


### PR DESCRIPTION
## Summary

Tier 3, file 2 of 5 — retrofits \`src/components/GameCard.stories.tsx\` to the single-Default Playground pattern and Controls Policy in issue #125.

- \`variant\` radio, \`customGameColor\` select from \`GAME_COLOR_KEYS\`, \`chipsText\` splits on commas.
- \`isBookmarked\` + \`bookmarkable\` expose the full bookmark matrix via args.
- Handlers wired via \`fn()\` in the render function; raw prop rows hidden from Controls.
- Collapse prior scenario exports into a single \`Default\` story.
- Render realism: card wrapped in \`<div className="w-64">\` (~grid-cell size) with \`layout: 'centered'\`.
- Skin wrapping handled by the global \`withDefaultSkin\` decorator (PR #154); no per-file wrapper.

Closes part of #125.

## Test plan

- [ ] \`yarn typecheck\` green
- [ ] \`yarn lint\` green
- [ ] \`yarn test:storybook\` green (runs in CI)
- [ ] Controls panel drives variant / customGameColor / bookmark combinations
- [ ] Card renders at realistic grid-cell width (not stretched to full canvas)