### PR TITLE
docs(skill/write-storybook): rename Default to Playground throughout

### DIFF
--- a/.claude/skills/write-storybook/SKILL.md
+++ b/.claude/skills/write-storybook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-storybook
-description: Use when adding, writing, or refactoring Storybook stories for React components in this project — enforces the single-Default Playground pattern, controls policy, decorators, and a11y rules
+description: Use when adding, writing, or refactoring Storybook stories for React components in this project — enforces the single-Playground pattern, controls policy, decorators, and a11y rules
 ---
 
 # Write Storybook
@@ -9,7 +9,7 @@ description: Use when adding, writing, or refactoring Storybook stories for Reac
 
 Stories live co-located with their component (`ComponentName.stories.tsx`). This project uses `@storybook/react` with TanStack Router and `next-themes`.
 
-**The standard pattern is the "Playground"**: every component gets a **single `Default` story** driven by proper interactive controls (selects, booleans, ranges, color pickers, text inputs). The control surface is the playground — designers, QA, and developers explore every UI behaviour by tweaking controls, not by clicking between a dozen named stories.
+**The standard pattern is the "Playground"**: every component gets a **single `Playground` story** driven by proper interactive controls (selects, booleans, ranges, color pickers, text inputs). The control surface is the playground — designers, QA, and developers explore every UI behaviour by tweaking controls, not by clicking between a dozen named stories.
 
 This pattern applies when:
 
@@ -27,11 +27,12 @@ Additional named stories are only added when a scenario genuinely **cannot** be 
 ## Rules
 
 - **Always use `export default meta`** for the meta object (framework config file — the one exception to the named-export rule)
-- **All story variants use named exports**: `export const Default: Story = {}`
-- Every story file **must include a `Default` story** — this is the Playground; every prop that affects UI must be driveable from its controls
+- **All story variants use named exports**: `export const Playground: Story = {}`
+- Every story file **must include a `Playground` story** — every prop that affects UI must be driveable from its controls
+- The Playground export **must be named exactly `Playground`** (not `Default`). Every reference story in this project uses this name — see [InstructionsOverlay](../../../src/components/answer-game/InstructionsOverlay/InstructionsOverlay.stories.tsx)
 - Use `tags: ['autodocs']` in meta unless there's a reason not to
 - Do NOT import `React` — JSX transform handles it
-- Auxiliary named stories are allowed only when a scenario can't be expressed by toggling controls on `Default` (see "When to Add Auxiliary Stories")
+- Auxiliary named stories are allowed only when a scenario can't be expressed by toggling controls on `Playground` (see "When to Add Auxiliary Stories")
 
 ## File Structure
 
@@ -41,7 +42,7 @@ src/components/MyComponent.stories.tsx
 
 ## Minimal Template
 
-The Playground pattern: a single `Default` story, with every UI-affecting prop wired as a control on `meta`. Props are set once in `meta.args` so they serve as the Playground's baseline.
+The Playground pattern: a single `Playground` story, with every UI-affecting prop wired as a control on `meta`. Props are set once in `meta.args` so they serve as the Playground's baseline.
 
 ```tsx
 import { fn } from 'storybook/test';
@@ -52,7 +53,7 @@ const meta: Meta<typeof MyComponent> = {
   component: MyComponent,
   tags: ['autodocs'],
   args: {
-    // Baseline values for the Playground — one place, drives Default.
+    // Baseline values for the Playground — one place, drives Playground.
     onClick: fn(), // Actions panel logs every invocation (see "Callbacks & Listeners")
   },
   argTypes: {
@@ -65,10 +66,10 @@ type Story = StoryObj<typeof MyComponent>;
 
 // The Playground. Empty body — it inherits meta.args and renders the
 // interactive control surface.
-export const Default: Story = {};
+export const Playground: Story = {};
 ```
 
-Extra named stories are only added when a scenario can't be expressed by flipping controls on `Default` — see "When to Add Auxiliary Stories".
+Extra named stories are only added when a scenario can't be expressed by flipping controls on `Playground` — see "When to Add Auxiliary Stories".
 
 ## Decorators
 
@@ -212,9 +213,9 @@ The Controls panel now shows individual `mode` and `rounds` inputs, and the rend
 
 ## Playground Pattern
 
-The goal: one `Default` story where **every** UI behaviour is reachable by flipping controls. Designers and QA get a single URL to explore the full component surface.
+The goal: one `Playground` story where **every** UI behaviour is reachable by flipping controls. Designers and QA get a single URL to explore the full component surface.
 
-### What belongs in `Default`
+### What belongs in `Playground`
 
 - Every string-union / enum prop → `select` or `radio` control, so switching values swaps the visual in place.
 - Every boolean prop → `boolean` control.
@@ -227,7 +228,7 @@ If a UI behaviour isn't reachable through the Playground, the Playground is inco
 
 ### When to Add Auxiliary Stories
 
