### PR TITLE
fix(deps): pin dexie to rxdb's exact version (4.0.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "dexie": "^4.4.2",
+    "dexie": "4.0.10",
     "eslint-plugin-unicorn": "^64.0.0",
     "i18next": "^26.0.3",
     "lucide-react": "^0.545.0",

--- a/src/data/words/authoring/dexie-version-pin.test.ts
+++ b/src/data/words/authoring/dexie-version-pin.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+type PackageJson = {
+  version?: string;
+  dependencies?: Record<string, string>;
+};
+
+const readJson = (relativeToRepo: string): PackageJson => {
+  const full = path.join(process.cwd(), relativeToRepo);
+  return JSON.parse(readFileSync(full, 'utf8')) as PackageJson;
+};
+
+const rootPkg = readJson('package.json');
+const rxdbPkg = readJson('node_modules/rxdb/package.json');
+const dexiePkg = readJson('node_modules/dexie/package.json');
+
+describe('dexie ↔ rxdb version pin invariant', () => {
+  it("root package.json must pin dexie to rxdb's exact dexie pin", () => {
+    const ourPin = rootPkg.dependencies?.['dexie'];
+    const rxdbPin = rxdbPkg.dependencies?.['dexie'];
+    expect(ourPin).toBeDefined();
+    expect(rxdbPin).toBeDefined();
+    expect(ourPin).toBe(rxdbPin);
+  });
+
+  it('only one resolved dexie exists, matching the rxdb pin', () => {
+    const rxdbPin = rxdbPkg.dependencies?.['dexie'];
+    expect(dexiePkg.version).toBe(rxdbPin);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6481,11 +6481,6 @@ dexie@4.0.10:
   resolved "https://registry.yarnpkg.com/dexie/-/dexie-4.0.10.tgz#979e3ee75993b44eea3852f97ceb198019d5b287"
   integrity sha512-eM2RzuR3i+M046r2Q0Optl3pS31qTWf8aFuA7H9wnsHTwl8EPvroVLwvQene/6paAs39Tbk6fWZcn2aZaHkc/w==
 
-dexie@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/dexie/-/dexie-4.4.2.tgz#447511328c982baaf6a88c736ddc08484916886c"
-  integrity sha512-zMtV8q79EFE5U8FKZvt0Y/77PCU/Hr/RDxv1EDeo228L+m/HTbeN2AjoQm674rhQCX8n3ljK87lajt7UQuZfvw==
-
 diff@^8.0.2:
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.4.tgz#4f5baf3188b9b2431117b962eb20ba330fadf696"


### PR DESCRIPTION
## Summary

- Pins `dexie` to `4.0.10` (matching `rxdb@17`'s exact internal pin) so only one Dexie copy is bundled. The dual-version state was crashing the SPA on boot with "Two different versions of Dexie loaded in the same app", manifesting as minified React error #418.
- Adds a regression test that asserts `package.json` `dependencies.dexie` always equals `node_modules/rxdb/package.json` `dependencies.dexie` — future rxdb upgrades that change Dexie will fail CI until the root pin is bumped in lockstep.

## Why two copies existed

| Source | Constraint | Resolved |
|---|---|---|
| `package.json` (direct dep) | `^4.4.2` | `4.4.2` |
| `node_modules/rxdb/package.json` | `4.0.10` (exact) | `4.0.10` |

`4.0.10` is not in `^4.4.2` and vice versa, so Yarn keeps both. Before the recent word-authoring scaffold, Vite tree-shook the top-level copy because nothing imported `dexie` directly. `src/data/words/authoring/draftStore.ts:1` is the first file to do `import Dexie from 'dexie'`, which forced both copies into the bundle and tripped Dexie's runtime duplicate-instance guard.

## Verification

- Regression test red before fix (`expected '^4.4.2' to be '4.0.10'`), green after.
- `yarn why dexie` → single hoisted entry at `4.0.10`.
- Production bundle: exactly one occurrence of the "Two different versions of Dexie" guard string in `dist/client/assets/main-*.js` (was two).
- `yarn typecheck` clean.
- Full unit suite: 1043/1043 passing (ran via pre-commit + pre-push hooks).

## Test plan

- [ ] CI green on this PR
- [ ] After merge, deploy completes and `https://leocaseiro.github.io/base-skill/` boots without the Dexie error in console
- [ ] `https://leocaseiro.github.io/base-skill/en/game/word-spell` renders the SPA (404 status from GH Pages is expected — `404.html` is the SPA shell)

## Notes for reviewers

- The `4.0.10` → `4.4.2` API surface that `draftStore.ts` uses (`Dexie`, `Table`, `version().stores()`, `where().equals().first()`, `add`) is identical, so downgrading is safe.
- The PR-preview redirect bug (`/pr/<n>/` returns 404 because no index.html is staged at that level) and the workbox precache base-prefix mismatch in the generated SW are separate issues — see the diagnosis thread for context. They're not regressions caused by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)