### PR TITLE
chore: untrack .claude/settings.local.json

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,5 +1,0 @@
-{
-  "permissions": {
-    "allow": ["Bash"]
-  }
-}


### PR DESCRIPTION
## Summary

- `.claude/settings.local.json` was added to `.gitignore` in 880298f7, but the file was already tracked, so git kept reporting local edits in `git status`.
- Remove it from the index with `git rm --cached` so the existing ignore rule actually takes effect. The file stays on disk locally.

## Test plan

- [ ] After merge, pull master and verify `git status` no longer shows `.claude/settings.local.json` as modified
- [ ] Verify `git check-ignore -v .claude/settings.local.json` reports the `.gitignore:25` rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)