-Only add a named story beyond `Default` when the scenario **cannot** be expressed by the Playground's control surface. Typical reasons:
+Only add a named story beyond `Playground` when the scenario **cannot** be expressed by the Playground's control surface. Typical reasons:
 
 - **Stateful wrappers that can't be modeled as a prop.** Example: `EncouragementAnnouncer` has a `ReplayTrigger` story because the component's `visible` prop is toggled by a local `useState` wrapper — the Playground shows the "start visible" state; `ReplayTrigger` shows the "user must click to show it" flow. Both are useful; neither is expressible purely through controls.
 - **Pinned theme or viewport** that's meaningfully different (e.g., a high-contrast-only edge case). See "Themes per Story" and "Viewport per Story".
@@ -277,7 +278,7 @@ Rule of thumb: if you can observe the callback by toggling a control, use contro
 - The component's primary flow is non-trivial and not already covered by an e2e test.
 - You want an assertion (keyboard-only flow, validation error appearing, focus management) that the Actions panel can't express.
 
-Add a `play()` to `Default` when the interaction is central, or create a dedicated named story per flow. Skip `play()` for pure-display components or when e2e coverage already asserts the same behaviour.
+Add a `play()` to `Playground` when the interaction is central, or create a dedicated named story per flow. Skip `play()` for pure-display components or when e2e coverage already asserts the same behaviour.
 
 Import helpers from `storybook/test`:
 
@@ -528,7 +529,7 @@ exit $TEST_EXIT
 
 When you edit an existing story file for any reason, run this checklist before opening the PR. Each item is a yes/no gate — if any answer is "no," either fix or justify in the PR description.
 
