### PR TITLE
stories(stories/ThemeShowcase): retrofit per single-Default Playground

### DIFF
--- a/src/stories/ThemeShowcase.stories.tsx
+++ b/src/stories/ThemeShowcase.stories.tsx
@@ -137,4 +137,4 @@ export default meta;
 
 type Story = StoryObj<typeof GameShell>;
 
-export const Default: Story = {};
+export const Playground: Story = {};

--- a/src/stories/ThemeShowcase.stories.tsx
+++ b/src/stories/ThemeShowcase.stories.tsx
@@ -108,6 +108,12 @@ const meta = {
   decorators: [withDb, withRouter],
   parameters: {
     layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Token-only page composed from GameShell + GameNameChip + ConfigFormFields. Cycle through the registered themes via the toolbar.',
+      },
+    },
   },
   args: {
     config: shellConfig,
@@ -117,25 +123,18 @@ const meta = {
     meta: sessionMeta,
     children: <ShowcaseBody />,
   },
+  argTypes: {
+    config: { table: { disable: true } },
+    moves: { table: { disable: true } },
+    initialState: { table: { disable: true } },
+    sessionId: { table: { disable: true } },
+    meta: { table: { disable: true } },
+    initialLog: { table: { disable: true } },
+    children: { table: { disable: true } },
+  },
 } satisfies Meta<typeof GameShell>;
 export default meta;
 
 type Story = StoryObj<typeof GameShell>;
 
-// ── 4 locked-theme VR stories ─────────────────────────────────────────────
-
-export const OceanLight: Story = {
-  parameters: { globals: { theme: 'light' } },
-};
-
-export const OceanDark: Story = {
-  parameters: { globals: { theme: 'dark' } },
-};
-
-export const ForestLight: Story = {
-  parameters: { globals: { theme: 'forest-light' } },
-};
-
-export const ForestDark: Story = {
-  parameters: { globals: { theme: 'forest-dark' } },
-};
+export const Default: Story = {};

--- a/src/stories/ThemeShowcase.stories.tsx
+++ b/src/stories/ThemeShowcase.stories.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { fn } from 'storybook/test';
 import { withDb } from '../../.storybook/decorators/withDb';
 import { withRouter } from '../../.storybook/decorators/withRouter';
 import type { ConfigField } from '@/lib/config-fields';
@@ -8,6 +10,7 @@ import type {
   SessionMeta,
 } from '@/lib/game-engine/types';
 import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentType } from 'react';
 import { ConfigFormFields } from '@/components/ConfigFormFields';
 import { GameShell } from '@/components/game/GameShell';
 import { GameNameChip } from '@/components/GameNameChip';
@@ -83,26 +86,54 @@ const configFields: ConfigField[] = [
 
 // ── Story body ────────────────────────────────────────────────────────────
 
-const ShowcaseBody = () => (
-  <div className="flex flex-col gap-4 p-4">
-    <GameNameChip
-      title="Sort Numbers"
-      customGameName="Easy Numbers"
-      customGameColor="teal"
-    />
-    <GameNameChip title="Word Spell" subject="reading" />
-    <ConfigFormFields
-      fields={configFields}
-      config={{ inputMethod: 'drag', totalRounds: 8, ttsEnabled: true }}
-      onChange={() => {}}
-    />
-  </div>
-);
+interface ShowcaseBodyProps {
+  onConfigChange: (config: Record<string, unknown>) => void;
+}
+
+const ShowcaseBody = ({ onConfigChange }: ShowcaseBodyProps) => {
+  const [formConfig, setFormConfig] = useState<Record<string, unknown>>(
+    {
+      inputMethod: 'drag',
+      totalRounds: 8,
+      ttsEnabled: true,
+    },
+  );
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <GameNameChip
+        title="Sort Numbers"
+        customGameName="Easy Numbers"
+        customGameColor="teal"
+      />
+      <GameNameChip title="Word Spell" subject="reading" />
+      <ConfigFormFields
+        fields={configFields}
+        config={formConfig}
+        onChange={(next) => {
+          setFormConfig(next);
+          onConfigChange(next);
+        }}
+      />
+    </div>
+  );
+};
 
 // ── Meta ──────────────────────────────────────────────────────────────────
 
-const meta = {
-  component: GameShell,
+interface StoryArgs {
+  onConfigChange: (config: Record<string, unknown>) => void;
+  // Shadowed GameShell props — fixed by the showcase, hidden from Controls.
+  config?: never;
+  moves?: never;
+  initialState?: never;
+  sessionId?: never;
+  meta?: never;
+  initialLog?: never;
+  children?: never;
+}
+
+const meta: Meta<StoryArgs> = {
+  component: GameShell as unknown as ComponentType<StoryArgs>,
   title: 'Pages/ThemeShowcase',
   tags: ['autodocs'],
   decorators: [withDb, withRouter],
@@ -111,19 +142,15 @@ const meta = {
     docs: {
       description: {
         component:
-          'Token-only page composed from GameShell + GameNameChip + ConfigFormFields. Cycle through the registered themes via the toolbar.',
+          'Token-only page composed from GameShell + GameNameChip + ConfigFormFields. Cycle through the registered themes via the toolbar. Form fields are stateful so editing a value updates the rendered preview, and onChange invocations log to the Actions panel.',
       },
     },
   },
   args: {
-    config: shellConfig,
-    moves: {},
-    initialState,
-    sessionId: 'showcase-session',
-    meta: sessionMeta,
-    children: <ShowcaseBody />,
+    onConfigChange: fn(),
   },
   argTypes: {
+    onConfigChange: { table: { disable: true } },
     config: { table: { disable: true } },
     moves: { table: { disable: true } },
     initialState: { table: { disable: true } },
@@ -132,9 +159,20 @@ const meta = {
     initialLog: { table: { disable: true } },
     children: { table: { disable: true } },
   },
-} satisfies Meta<typeof GameShell>;
+  render: ({ onConfigChange }) => (
+    <GameShell
+      config={shellConfig}
+      moves={{}}
+      initialState={initialState}
+      sessionId="showcase-session"
+      meta={sessionMeta}
+    >
+      <ShowcaseBody onConfigChange={onConfigChange} />
+    </GameShell>
+  ),
+};
 export default meta;
 
-type Story = StoryObj<typeof GameShell>;
+type Story = StoryObj<StoryArgs>;
 
 export const Playground: Story = {};


### PR DESCRIPTION
## Summary

Tier 3, file 5 of 5 — retrofits `src/stories/ThemeShowcase.stories.tsx` to the single-Default Playground pattern and Controls Policy in issue #125.

- Hide all 7 GameShell-prop rows from Controls via `argTypes.table.disable`.
- Collapse theme-pinned exports into a single `Default` — the theme toolbar reproduces every pin in one tap.
- Skin wrapping handled globally by `withDefaultSkin` (PR #154); no per-file wrapper.

Closes part of #125.

## Test plan

- [ ] `yarn typecheck` green
- [ ] `yarn lint` green
- [ ] `yarn test:storybook` green (runs in CI)
- [ ] Controls panel is empty on the `Default` story (all docgen rows hidden)
- [ ] Theme toolbar cycles through registered themes on the single `Default` story