-- [ ] A single `Default` story exists and every UI-affecting prop is reachable from its controls (the Playground)
+- [ ] A single `Playground` story exists and every UI-affecting prop is reachable from its controls (the Playground)
 - [ ] All non-callback, non-JSX props have proper `argTypes` controls (no raw JSON for enums/booleans/numbers/colors)
 - [ ] Every `onFoo` handler wired to a `fn()` spy in `args` (shows in [Actions panel](https://storybook.js.org/docs/essentials/actions); usable in `play()` if needed) — do NOT rely on the global `argTypesRegex` alone; it only covers props already in `argTypes`, which react-docgen doesn't produce for DOM-extended props
 - [ ] Auxiliary named stories (if any) exist only for scenarios the Playground's controls can't express — see "When to Add Auxiliary Stories". Remove named stories that duplicate what a control toggle would show.
@@ -543,23 +544,24 @@ If you're touching the file, leave it better than you found it.
 
 ## Common Mistakes
 
-| Mistake                                                  | Fix                                                                                                                                                                              |
-| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `import React from 'react'` at top                       | Remove — not needed                                                                                                                                                              |
-| Named export for meta (`export const meta`)              | Use `export default meta`                                                                                                                                                        |
-| Default export for stories (`export default Default`)    | Use `export const Default: Story = {}`                                                                                                                                           |
-| Missing `Default` story                                  | Always add one — it is the Playground                                                                                                                                            |
-| Multiple stories duplicating what a control would toggle | Delete them; wire the prop as a control on `Default` instead (see "Playground Pattern")                                                                                          |
-| Named story for every enum value                         | Use a `select`/`radio` control; enum-per-value stories are only justified for pinned-theme/viewport or `play()` assertions                                                       |
-| Callback only reachable by a one-shot interaction        | Add a trigger button in `render` (see EncouragementAnnouncer) — don't rely on a static prop                                                                                      |
-| Forgetting `withRouter` for routing components           | Check if component calls `useNavigate`, `Link`, or reads route params                                                                                                            |
-| Forgetting `withDb` for DB/settings hooks                | Check if component (or any provider it uses) calls `useRxDB`, `useSettings`, or any DB hook — includes `AnswerGameProvider` which calls `useGameTTS` → `useSettings` → `useRxDB` |
-| Adding `ThemeProvider` decorator                         | Already global — skip                                                                                                                                                            |
-| `SKIP_STORYBOOK=1` because port 6006 is in use           | Find a free port and start your own instance — never skip to avoid a conflict                                                                                                    |
-| Running `yarn test:storybook` without `--url`            | Without `--url` it defaults to 6006 and may hit the wrong agent's Storybook                                                                                                      |
-| Raw JSON control for an enum/union prop                  | Add `argTypes` with `select`/`radio` and explicit `options`                                                                                                                      |
-| Whole-config JSON blob as a single control               | Break into individual args + custom `render` (see "Complex Object Props")                                                                                                        |
-| Relying on global `argTypesRegex` for Actions panel      | Doesn't work for DOM-extended props under react-docgen — wire `args: { onFoo: fn() }` from `storybook/test` explicitly                                                           |
-| Adding `parameters.chromatic`                            | Remove — VR is in `e2e/visual.spec.ts`, not Storybook                                                                                                                            |
-| Trying to opt out of a11y on a new story                 | Don't — it's enforced. Fix the violation, or use `test: 'todo'` only with documented justification                                                                               |
-| Inlining `Math.random()` results in story args           | Pin via `globalThis.Math.random = () => N` inside `play()` for reproducibility                                                                                                   |
+| Mistake                                                  | Fix                                                                                                                                                                                                     |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `import React from 'react'` at top                       | Remove — not needed                                                                                                                                                                                     |
+| Named export for meta (`export const meta`)              | Use `export default meta`                                                                                                                                                                               |
+| Default export for stories (`export default Playground`) | Use `export const Playground: Story = {}`                                                                                                                                                               |
+| Story export named `Default`                             | Use `Playground` — the canonical name across all reference stories (InstructionsOverlay, AnswerGame, ProgressHUD, Footer, Header, etc.). The pattern is _called_ "Playground"; the export name matches. |
+| Missing `Playground` story                               | Always add one — it is the Playground                                                                                                                                                                   |
+| Multiple stories duplicating what a control would toggle | Delete them; wire the prop as a control on `Playground` instead (see "Playground Pattern")                                                                                                              |
+| Named story for every enum value                         | Use a `select`/`radio` control; enum-per-value stories are only justified for pinned-theme/viewport or `play()` assertions                                                                              |
+| Callback only reachable by a one-shot interaction        | Add a trigger button in `render` (see EncouragementAnnouncer) — don't rely on a static prop                                                                                                             |
+| Forgetting `withRouter` for routing components           | Check if component calls `useNavigate`, `Link`, or reads route params                                                                                                                                   |
+| Forgetting `withDb` for DB/settings hooks                | Check if component (or any provider it uses) calls `useRxDB`, `useSettings`, or any DB hook — includes `AnswerGameProvider` which calls `useGameTTS` → `useSettings` → `useRxDB`                        |
+| Adding `ThemeProvider` decorator                         | Already global — skip                                                                                                                                                                                   |
+| `SKIP_STORYBOOK=1` because port 6006 is in use           | Find a free port and start your own instance — never skip to avoid a conflict                                                                                                                           |
+| Running `yarn test:storybook` without `--url`            | Without `--url` it defaults to 6006 and may hit the wrong agent's Storybook                                                                                                                             |
+| Raw JSON control for an enum/union prop                  | Add `argTypes` with `select`/`radio` and explicit `options`                                                                                                                                             |
+| Whole-config JSON blob as a single control               | Break into individual args + custom `render` (see "Complex Object Props")                                                                                                                               |
+| Relying on global `argTypesRegex` for Actions panel      | Doesn't work for DOM-extended props under react-docgen — wire `args: { onFoo: fn() }` from `storybook/test` explicitly                                                                                  |
+| Adding `parameters.chromatic`                            | Remove — VR is in `e2e/visual.spec.ts`, not Storybook                                                                                                                                                   |
+| Trying to opt out of a11y on a new story                 | Don't — it's enforced. Fix the violation, or use `test: 'todo'` only with documented justification                                                                                                      |
+| Inlining `Math.random()` results in story args           | Pin via `globalThis.Math.random = () => N` inside `play()` for reproducibility                                                                                                                          |


### PR DESCRIPTION
## Summary

The `write-storybook` skill's template, rules, audit checklist, and Common Mistakes table all said `export const Default: Story = {}` — but every reference story in this project actually exports `Playground`. The deployed Storybook URL pattern (`...--playground`) confirms `Playground` is the canonical name.

This mismatch caused the 5 Tier 3 retrofit agents (#203 GameGrid, #204 GameNameChip, #205 ConfigFormFields, #206 GameCard, #207 ThemeShowcase) to land on `Default` on first pass; each got a follow-up commit to rename. Tier 4/5 work would have repeated the same mistake.

## Changes

- Replaced every story-name `Default` with `Playground`: 12 backticked occurrences, 3 `Default: Story` signatures, 1 frontmatter description, 1 inline comment, 1 \`export default Default\` example in Common Mistakes
- Added a new Rules bullet making the canonical name explicit: \"must be named exactly \`Playground\` (not \`Default\`)\" with a link to the InstructionsOverlay reference
- Added a new Common Mistakes row capturing the rationalization (\"Story export named \`Default\`\" → use \`Playground\`)
- Dropped the now-redundant \"— this is the Playground\" tail from the rules
- Left section headings unrelated to story name untouched (`### Default: rely on the Actions panel`, `## Default Skin Is Applied Globally`, `withDefaultSkin` decorator)

## Test plan

- [x] \`yarn lint:md\` clean
- [x] \`prettier --check\` clean
- [x] All pre-push gates passed
- [ ] Reviewer confirms no story-name \`Default\` references slipped through (\`grep -nE 'Default' .claude/skills/write-storybook/SKILL.md\` returns only the 9 intentional non-story-name occurrences listed below):

\`\`\`
32: \"(not \`Default\`)\" — explicit anti-rule
242: \"Default Skin Is Applied Globally\" cross-reference
248: \"### Default: rely on the Actions panel\" section header
353: \"## Default Skin Is Applied Globally\" section header
355, 379, 539: \`withDefaultSkin\` decorator name
551: \"Default export for stories\" (JS keyword)
552: \"Story export named \`Default\`\" (explicit anti-pattern in Common Mistakes)
\`\`\`

## Related

- Tier 3 PRs that exposed this gap: #203, #204, #205, #206, #207
- Tracking issue: #125
- Canonical reference: \`src/components/answer-game/InstructionsOverlay/InstructionsOverlay.stories.tsx\`