### PR TITLE
docs: WordSpell levels-and-defaults design spec

### DIFF
--- a/.claude/handoffs/2026-04-28-wordspell-levels-defaults.md
+++ b/.claude/handoffs/2026-04-28-wordspell-levels-defaults.md
@@ -1,0 +1,76 @@
+# Handoff: WordSpell levels-and-defaults plan ready for subagent-driven execution
+
+**Date:** 2026-04-28
+**Branch:** feat/wordspell-levels-defaults
+**Worktree:** worktrees/feat-wordspell-levels-defaults
+**Worktree path:** /Users/leocaseiro/Sites/base-skill/worktrees/feat-wordspell-levels-defaults
+**Git status:** clean
+**Last commit:** a1757b3e docs: add WordSpell levels-and-defaults implementation plan
+**PR:** #212 — open (<https://github.com/leocaseiro/base-skill/pull/212>)
+
+## Resume command
+
+```
+# Continue in this same worktree — do NOT create a new one.
+cd /Users/leocaseiro/Sites/base-skill/worktrees/feat-wordspell-levels-defaults
+/resync
+# Then dispatch subagent-driven execution of the plan:
+# Use superpowers:subagent-driven-development on
+# docs/superpowers/plans/2026-04-28-wordspell-levels-defaults.md
+```
+
+## Current state
+
+**Task:** WordSpell — fix Level 3+, bring Advanced to parity with Simple, switch defaults to recall + random, remove scramble, add regression tests
+**Phase:** implementation (plan written, code not started)
+**Progress:** Spec + plan committed and pushed to PR #212. Tasks 1–11 ready to execute. **Next session: subagent-driven execution.**
+
+## What we did
+
+Brainstormed the WordSpell config overhaul from a "Levels in advanced + recall default" idea into a full design. Discovered the Level 3+ regression mid-brainstorm: the Simple form was populating `phonemesAllowed` with only the chosen level's phonemes, but `filterWords` requires every grapheme of a candidate word to map into the allowed set, so words using prerequisite-level phonemes were silently filtered out. Wrote the spec, then the implementation plan with a TDD red/green sequence and a parameterized curriculum-invariant test that locks the bug class out going forward.
+
+## Decisions made
+
+- **Default mode = `recall`** — picture mode silently degrades for library-sourced rounds (`adapters.ts:4-6` only sets `word`, no emoji/image). Recall is the synthetic-phonics target.
+- **Random rounds by default** — `roundsInOrder: false`. No VR work needed: stories that need stability already opt in (`roundsInOrder: true` or `seed="storybook"`); the default flip only affects the no-config route launch path which isn't VR-tested.
+- **Remove `scramble` mode entirely** — never used in any user-facing flow. No migration for old saved configs (pre-launch / dev-only data).
+- **Advanced gains Level + Phonemes via shared sub-component** — extract `WordSpellLibrarySource`, expose to Advanced through a new `getAdvancedHeaderRenderer` registry hook. Other games unaffected.
+- **Advanced also gains `distractorCount`** — was missing from WordSpell despite distractor mode being supported (NumberMatch already had it).
+- **Three-layer regression strategy** — (1) curriculum invariant test parameterized over every (region, level) with `MIN_PLAYABLE_HITS = 4`; (2) form-emits-playable test that fails for Level 3+ before the fix; (3) cumulativeGraphemes helper unit test. Skipped E2E "play through every level" — too slow, redundant.
+
+## Spec / Plan
+
+- docs/superpowers/specs/2026-04-28-wordspell-levels-defaults-design.md
+- docs/superpowers/plans/2026-04-28-wordspell-levels-defaults.md
+
+## Key files (no edits yet — listed for the next session)
+
+- src/games/word-spell/WordSpellSimpleConfigForm/WordSpellSimpleConfigForm.tsx:39-52,60-75 — bug site; switch `GRAPHEMES_BY_LEVEL[level]` → `cumulativeGraphemes(level)`
+- src/data/words/levels.ts:130-144 — `cumulativeGraphemes` helper (already correct; lock with test in Task 1)
+- src/data/words/filter.ts:70-73 — the `every` predicate that defines the playable contract
+- src/games/word-spell/types.ts:38,88-94 — drop `'scramble'`; add `distractorCount` field with `visibleWhen`
+- src/games/word-spell/resolve-simple-config.ts:9 — flip `mode: 'scramble'` → `'recall'`
+- src/routes/$locale/_app/game/$gameId.tsx:96-112 — flip `DEFAULT_WORD_SPELL_CONFIG.mode` → `'recall'` and `roundsInOrder` → `false`
+- src/games/word-spell/WordSpell/WordSpell.tsx:505-509 — slot-interaction simplifies after scramble removal
+- src/games/config-fields-registry.ts — add `getAdvancedHeaderRenderer` hook
+- src/components/AdvancedConfigModal.tsx:236 — render header above `ConfigFormFields`
+- src/games/build-round-order.ts — already accepts `seed` parameter; no engine change needed
+
+## Next steps
+
+1. [ ] In a fresh session, run `/resync` and `cd worktrees/feat-wordspell-levels-defaults`
+2. [ ] Invoke `superpowers:subagent-driven-development` with the plan path: `docs/superpowers/plans/2026-04-28-wordspell-levels-defaults.md`
+3. [ ] Execute Tasks 1 → 11 with one subagent per task and review between tasks
+4. [ ] Push commits to PR #212; flip PR description from "spec only" to "spec + implementation"
+5. [ ] When the dev-server smoke test in Task 11 passes, request review on PR #212
+
+## Context to remember
+
+- **Worktree gate is mandatory** — every task starts in `worktrees/<name>/`, including doc edits. Never edit on master.
+- **TDD for bug fixes is required** — Task 3 must run and **fail** before Task 4's fix is applied. Don't skip the red phase.
+- **Markdown gate** — any `.md` edit must pass `yarn lint:md` and `npx prettier --check`. Use `yarn fix:md` to auto-fix.
+- **Named exports only** in React components (`react/function-component-definition`). The plan already follows this.
+- **Baby-step commits** — multiple commits per PR are preferred. The plan splits work into focused commits per task.
+- **VR baselines: not affected by this work.** `DEFAULT_WORD_SPELL_CONFIG` flipping to `roundsInOrder: false` does not break Storybook stories because each story explicitly sets its own config. If a VR run drifts unexpectedly, that's a real regression — investigate, don't auto-update baselines.
+- **`MIN_PLAYABLE_HITS = 4`** in the curriculum-invariant test is load-bearing. Don't lower it. If a non-AUS region under-shoots, narrow the test to AUS and treat the others as deferred (Task 2 says this explicitly).
+- **The user prefers `/resync` at session start** to surface any new commits on master — pause for their go-ahead before running.

--- a/docs/superpowers/plans/2026-04-28-wordspell-levels-defaults.md
+++ b/docs/superpowers/plans/2026-04-28-wordspell-levels-defaults.md
@@ -1,0 +1,1182 @@
+# WordSpell Levels-and-Defaults Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix Level 3+ in WordSpell, bring Advanced form to parity with Simple
+(Level + Phonemes + `distractorCount`), make `recall` and random rounds the
+defaults, remove the unused `scramble` mode, and lock the bug class out with
+parameterized regression tests.
+
+**Architecture:** Extract Level/Phonemes UI into a shared `WordSpellLibrarySource`
+sub-component used by both Simple and Advanced. Wire it into Advanced via a
+new optional `getAdvancedHeaderRenderer` hook on the config-fields registry —
+other games are unaffected. Cumulative-phoneme handling moves from
+`GRAPHEMES_BY_LEVEL[level]` to the existing `cumulativeGraphemes(level)`
+helper so library queries return playable word counts at every level.
+
+**Tech Stack:** React + TypeScript (named exports only — `react/function-component-definition`),
+Vitest + Testing Library + userEvent, Vite, TanStack Router, existing
+`config-fields` registry, existing `buildRoundOrder` (already accepts a `seed`
+parameter — no engine changes needed).
+
+**Spec:** `docs/superpowers/specs/2026-04-28-wordspell-levels-defaults-design.md`
+
+---
+
+## Pre-flight
+
+Before any task: verify you're on the right branch and worktree.
+
+```bash
+git rev-parse --abbrev-ref HEAD   # → feat/wordspell-levels-defaults
+pwd                                # → .../worktrees/feat-wordspell-levels-defaults
+```
+
+If either is wrong, stop and ask — do not commit on master.
+
+---
+
+## Task 1: Cumulative-graphemes helper unit test (defensive lock-in)
+
+The `cumulativeGraphemes(level)` helper is already correct in the codebase
+(`src/data/words/levels.ts:130-144`). This task locks the contract with a
+direct unit test so any future edit that breaks cumulativity fails fast.
+
+**Files:**
+
+- Create: `src/data/words/levels.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { cumulativeGraphemes, GRAPHEMES_BY_LEVEL } from './levels';
+
+describe('cumulativeGraphemes', () => {
+  it('returns only level-1 units at level 1', () => {
+    const units = cumulativeGraphemes(1);
+    const level1 = GRAPHEMES_BY_LEVEL[1] ?? [];
+    expect(units).toHaveLength(level1.length);
+  });
+
+  it('includes phonemes from levels 1..N at level 3', () => {
+    const phonemes = new Set(cumulativeGraphemes(3).map((u) => u.p));
+    expect(phonemes.has('s')).toBe(true); // level 1
+    expect(phonemes.has('m')).toBe(true); // level 2
+    expect(phonemes.has('b')).toBe(true); // level 3
+  });
+
+  it('dedupes by grapheme+phoneme key', () => {
+    const units = cumulativeGraphemes(8);
+    const keys = units.map((u) => `${u.g}|${u.p}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('preserves introduction order — level-1 units come first', () => {
+    const units = cumulativeGraphemes(3);
+    const firstLevel1Index = units.findIndex((u) =>
+      (GRAPHEMES_BY_LEVEL[1] ?? []).some(
+        (l1) => l1.g === u.g && l1.p === u.p,
+      ),
+    );
+    expect(firstLevel1Index).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `yarn vitest run src/data/words/levels.test.ts`
+Expected: 4 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/data/words/levels.test.ts
+git commit -m "test: lock in cumulativeGraphemes helper contract"
+```
+
+---
+
+## Task 2: Curriculum invariant test (data contract)
+
+Parameterized over every `(region, level)`. With cumulative phonemes
+populated from `cumulativeGraphemes(level)`, every level must yield at least
+`MIN_PLAYABLE_HITS = 4` words. This test passes against the current data —
+its job is to fail loudly if anyone (a) ships a curriculum file with a level
+that has no playable words, (b) tightens the filter logic in a way that drops
+valid content, or (c) breaks the cumulativity helper.
+
+**Files:**
+
+- Create: `src/data/words/curriculum-invariant.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { filterWords } from './filter';
+import { ALL_REGIONS, cumulativeGraphemes } from './levels';
+
+const MIN_PLAYABLE_HITS = 4;
+const LEVELS = [1, 2, 3, 4, 5, 6, 7, 8] as const;
+
+describe('curriculum invariant: every level has playable defaults', () => {
+  for (const region of ALL_REGIONS) {
+    for (const level of LEVELS) {
+      it(`${region} L${level}: cumulative phonemes yield ≥ ${MIN_PLAYABLE_HITS} words`, async () => {
+        const phonemesAllowed = [
+          ...new Set(cumulativeGraphemes(level).map((u) => u.p)),
+        ];
+        const result = await filterWords({
+          region,
+          level,
+          phonemesAllowed,
+        });
+        expect(result.hits.length).toBeGreaterThanOrEqual(
+          MIN_PLAYABLE_HITS,
+        );
+      });
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `yarn vitest run src/data/words/curriculum-invariant.test.ts`
+Expected: 32 passing tests (4 regions × 8 levels). The AUS branch is the
+shipping curriculum; UK/US/BR fall back to AUS in `filterWords` when their
+own curriculum is empty, so they should still meet the threshold.
+
+If a non-AUS region returns < 4 hits even with fallback, narrow the test to
+AUS and treat the others as deferred. **Do not weaken `MIN_PLAYABLE_HITS`
+below 4.**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/data/words/curriculum-invariant.test.ts
+git commit -m "test: parameterized curriculum invariant — every (region, level) is playable"
+```
+
+---
+
+## Task 3: Failing form-emits-playable test (TDD red for the bug)
+
+Per CLAUDE.md, every bug fix needs a failing test first. This test simulates
+the user picking each level in the form and asserts the emitted
+`source.filter` produces ≥ 1 hit from `filterWords`. It will **fail** for
+levels 3+ on the current code, demonstrating the bug.
+
+**Files:**
+
+- Create: `src/games/word-spell/WordSpellSimpleConfigForm/source-emits-playable.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { WordSpellSimpleConfigForm } from './WordSpellSimpleConfigForm';
+import { filterWords } from '@/data/words';
+
+type SourceConfig = {
+  source?: {
+    type: 'word-library';
+    filter: {
+      region: string;
+      level: number;
+      phonemesAllowed?: string[];
+    };
+  };
+};
+
+const Harness = ({
+  initialLevel,
+  onConfigRef,
+}: {
+  initialLevel: number;
+  onConfigRef: (cfg: Record<string, unknown>) => void;
+}) => {
+  const [config, setConfig] = useState<Record<string, unknown>>({
+    configMode: 'simple',
+    source: {
+      type: 'word-library',
+      filter: {
+        region: 'aus',
+        level: initialLevel,
+        phonemesAllowed: [],
+      },
+    },
+    inputMethod: 'drag',
+  });
+  onConfigRef(config);
+  return (
+    <WordSpellSimpleConfigForm
+      config={config}
+      onChange={(next) => {
+        setConfig(next);
+        onConfigRef(next);
+      }}
+    />
+  );
+};
+
+const LEVELS = [1, 2, 3, 4, 5, 6, 7, 8] as const;
+
+describe('Simple form emits playable source for every level', () => {
+  for (const level of LEVELS) {
+    it(`level ${level}: switching to it produces ≥ 1 hit`, async () => {
+      const user = userEvent.setup();
+      let captured: Record<string, unknown> = {};
+      render(
+        <Harness
+          initialLevel={1}
+          onConfigRef={(c) => {
+            captured = c;
+          }}
+        />,
+      );
+
+      // Pick the target level via the level select
+      await user.selectOptions(
+        screen.getByLabelText(/level/i),
+        String(level),
+      );
+
+      const source = captured.source as SourceConfig['source'];
+      expect(source).toBeDefined();
+      const result = await filterWords(source!.filter);
+      expect(result.hits.length).toBeGreaterThan(0);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails for levels 3+**
+
+Run: `yarn vitest run src/games/word-spell/WordSpellSimpleConfigForm/source-emits-playable.test.tsx`
+Expected:
+
+- Level 1, 2: pass
+- Level 3+: **FAIL** with `expected 0 to be greater than 0`
+
+This is the bug captured. Do not commit yet — TDD red phase.
+
+---
+
+## Task 4: Apply the cumulative-phonemes fix (TDD green)
+
+Replace `GRAPHEMES_BY_LEVEL[level]` with `cumulativeGraphemes(level)` in two
+spots in the form. The chip strip and the default `phonemesAllowed` both
+become cumulative.
+
+**Files:**
+
+- Modify: `src/games/word-spell/WordSpellSimpleConfigForm/WordSpellSimpleConfigForm.tsx`
+
+- [ ] **Step 1: Update the import**
+
+Edit `src/games/word-spell/WordSpellSimpleConfigForm/WordSpellSimpleConfigForm.tsx`:
+
+Replace:
+
+```ts
+import { GRAPHEMES_BY_LEVEL } from '@/data/words/levels';
+```
+
+with:
+
+```ts
+import { cumulativeGraphemes } from '@/data/words/levels';
+```
+
+Also update the `LEVEL_OPTIONS` constant — it currently reads from
+`GRAPHEMES_BY_LEVEL`. Replace:
+
+```ts
+const LEVEL_OPTIONS = Object.keys(GRAPHEMES_BY_LEVEL).map((n) => ({
+  value: n,
+  label: `Level ${n}`,
+}));
+```
+
+with:
+
+```ts
+const LEVEL_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8].map((n) => ({
+  value: String(n),
+  label: `Level ${n}`,
+}));
+```
+
+- [ ] **Step 2: Use cumulative in the chip pool**
+
+Replace:
+
+```ts
+const unitsAtLevel = GRAPHEMES_BY_LEVEL[level] ?? [];
+```
+
+with:
+
+```ts
+const unitsAtLevel = cumulativeGraphemes(level);
+```
+
+- [ ] **Step 3: Use cumulative inside `setLevel`**
+
+Replace:
+
+```ts
+const setLevel = (n: number) => {
+  const available = [
+    ...new Set((GRAPHEMES_BY_LEVEL[n] ?? []).map((u) => u.p)),
+  ];
+  onChange({
+    ...config,
+    source: {
+      type: 'word-library',
+      filter: {
+        ...(source?.filter ?? { region: 'aus' }),
+        level: n,
+        phonemesAllowed: available,
+      },
+    },
+  });
+};
+```
+
+with:
+
+```ts
+const setLevel = (n: number) => {
+  const available = [
+    ...new Set(cumulativeGraphemes(n).map((u) => u.p)),
+  ];
+  onChange({
+    ...config,
+    source: {
+      type: 'word-library',
+      filter: {
+        ...(source?.filter ?? { region: 'aus' }),
+        level: n,
+        phonemesAllowed: available,
+      },
+    },
+  });
+};
+```
+
+- [ ] **Step 4: Run the form-emits-playable test — should now pass for all levels**
+
+Run: `yarn vitest run src/games/word-spell/WordSpellSimpleConfigForm/source-emits-playable.test.tsx`
+Expected: 8 passing tests.
+
+- [ ] **Step 5: Run the full WordSpellSimpleConfigForm test suite**
+
+Run: `yarn vitest run src/games/word-spell/WordSpellSimpleConfigForm`
+Expected: all tests pass. The existing `'shows a chip per phoneme at the current level'`
+test asserts level-2 chips (`m /m/`, `d /d/`) are present — both still appear
+in the cumulative set, so it stays green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/games/word-spell/WordSpellSimpleConfigForm/
+git commit -m "fix(word-spell): use cumulative phonemes so Level 3+ produces playable words
+
+Closes the Level 3+ regression: filterWords requires every grapheme of a
+candidate word to map to a phoneme in phonemesAllowed, but the form was only
+loading the phonemes introduced at level N. Switching to cumulativeGraphemes(N)
+makes phonemes from levels 1..N all addressable, matching what the curriculum
+words actually use."
+```
+
+---
+
+## Task 5: Extract `WordSpellLibrarySource` sub-component
+
+Move the Level select + Phonemes chip strip out of `WordSpellSimpleConfigForm`
+into a reusable component. The Simple form keeps the Input Method picker and
+delegates the library source UI to the new component.
+
+**Files:**
+
+- Create: `src/games/word-spell/WordSpellLibrarySource/WordSpellLibrarySource.tsx`
+- Create: `src/games/word-spell/WordSpellLibrarySource/WordSpellLibrarySource.test.tsx`
+- Modify: `src/games/word-spell/WordSpellSimpleConfigForm/WordSpellSimpleConfigForm.tsx`
+
+- [ ] **Step 1: Create the sub-component**
+
+Create `src/games/word-spell/WordSpellLibrarySource/WordSpellLibrarySource.tsx`:
+
+```tsx
+import type { JSX } from 'react';
+import { CellSelect } from '@/components/config/CellSelect';
+import { ChipStrip } from '@/components/config/ChipStrip';
+import { cumulativeGraphemes } from '@/data/words/levels';
+
+type Props = {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+};
+
+const LEVEL_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8].map((n) => ({
+  value: String(n),
+  label: `Level ${n}`,
+}));
+
+export const WordSpellLibrarySource = ({
+  config,
+  onChange,
+}: Props): JSX.Element => {
+  const source =
+    typeof config.source === 'object' && config.source !== null
+      ? (config.source as {
+          type: 'word-library';
+          filter: {
+            region: string;
+            level: number;
+            phonemesAllowed?: string[];
+          };
+        })
+      : undefined;
+  const level =
+    typeof source?.filter.level === 'number' ? source.filter.level : 1;
+
+  const unitsAtLevel = cumulativeGraphemes(level);
+  const phonemeToGraphemes = new Map<string, string[]>();
+  for (const u of unitsAtLevel) {
+    const existing = phonemeToGraphemes.get(u.p);
+    if (existing) {
+      existing.push(u.g);
+    } else {
+      phonemeToGraphemes.set(u.p, [u.g]);
+    }
+  }
+  const allPhonemesAtLevel = [...phonemeToGraphemes.keys()];
+  const phonemesAllowed =
+    source?.filter.phonemesAllowed ?? allPhonemesAtLevel;
+  const chips = allPhonemesAtLevel.map((p) => ({
+    value: p,
+    label: `${(phonemeToGraphemes.get(p) ?? []).join(', ')} /${p}/`,
+  }));
+
+  const setLevel = (n: number) => {
+    const available = [
+      ...new Set(cumulativeGraphemes(n).map((u) => u.p)),
+    ];
+    onChange({
+      ...config,
+      source: {
+        type: 'word-library',
+        filter: {
+          ...(source?.filter ?? { region: 'aus' }),
+          level: n,
+          phonemesAllowed: available,
+        },
+      },
+    });
+  };
+
+  const setPhonemes = (next: string[]) => {
+    onChange({
+      ...config,
+      source: {
+        type: 'word-library',
+        filter: {
+          ...(source?.filter ?? { region: 'aus' }),
+          level,
+          phonemesAllowed: next,
+        },
+      },
+    });
+  };
+
+  const invalid = phonemesAllowed.length === 0;
+
+  return (
+    <div
+      className="flex flex-col gap-4"
+      data-invalid={invalid ? 'true' : 'false'}
+    >
+      <div className="flex flex-col gap-1 text-xs font-semibold uppercase text-muted-foreground">
+        Level
+        <CellSelect
+          label="Level"
+          value={String(level)}
+          options={LEVEL_OPTIONS}
+          onChange={(v) => setLevel(Number(v))}
+        />
+      </div>
+
+      <div>
+        <div className="text-xs font-semibold uppercase text-muted-foreground">
+          Sounds at this level (tap to toggle)
+        </div>
+        <div className="mt-2">
+          <ChipStrip
+            chips={chips}
+            selected={phonemesAllowed}
+            mode="toggleable"
+            onChange={setPhonemes}
+          />
+        </div>
+        {invalid && (
+          <p className="mt-2 text-xs text-destructive">
+            Pick at least one sound to play.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Create the sub-component test**
+
+Create `src/games/word-spell/WordSpellLibrarySource/WordSpellLibrarySource.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { WordSpellLibrarySource } from './WordSpellLibrarySource';
+
+const Harness = ({ initialLevel }: { initialLevel: number }) => {
+  const [config, setConfig] = useState<Record<string, unknown>>({
+    source: {
+      type: 'word-library',
+      filter: {
+        region: 'aus',
+        level: initialLevel,
+        phonemesAllowed: [],
+      },
+    },
+  });
+  return (
+    <WordSpellLibrarySource config={config} onChange={setConfig} />
+  );
+};
+
+describe('WordSpellLibrarySource', () => {
+  it('shows the Level select', () => {
+    render(<Harness initialLevel={1} />);
+    expect(screen.getByLabelText(/level/i)).toBeInTheDocument();
+  });
+
+  it('shows cumulative phoneme chips at level 3', () => {
+    render(<Harness initialLevel={3} />);
+    // Level 1 phoneme — must appear because cumulative
+    expect(
+      screen.getByRole('button', { name: /s \/s\//i }),
+    ).toBeInTheDocument();
+    // Level 3 phoneme
+    expect(
+      screen.getByRole('button', { name: /b \/b\//i }),
+    ).toBeInTheDocument();
+  });
+
+  it('flags data-invalid when phonemesAllowed is empty', () => {
+    const { container } = render(<Harness initialLevel={2} />);
+    expect(container.firstElementChild).toHaveAttribute(
+      'data-invalid',
+      'true',
+    );
+  });
+
+  it('toggles a phoneme via aria-pressed when a chip is tapped', async () => {
+    const user = userEvent.setup();
+    render(<Harness initialLevel={2} />);
+    const chip = screen.getByRole('button', { name: /m \/m\//i });
+    await user.click(chip);
+    expect(chip).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+```
+
+- [ ] **Step 3: Run sub-component tests**
+
+Run: `yarn vitest run src/games/word-spell/WordSpellLibrarySource`
+Expected: 4 passing tests.
+
+- [ ] **Step 4: Update the Simple form to delegate to the sub-component**
+
+Replace the contents of
+`src/games/word-spell/WordSpellSimpleConfigForm/WordSpellSimpleConfigForm.tsx`
+with:
+
+```tsx
+import type { JSX } from 'react';
+import { ChunkGroup } from '@/components/config/ChunkGroup';
+import { WordSpellLibrarySource } from '../WordSpellLibrarySource/WordSpellLibrarySource';
+
+type Props = {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+};
+
+export const WordSpellSimpleConfigForm = ({
+  config,
+  onChange,
+}: Props): JSX.Element => {
+  const inputMethod =
+    config.inputMethod === 'type' || config.inputMethod === 'both'
+      ? config.inputMethod
+      : 'drag';
+
+  return (
+    <div className="flex flex-col gap-4">
+      <WordSpellLibrarySource config={config} onChange={onChange} />
+      <ChunkGroup
+        label="How do you answer?"
+        options={[
+          { value: 'drag', emoji: '✋', label: 'Drag' },
+          { value: 'type', emoji: '⌨️', label: 'Type' },
+          { value: 'both', emoji: '✨', label: 'Both' },
+        ]}
+        value={inputMethod}
+        onChange={(m) => onChange({ ...config, inputMethod: m })}
+      />
+    </div>
+  );
+};
+```
+
+- [ ] **Step 5: Run all WordSpellSimpleConfigForm tests + the form-emits-playable test**
+
+Run: `yarn vitest run src/games/word-spell/WordSpellSimpleConfigForm src/games/word-spell/WordSpellLibrarySource`
+Expected: all pass. (The existing `data-invalid` test on the form's
+`firstElementChild` still passes because the wrapping div still carries that
+attribute via the sub-component's root.)
+
+If the existing form test for `data-invalid` fails because the attribute is
+now on a nested element, update it to query the sub-component's container
+instead — but try the run first and let it tell you.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/games/word-spell/WordSpellLibrarySource/ src/games/word-spell/WordSpellSimpleConfigForm/
+git commit -m "refactor(word-spell): extract WordSpellLibrarySource sub-component
+
+Carved the Level + Phonemes UI out of WordSpellSimpleConfigForm into a
+reusable component so the Advanced modal can reuse the exact same UI for
+parity (added in the next commit). Behaviour is unchanged."
+```
+
+---
+
+## Task 6: Wire `WordSpellLibrarySource` into Advanced via a registry hook
+
+Add a third lookup to the config-fields registry — an optional renderer
+shown above the standard `ConfigFormFields` in the Advanced modal. Word-spell
+returns the new sub-component; other games leave it unset.
+
+**Files:**
+
+- Modify: `src/games/config-fields-registry.ts`
+- Modify: `src/components/AdvancedConfigModal.tsx`
+- Modify: `src/components/AdvancedConfigModal.test.tsx`
+
+- [ ] **Step 1: Add the registry hook**
+
+Edit `src/games/config-fields-registry.ts`. Add to the imports:
+
+```ts
+import { WordSpellLibrarySource } from './word-spell/WordSpellLibrarySource/WordSpellLibrarySource';
+```
+
+Append at the end of the file (after `getSimpleConfigFormRenderer`):
+
+```ts
+export const getAdvancedHeaderRenderer = (
+  gameId: string,
+): ConfigFormRenderer | undefined => {
+  switch (gameId) {
+    case 'word-spell': {
+      return WordSpellLibrarySource;
+    }
+    default: {
+      return undefined;
+    }
+  }
+};
+```
+
+- [ ] **Step 2: Render the header in AdvancedConfigModal**
+
+Edit `src/components/AdvancedConfigModal.tsx`:
+
+Replace:
+
+```ts
+import { getAdvancedConfigFields } from '@/games/config-fields-registry';
+```
+
+with:
+
+```ts
+import {
+  getAdvancedConfigFields,
+  getAdvancedHeaderRenderer,
+} from '@/games/config-fields-registry';
+```
+
+Inside the component, just below `const fields = getAdvancedConfigFields(gameId);`,
+add:
+
+```ts
+const HeaderRenderer = getAdvancedHeaderRenderer(gameId);
+```
+
+Then in the JSX, just before `<ConfigFormFields ... />` (currently at line 236
+of the file), insert:
+
+```tsx
+{
+  HeaderRenderer && (
+    <HeaderRenderer config={config} onChange={setConfig} />
+  );
+}
+```
+
+- [ ] **Step 3: Add a test that Advanced shows Level for word-spell**
+
+Edit `src/components/AdvancedConfigModal.test.tsx`. Append a new `it` block
+inside the existing `describe('AdvancedConfigModal', ...)`:
+
+```tsx
+it('renders the Level select for word-spell games', () => {
+  render(
+    <AdvancedConfigModal
+      open
+      onOpenChange={() => {}}
+      gameId="word-spell"
+      mode={{ kind: 'default' }}
+      config={{
+        source: {
+          type: 'word-library',
+          filter: { region: 'aus', level: 2, phonemesAllowed: [] },
+        },
+      }}
+      onCancel={() => {}}
+      onSaveNew={vi.fn()}
+    />,
+    { wrapper },
+  );
+  expect(screen.getByLabelText(/level/i)).toBeInTheDocument();
+});
+
+it('does not render the Level select for non-word-spell games', () => {
+  render(
+    <AdvancedConfigModal
+      open
+      onOpenChange={() => {}}
+      gameId="sort-numbers"
+      mode={{ kind: 'default' }}
+      config={{}}
+      onCancel={() => {}}
+      onSaveNew={vi.fn()}
+    />,
+    { wrapper },
+  );
+  expect(screen.queryByLabelText(/level/i)).toBeNull();
+});
+```
+
+- [ ] **Step 4: Run the Advanced modal tests**
+
+Run: `yarn vitest run src/components/AdvancedConfigModal.test.tsx`
+Expected: existing 3 tests + 2 new tests = 5 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/games/config-fields-registry.ts src/components/AdvancedConfigModal.tsx src/components/AdvancedConfigModal.test.tsx
+git commit -m "feat(word-spell): expose Level + Phonemes in the Advanced modal
+
+Adds an optional getAdvancedHeaderRenderer registry hook. Word-spell
+returns the WordSpellLibrarySource component, which renders above the
+standard ConfigFormFields. Other games are unaffected (hook returns
+undefined for them)."
+```
+
+---
+
+## Task 7: Add `distractorCount` to WordSpell Advanced fields
+
+The only `AnswerGameConfig` field WordSpell's Advanced was missing.
+NumberMatch already exposes it the same way.
+
+**Files:**
+
+- Modify: `src/games/word-spell/types.ts`
+
+- [ ] **Step 1: Add the field**
+
+Edit `src/games/word-spell/types.ts`. In `wordSpellConfigFields`, insert this
+field after the `tileBankMode` block (line 67 in the current file):
+
+```ts
+{
+  type: 'number',
+  key: 'distractorCount',
+  label: 'Distractor count',
+  min: 1,
+  max: 10,
+  visibleWhen: { key: 'tileBankMode', value: 'distractors' },
+},
+```
+
+- [ ] **Step 2: Add a test that the field appears only with distractor mode**
+
+Edit `src/components/AdvancedConfigModal.test.tsx`. Append:
+
+```tsx
+it('reveals distractorCount when WordSpell tileBankMode is distractors', () => {
+  render(
+    <AdvancedConfigModal
+      open
+      onOpenChange={() => {}}
+      gameId="word-spell"
+      mode={{ kind: 'default' }}
+      config={{ tileBankMode: 'distractors', distractorCount: 3 }}
+      onCancel={() => {}}
+      onSaveNew={vi.fn()}
+    />,
+    { wrapper },
+  );
+  expect(
+    screen.getByLabelText(/distractor count/i),
+  ).toBeInTheDocument();
+});
+
+it('hides distractorCount when WordSpell tileBankMode is exact', () => {
+  render(
+    <AdvancedConfigModal
+      open
+      onOpenChange={() => {}}
+      gameId="word-spell"
+      mode={{ kind: 'default' }}
+      config={{ tileBankMode: 'exact' }}
+      onCancel={() => {}}
+      onSaveNew={vi.fn()}
+    />,
+    { wrapper },
+  );
+  expect(screen.queryByLabelText(/distractor count/i)).toBeNull();
+});
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `yarn vitest run src/components/AdvancedConfigModal.test.tsx`
+Expected: 7 passing tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/games/word-spell/types.ts src/components/AdvancedConfigModal.test.tsx
+git commit -m "feat(word-spell): expose distractorCount in Advanced modal
+
+Visible only when tileBankMode is distractors. Mirrors how NumberMatch
+exposes the same field."
+```
+
+---
+
+## Task 8: Default mode = `recall`
+
+Change both the no-config fallback and the simple-mode resolver to land on
+`recall`. Library-sourced rounds have no images today, so `picture` mode
+silently degrades — `recall` is the synthetic-phonics target the curriculum
+is built for.
+
+**Files:**
+
+- Modify: `src/games/word-spell/resolve-simple-config.ts`
+- Modify: `src/games/word-spell/resolve-simple-config.test.ts`
+- Modify: `src/routes/$locale/_app/game/$gameId.tsx`
+
+- [ ] **Step 1: Update the simple-mode resolver default**
+
+Edit `src/games/word-spell/resolve-simple-config.ts`. Replace:
+
+```ts
+mode: 'scramble',
+```
+
+with:
+
+```ts
+mode: 'recall',
+```
+
+- [ ] **Step 2: Update the simple-config test**
+
+Edit `src/games/word-spell/resolve-simple-config.test.ts`. Find the
+assertion `expect(full.mode).toBe('scramble')` and replace with:
+
+```ts
+expect(full.mode).toBe('recall');
+```
+
+- [ ] **Step 3: Update the no-config fallback default**
+
+Edit `src/routes/$locale/_app/game/$gameId.tsx`. In `DEFAULT_WORD_SPELL_CONFIG`
+(around line 96), replace:
+
+```ts
+mode: 'picture',
+```
+
+with:
+
+```ts
+mode: 'recall',
+```
+
+- [ ] **Step 4: Run the affected suites**
+
+Run: `yarn vitest run src/games/word-spell src/routes/$locale/_app/game/resolveWordSpellConfig.test.ts`
+Expected: all pass.
+
+If `useLibraryRounds.test.tsx` or `WordSpell.test.tsx` had assertions that
+hardcoded `mode: 'picture'` for a default scenario, update those assertions
+to `mode: 'recall'` — but only if they describe **the default**. Tests that
+explicitly target picture mode (e.g. "picture mode shows the emoji") stay on
+`picture`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/games/word-spell/resolve-simple-config.ts src/games/word-spell/resolve-simple-config.test.ts src/routes/$locale/_app/game/\$gameId.tsx
+git commit -m "feat(word-spell): default to recall mode
+
+Library-sourced rounds have no images, so the previous picture default
+silently degraded. recall is the mode the synthetic-phonics curriculum is
+designed for and is what the player actually experiences when no images are
+attached."
+```
+
+---
+
+## Task 9: Default `roundsInOrder = false`
+
+The shuffler (`buildRoundOrder`) already accepts a `seed` parameter and
+WordSpell stories that need stability already pass either `roundsInOrder: true`
+or `seed="storybook"`. So flipping the default is safe — it only affects the
+no-config route launch path, which isn't VR-tested. E2E tests in CI either
+pass an explicit config or don't depend on round ordering.
+
+**Files:**
+
+- Modify: `src/routes/$locale/_app/game/$gameId.tsx`
+
+- [ ] **Step 1: Flip the default**
+
+Edit `src/routes/$locale/_app/game/$gameId.tsx`. In `DEFAULT_WORD_SPELL_CONFIG`,
+replace:
+
+```ts
+// Deterministic order by default. `buildRoundOrder` shuffles when this is
+// false using a nanoid-based seed (crypto.getRandomValues) which VR tests
+// cannot pin, causing baseline drift. Users can still opt into shuffling
+// via the settings panel.
+roundsInOrder: true,
+```
+
+with:
+
+```ts
+roundsInOrder: false,
+```
+
+(Drop the comment too — it described the old reasoning and is no longer
+accurate. Storybook scenes that need determinism already opt into it
+explicitly.)
+
+- [ ] **Step 2: Run the route test + WordSpell tests**
+
+Run: `yarn vitest run src/routes/$locale/_app/game src/games/word-spell`
+Expected: all pass. The existing `resolveWordSpellConfig.test.ts` asserts
+`expect(resolved.roundsInOrder).toBe(false)` for the simple-mode case — that
+keeps passing. The advanced-mode case in the same test file asserts on
+`rounds.length`, not order, so it's unaffected.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/routes/$locale/_app/game/\$gameId.tsx
+git commit -m "feat(word-spell): random rounds by default
+
+Stories that need pinned ordering already pass roundsInOrder: true or seed
+explicitly. The route default is the only thing that flips, and the route
+isn't covered by VR baselines."
+```
+
+---
+
+## Task 10: Remove the unused `scramble` mode
+
+Drop the union member, the mode-select option, the slot-interaction branch,
+and the `ScrambleMode` story.
+
+**Files:**
+
+- Modify: `src/games/word-spell/types.ts`
+- Modify: `src/games/word-spell/WordSpell/WordSpell.tsx`
+- Modify: `src/games/word-spell/WordSpell/WordSpell.stories.tsx`
+
+- [ ] **Step 1: Drop `scramble` from the union and select options**
+
+Edit `src/games/word-spell/types.ts`.
+
+Replace:
+
+```ts
+mode: 'picture' | 'scramble' | 'recall' | 'sentence-gap';
+```
+
+with:
+
+```ts
+mode: 'picture' | 'recall' | 'sentence-gap';
+```
+
+In `wordSpellConfigFields`, in the `mode` select options, delete the line:
+
+```ts
+{ value: 'scramble', label: 'scramble' },
+```
+
+- [ ] **Step 2: Simplify slot-interaction in WordSpell.tsx**
+
+Edit `src/games/word-spell/WordSpell/WordSpell.tsx`. Lines 505-509 currently:
+
+```ts
+slotInteraction:
+  resolvedConfig.mode === 'scramble' ||
+  resolvedConfig.mode === 'sentence-gap'
+    ? 'free-swap'
+    : 'ordered',
+```
+
+Replace with:
+
+```ts
+slotInteraction:
+  resolvedConfig.mode === 'sentence-gap' ? 'free-swap' : 'ordered',
+```
+
+- [ ] **Step 3: Delete the ScrambleMode story**
+
+Edit `src/games/word-spell/WordSpell/WordSpell.stories.tsx`. Remove the
+entire block (around lines 48-50):
+
+```ts
+export const ScrambleMode: Story = {
+  args: { config: { ...baseConfig, mode: 'scramble' } },
+};
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `yarn typecheck`
+Expected: no errors. If TypeScript reports any remaining `'scramble'`
+reference, search and remove it:
+
+```bash
+grep -rn "'scramble'" src/
+```
+
+- [ ] **Step 5: Run all WordSpell tests**
+
+Run: `yarn vitest run src/games/word-spell src/components/AdvancedConfigModal`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/games/word-spell/
+git commit -m "refactor(word-spell): remove unused scramble mode
+
+Was never used in any user-facing flow. Slot-interaction simplifies to
+sentence-gap → free-swap, everything else → ordered."
+```
+
+---
+
+## Task 11: Final verification
+
+Run every gate that pre-push will run, plus a manual smoke check.
+
+- [ ] **Step 1: Full lint + typecheck**
+
+Run: `yarn lint && yarn typecheck`
+Expected: both pass with no errors.
+
+- [ ] **Step 2: Full unit-test suite**
+
+Run: `yarn test`
+Expected: all suites pass.
+
+- [ ] **Step 3: Markdown checks for the spec + plan**
+
+Run: `yarn lint:md && npx prettier --check 'docs/superpowers/**/*.md'`
+Expected: 0 errors.
+
+- [ ] **Step 4: Manual smoke test in dev server**
+
+Run: `yarn dev`
+Open the app and:
+
+1. Launch WordSpell with no custom config — confirm it lands on `recall`
+   mode, plays in random order, draws words from level 1 cumulatively.
+2. Open the Advanced modal for WordSpell — confirm Level select and Phoneme
+   chips appear at the top, plus the existing fields, plus
+   `distractorCount` (visible when you toggle `tileBankMode` to
+   `distractors`).
+3. Switch to Level 3 in the Simple form — confirm chips for /s/, /æ/, /m/,
+   /b/, etc. all appear and that the game produces non-empty rounds.
+4. Confirm there's no `scramble` option in the mode dropdown.
+
+If any of these fail, fix and add a regression test before continuing.
+
+- [ ] **Step 5: Push and update the existing PR**
+
+```bash
+git push
+```
+
+The PR (#212) auto-updates with the new commits.
+
+---
+
+## Self-Review Checklist
+
+After running the plan end-to-end, confirm:
+
+- [ ] **Spec coverage** — every spec section maps to a task above: - "Fix Level 3+" → Tasks 3 + 4 - "Advanced ⊇ Simple" — Level + Phonemes → Tasks 5 + 6 - "Advanced ⊇ Simple" — distractorCount → Task 7 - "Default mode = recall" → Task 8 - "Random by default + VR" → Task 9 (no VR change needed; verified
+      stories already opt-in to determinism) - "Remove scramble" → Task 10 - "Curriculum invariant test" → Task 2 - "Form-emits-playable test" → Tasks 3 + 4 - "Cumulative-helper unit test" → Task 1
+- [ ] **No placeholders** — every step shows the actual code or command.
+- [ ] **Type consistency** — `WordSpellLibrarySource`, `getAdvancedHeaderRenderer`,
+      and `cumulativeGraphemes` are spelled identically in every task that
+      references them.
+- [ ] **Commits per task** — each task produces one or two focused commits,
+      never a monolithic "do everything" commit.
+
+## Open Questions Resolved Inline
+
+- **Seed-injection point** (deferred from spec): no change needed.
+  `buildRoundOrder` already accepts a `seed`, and stories that need
+  stability already pass it. The default flip in Task 9 only affects the
+  no-config route, which isn't VR-tested.
+- **Migration for old `scramble` configs**: no migration. Pre-launch / dev-
+  only data is throwaway per the spec's non-goals.

--- a/docs/superpowers/specs/2026-04-28-wordspell-levels-defaults-design.md
+++ b/docs/superpowers/specs/2026-04-28-wordspell-levels-defaults-design.md
@@ -28,15 +28,18 @@ class from returning.
 1. **Fix Level 3+** — cumulative phoneme handling so library queries return
    playable word counts at every level.
 2. **Advanced ⊇ Simple** — every option in the Simple form is also reachable
-   from the Advanced form.
+   from the Advanced form. Concretely, Advanced gains:
+   - **Level** (currently Simple-only)
+   - **Phonemes / sounds at this level** (currently Simple-only)
+   - **`distractorCount`** — never exposed in WordSpell's Advanced even though
+     the game uses distractor mode. NumberMatch already exposes this; WordSpell
+     forgot to.
 3. **`recall` becomes the default mode** — picture mode is a scaffold; recall
    is the synthetic-phonics target. Library-sourced rounds also have no
    image/emoji today, so picture mode silently degrades.
 4. **Random rounds by default** (`roundsInOrder: false`).
 5. **Remove the unused `scramble` mode.**
-6. **Add a `distractorCount` field to Advanced** — the only `AnswerGameConfig`
-   field other Word/Number games expose that WordSpell's Advanced is missing.
-7. **Lock the bug class out of the codebase** with parameterized regression
+6. **Lock the bug class out of the codebase** with parameterized regression
    tests that fail loudly if any (region, level) ever drops below the playable
    minimum.
 
@@ -112,23 +115,23 @@ default truly random.
 
 ### Advanced form gap
 
-| `AnswerGameConfig` field                  | In WordSpell Advanced today? | Action                               |
-| ----------------------------------------- | ---------------------------- | ------------------------------------ |
-| `inputMethod`                             | ✅                           | keep                                 |
-| `wrongTileBehavior`                       | ✅                           | keep                                 |
-| `tileBankMode`                            | ✅                           | keep                                 |
-| `distractorCount`                         | ❌                           | **add** (NumberMatch already has it) |
-| `totalRounds`                             | ✅                           | keep                                 |
-| `roundsInOrder`                           | ✅                           | keep                                 |
-| `ttsEnabled`                              | ✅                           | keep                                 |
-| `mode`                                    | ✅                           | keep (drop `scramble`)               |
-| `tileUnit`                                | ✅                           | keep                                 |
-| `source.filter.level` + `phonemesAllowed` | ❌                           | **add** via shared sub-component     |
-| `skin`                                    | ❌                           | skip — managed by `SkinHarness`      |
-| `hud.*`                                   | ❌                           | skip — not exposed by any game       |
-| `timing.*`                                | ❌                           | skip — not exposed by any game       |
-| `slotInteraction`                         | ❌                           | skip — derived from `mode`           |
-| `touchKeyboardInputMode`                  | ❌                           | skip — derived from `inputMethod`    |
+| Field                                     | In Advanced today | Action                               |
+| ----------------------------------------- | ----------------- | ------------------------------------ |
+| `inputMethod`                             | yes               | keep                                 |
+| `wrongTileBehavior`                       | yes               | keep                                 |
+| `tileBankMode`                            | yes               | keep                                 |
+| `distractorCount`                         | no                | **add** (NumberMatch already has it) |
+| `totalRounds`                             | yes               | keep                                 |
+| `roundsInOrder`                           | yes               | keep                                 |
+| `ttsEnabled`                              | yes               | keep                                 |
+| `mode`                                    | yes               | keep (drop `scramble`)               |
+| `tileUnit`                                | yes               | keep                                 |
+| `source.filter.level` + `phonemesAllowed` | no                | **add** via shared sub-component     |
+| `skin`                                    | no                | skip — managed by `SkinHarness`      |
+| `hud` fields                              | no                | skip — not exposed by any game       |
+| `timing` fields                           | no                | skip — not exposed by any game       |
+| `slotInteraction`                         | no                | skip — derived from `mode`           |
+| `touchKeyboardInputMode`                  | no                | skip — derived from `inputMethod`    |
 
 ### `scramble` mode is unused
 
@@ -326,25 +329,25 @@ short test asserting `cumulativeGraphemes(3)` includes phonemes from levels
 
 ## Acceptance Criteria
 
-- [ ] Selecting any level 1..8 in the Simple form produces a playable round
-      pool (≥ 4 words).
-- [ ] Selecting a level shows the cumulative phoneme chips for levels 1..N,
-      not just level N.
-- [ ] The Advanced modal for WordSpell shows Level + Phonemes controls at the
-      top, plus the existing 8 fields, plus a new `distractorCount` field
-      that appears only when `tileBankMode === 'distractors'`.
-- [ ] Saving from Simple and Advanced both produce equivalent
-      `WordSpellConfig` objects when the same options are set.
-- [ ] No-config WordSpell launch defaults to `mode: 'recall'`,
-      `roundsInOrder: false`.
-- [ ] Simple-form launch defaults to `mode: 'recall'`.
-- [ ] No `scramble` references remain in production code; type union is
-      narrowed to `'picture' | 'recall' | 'sentence-gap'`.
-- [ ] `yarn typecheck`, `yarn lint`, `yarn test` pass.
-- [ ] VR baselines stable (re-recorded once for the new defaults; subsequent
-      runs match without drift).
-- [ ] Curriculum-invariant test exists and passes for every
-      `(region, level)`.
+- Selecting any level 1..8 in the Simple form produces a playable round
+  pool (≥ 4 words).
+- Selecting a level shows the cumulative phoneme chips for levels 1..N,
+  not just level N.
+- The Advanced modal for WordSpell shows Level + Phonemes controls at the
+  top, plus the existing 8 fields, plus a new `distractorCount` field
+  that appears only when `tileBankMode === 'distractors'`.
+- Saving from Simple and Advanced both produce equivalent
+  `WordSpellConfig` objects when the same options are set.
+- No-config WordSpell launch defaults to `mode: 'recall'`,
+  `roundsInOrder: false`.
+- Simple-form launch defaults to `mode: 'recall'`.
+- No `scramble` references remain in production code; type union is
+  narrowed to `'picture' | 'recall' | 'sentence-gap'`.
+- `yarn typecheck`, `yarn lint`, `yarn test` pass.
+- VR baselines stable (re-recorded once for the new defaults; subsequent
+  runs match without drift).
+- Curriculum-invariant test exists and passes for every
+  `(region, level)`.
 
 ## Open Questions Deferred to Plan
 
@@ -353,4 +356,4 @@ short test asserting `cumulativeGraphemes(3)` includes phonemes from levels
   paths.
 - Whether to keep `WordSpellSimpleConfigForm` at all once Advanced has
   parity, or whether the Simple form remains as a streamlined onboarding
-  view. Spec assumes the latter (status quo).
+  view. Spec assumes the latter (status **quo).**

--- a/docs/superpowers/specs/2026-04-28-wordspell-levels-defaults-design.md
+++ b/docs/superpowers/specs/2026-04-28-wordspell-levels-defaults-design.md
@@ -1,0 +1,356 @@
+# WordSpell — Levels in Advanced + Defaults Overhaul
+
+> Status: **Approved (design)** — implementation plan to follow.
+> Date: 2026-04-28
+> Owner: leocaseiro
+
+## Background
+
+WordSpell exposes two configuration surfaces:
+
+- A **Simple** form (`WordSpellSimpleConfigForm`) with Level + Phonemes + Input Method
+- An **Advanced** modal (`AdvancedConfigModal` driven by `wordSpellConfigFields`)
+  with eight other fields
+
+The two forms don't share fields, so Advanced lacks the most fundamental
+content controls (which Level, which sounds). Several defaults also fight the
+synthetic-phonics flow the curriculum is built around. And — discovered while
+writing this spec — Levels 3+ are effectively broken: a filter-cumulativity
+mismatch silently drops most words from the playable pool, so the player sees
+"no rounds" or a tiny pool.
+
+This spec covers the user-facing defaults overhaul, the Advanced-form parity
+fix, the Level 3+ bug fix, and the regression coverage that prevents the bug
+class from returning.
+
+## Goals
+
+1. **Fix Level 3+** — cumulative phoneme handling so library queries return
+   playable word counts at every level.
+2. **Advanced ⊇ Simple** — every option in the Simple form is also reachable
+   from the Advanced form.
+3. **`recall` becomes the default mode** — picture mode is a scaffold; recall
+   is the synthetic-phonics target. Library-sourced rounds also have no
+   image/emoji today, so picture mode silently degrades.
+4. **Random rounds by default** (`roundsInOrder: false`).
+5. **Remove the unused `scramble` mode.**
+6. **Add a `distractorCount` field to Advanced** — the only `AnswerGameConfig`
+   field other Word/Number games expose that WordSpell's Advanced is missing.
+7. **Lock the bug class out of the codebase** with parameterized regression
+   tests that fail loudly if any (region, level) ever drops below the playable
+   minimum.
+
+## Non-Goals
+
+- No data migration for existing saved configs that use `mode: 'scramble'` —
+  pre-launch / dev-only data is treated as throwaway.
+- No new game modes; `picture`, `recall`, and `sentence-gap` stay.
+- No curriculum content changes.
+- No changes to `skin`, `hud`, `timing` exposure (consistent with other games).
+
+## Findings (the why)
+
+### Level 3+ is silently broken
+
+`filterWords` requires that **every** grapheme of a candidate word's phoneme
+mapping be present in `filter.phonemesAllowed` (`src/data/words/filter.ts`,
+lines 70–73):
+
+```ts
+if (filter.phonemesAllowed) {
+  const allowed = new Set(filter.phonemesAllowed);
+  if (!hit.graphemes.every((g) => allowed.has(g.p))) return false;
+}
+```
+
+`WordSpellSimpleConfigForm.setLevel(N)` populates `phonemesAllowed` with the
+phonemes from level `N` only — not levels 1..N (`WordSpellSimpleConfigForm.tsx`
+lines 39–52, 60–75):
+
+```ts
+const unitsAtLevel = GRAPHEMES_BY_LEVEL[level] ?? [];
+// ...
+const setLevel = (n: number) => {
+  const available = [
+    ...new Set((GRAPHEMES_BY_LEVEL[n] ?? []).map((u) => u.p)),
+  ];
+  // -> phonemesAllowed = level-N phonemes only
+};
+```
+
+Consequence: a Level 3 word like `bat` uses three phonemes: `/b/` (level 3),
+`/æ/` (level 1), and `/t/` (level 1). With `phonemesAllowed` containing only
+level-3 phonemes, `/æ/` and `/t/` are not in the allowed set and the word is
+rejected. Levels 1 and 2 worked by coincidence (level 2's phoneme set
+contains enough overlap with level-1 sounds for some words to slip through).
+Level 3+ effectively yields zero or near-zero hits.
+
+The fix is to use `cumulativeGraphemes(level)` (already defined in
+`src/data/words/levels.ts:130-144`) for both the chip pool and the default
+`phonemesAllowed` set.
+
+### Library rounds have no image / emoji
+
+`toWordSpellRound` in `src/data/words/adapters.ts:4-6` only sets `word`. No
+`emoji`, no `image`. So library-sourced rounds in `picture` mode show nothing
+visual and silently behave like `recall` — except in `recall` we also disable
+the placeholder, so the user gets a coherent UX. This is a second reason
+`recall` is the right default for library-driven gameplay.
+
+### Defaults bias toward "training wheels" instead of synthetic-phonics flow
+
+| Default                                   | Today                       | Should be        |
+| ----------------------------------------- | --------------------------- | ---------------- |
+| `DEFAULT_WORD_SPELL_CONFIG.mode`          | `picture`                   | `recall`         |
+| `DEFAULT_WORD_SPELL_CONFIG.roundsInOrder` | `true` (deliberate, for VR) | `false` (random) |
+| `resolveSimpleConfig.mode`                | `scramble`                  | `recall`         |
+
+Random rounds were avoided in defaults because the shuffler uses a
+`crypto.getRandomValues` seed VR tests can't pin. Solution: deterministic
+seed injection in test mode (see "VR stability" below) — keep the user-facing
+default truly random.
+
+### Advanced form gap
+
+| `AnswerGameConfig` field                  | In WordSpell Advanced today? | Action                               |
+| ----------------------------------------- | ---------------------------- | ------------------------------------ |
+| `inputMethod`                             | ✅                           | keep                                 |
+| `wrongTileBehavior`                       | ✅                           | keep                                 |
+| `tileBankMode`                            | ✅                           | keep                                 |
+| `distractorCount`                         | ❌                           | **add** (NumberMatch already has it) |
+| `totalRounds`                             | ✅                           | keep                                 |
+| `roundsInOrder`                           | ✅                           | keep                                 |
+| `ttsEnabled`                              | ✅                           | keep                                 |
+| `mode`                                    | ✅                           | keep (drop `scramble`)               |
+| `tileUnit`                                | ✅                           | keep                                 |
+| `source.filter.level` + `phonemesAllowed` | ❌                           | **add** via shared sub-component     |
+| `skin`                                    | ❌                           | skip — managed by `SkinHarness`      |
+| `hud.*`                                   | ❌                           | skip — not exposed by any game       |
+| `timing.*`                                | ❌                           | skip — not exposed by any game       |
+| `slotInteraction`                         | ❌                           | skip — derived from `mode`           |
+| `touchKeyboardInputMode`                  | ❌                           | skip — derived from `inputMethod`    |
+
+### `scramble` mode is unused
+
+Reference search shows `scramble` only in defaults, stories, and tests — not
+in any user-visible flow the team uses. Removing it simplifies the slot-
+interaction logic in `WordSpell.tsx:505-509` to a single `mode === 'sentence-gap'`
+check.
+
+## Approach
+
+### A. Cumulative phonemes
+
+In `WordSpellSimpleConfigForm.tsx`, replace `GRAPHEMES_BY_LEVEL[level] ?? []`
+with `cumulativeGraphemes(level)`:
+
+- Used to build the chip pool so users can toggle phonemes from levels 1..N.
+- Used inside `setLevel(N)` to seed `phonemesAllowed` to all phonemes at
+  levels 1..N (the natural "all sounds learned so far" default).
+
+The chip-strip rendering (one chip per unique phoneme, listing all graphemes
+that teach it) stays the same — it already collapses graphemes-per-phoneme.
+
+### B. Shared `WordSpellLibrarySource` sub-component
+
+Extract the Level select + Phonemes chip strip from `WordSpellSimpleConfigForm`
+into a new component:
+
+```text
+src/games/word-spell/WordSpellLibrarySource/
+├── WordSpellLibrarySource.tsx
+└── WordSpellLibrarySource.test.tsx
+```
+
+The component owns `config.source` (`type: 'word-library'`, `filter.level`,
+`filter.phonemesAllowed`, `filter.region`). It exposes the same
+`{ config, onChange }` props every config form takes.
+
+Both forms render it:
+
+- `WordSpellSimpleConfigForm` renders `<WordSpellLibrarySource />` then the
+  Input Method picker.
+- `AdvancedConfigModal` renders it via a new registry hook
+  (`getAdvancedHeaderRenderer(gameId)`) above the standard `ConfigFormFields`.
+
+### C. Registry hook: `getAdvancedHeaderRenderer`
+
+Add a third lookup to `src/games/config-fields-registry.ts`:
+
+```ts
+export const getAdvancedHeaderRenderer = (
+  gameId: string,
+): ConfigFormRenderer | undefined => {
+  switch (gameId) {
+    case 'word-spell':
+      return WordSpellLibrarySource;
+    default:
+      return undefined;
+  }
+};
+```
+
+`AdvancedConfigModal.tsx` consults the hook; when a renderer exists it appears
+above the existing `<ConfigFormFields>`. Other games are unaffected.
+
+### D. Default mode = `recall`
+
+- `src/routes/$locale/_app/game/$gameId.tsx:96-112` →
+  `DEFAULT_WORD_SPELL_CONFIG.mode = 'recall'`.
+- `src/games/word-spell/resolve-simple-config.ts:9` → `mode: 'recall'`.
+- Stories / tests that hardcode `mode: 'picture'` or `mode: 'scramble'`
+  updated where they describe the default; story scenarios that explicitly
+  cover `picture` mode keep that mode.
+
+### E. Random rounds by default + VR stability
+
+- `DEFAULT_WORD_SPELL_CONFIG.roundsInOrder = false`.
+- The engine's `buildRoundOrder` (or its underlying shuffler) gains a way to
+  accept a seed. When `import.meta.env.MODE === 'test'` (or, more precisely,
+  in the Storybook/VR setup file), inject a fixed seed so VR baselines stay
+  pinned. Production runtime stays truly random.
+- Plan note: confirm the exact seed-injection point during plan-writing
+  (likely the nanoid-based shuffle inside the engine; might mean exposing a
+  `roundOrderSeed` config option used only by tests).
+- VR baselines re-recorded after the seed mechanism lands.
+
+### F. Remove `scramble`
+
+- Drop `'scramble'` from `WordSpellConfig['mode']` (`types.ts:38`).
+- Drop the `scramble` option from `wordSpellConfigFields` mode select
+  (`types.ts:88-94`).
+- Simplify `WordSpell.tsx:505-509`:
+
+  ```ts
+  slotInteraction:
+    resolvedConfig.mode === 'sentence-gap' ? 'free-swap' : 'ordered',
+  ```
+
+- Update or delete stories/tests referencing `scramble`.
+- No migration: any saved config with `mode: 'scramble'` is throwaway dev data.
+
+### G. Add `distractorCount` to Advanced
+
+Add a new field with `visibleWhen` so it only appears when the user picks
+`tileBankMode: 'distractors'`:
+
+```ts
+{
+  type: 'number',
+  key: 'distractorCount',
+  label: 'Distractor count',
+  min: 1,
+  max: 10,
+  visibleWhen: { key: 'tileBankMode', value: 'distractors' },
+},
+```
+
+## Files Touched
+
+| Path                                                                                   | Change                                               |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `src/games/word-spell/types.ts`                                                        | Drop `scramble`; add `distractorCount` field         |
+| `src/games/word-spell/WordSpellSimpleConfigForm/WordSpellSimpleConfigForm.tsx`         | Use cumulative; delegate to `WordSpellLibrarySource` |
+| **NEW** `src/games/word-spell/WordSpellLibrarySource/WordSpellLibrarySource.tsx`       | Shared Level + Phonemes UI                           |
+| **NEW** `src/games/word-spell/WordSpellLibrarySource/WordSpellLibrarySource.test.tsx`  | Sub-component tests                                  |
+| `src/games/word-spell/resolve-simple-config.ts`                                        | `mode: 'recall'` default                             |
+| `src/games/config-fields-registry.ts`                                                  | Add `getAdvancedHeaderRenderer`                      |
+| `src/components/AdvancedConfigModal.tsx`                                               | Render header when registered                        |
+| `src/routes/$locale/_app/game/$gameId.tsx`                                             | Defaults: `recall`, `roundsInOrder: false`           |
+| `src/games/word-spell/WordSpell/WordSpell.tsx`                                         | Drop `scramble` branch                               |
+| Engine round-order shuffler (TBD in plan)                                              | Seed-injection for test mode                         |
+| Stories / tests referencing `scramble` or old defaults                                 | Update or delete                                     |
+| **NEW** `src/data/words/curriculum-invariant.test.ts`                                  | Parameterized (region, level) playability test       |
+| **NEW** `src/games/word-spell/WordSpellSimpleConfigForm/source-emits-playable.test.ts` | Parameterized form-emits-playable test               |
+| `src/games/word-spell/WordSpell/word-spell-initial-content.test.ts`                    | Update mode references                               |
+| VR baselines                                                                           | Re-record after seed-injection                       |
+
+## Testing Strategy
+
+### Layer 1 — Curriculum invariant (the test that would have caught this)
+
+`src/data/words/curriculum-invariant.test.ts`. Parameterized over every
+`(region, level)` in `ALL_REGIONS × {1..8}`:
+
+```ts
+const MIN_PLAYABLE_HITS = 4; // one full round at the default totalRounds
+
+describe('curriculum invariant: every level has playable defaults', () => {
+  for (const region of ALL_REGIONS) {
+    for (const level of [1, 2, 3, 4, 5, 6, 7, 8]) {
+      it(`${region} L${level}: cumulative phonemes yield ≥ ${MIN_PLAYABLE_HITS} words`, async () => {
+        const phonemesAllowed = [
+          ...new Set(cumulativeGraphemes(level).map((u) => u.p)),
+        ];
+        const result = await filterWords({
+          region,
+          level,
+          phonemesAllowed,
+        });
+        expect(result.hits.length).toBeGreaterThanOrEqual(
+          MIN_PLAYABLE_HITS,
+        );
+      });
+    }
+  }
+});
+```
+
+This fails loudly if any future change (curriculum content, filter logic,
+cumulativity helper) breaks the playable contract.
+
+### Layer 2 — Form emits playable source
+
+`src/games/word-spell/WordSpellSimpleConfigForm/source-emits-playable.test.ts`.
+Render the form, simulate `setLevel(N)` for each level, capture the emitted
+`source.filter`, and assert `filterWords` returns ≥ 1 hit. Catches form-side
+regressions even when the curriculum is fine.
+
+### Layer 3 — Cumulative helper unit test
+
+If `cumulativeGraphemes` doesn't already have direct test coverage, add a
+short test asserting `cumulativeGraphemes(3)` includes phonemes from levels
+1, 2, and 3 with no duplicates. Cheap, documents intent.
+
+### Layer 4 — Existing-test updates
+
+- `resolve-simple-config.test.ts`: default mode is `recall`.
+- `useLibraryRounds.test.tsx`, `WordSpell.test.tsx`,
+  `word-spell-initial-content.test.ts`: update hardcoded `mode: 'picture'`
+  / `mode: 'scramble'` references that describe the default. Targeted-mode
+  scenarios stay unchanged.
+- New AdvancedConfigModal test: opening the modal for `gameId === 'word-spell'`
+  shows Level + Phonemes controls.
+- Skipped: full E2E "play through every level" — too slow, redundant with
+  Layers 1+2.
+
+## Acceptance Criteria
+
+- [ ] Selecting any level 1..8 in the Simple form produces a playable round
+      pool (≥ 4 words).
+- [ ] Selecting a level shows the cumulative phoneme chips for levels 1..N,
+      not just level N.
+- [ ] The Advanced modal for WordSpell shows Level + Phonemes controls at the
+      top, plus the existing 8 fields, plus a new `distractorCount` field
+      that appears only when `tileBankMode === 'distractors'`.
+- [ ] Saving from Simple and Advanced both produce equivalent
+      `WordSpellConfig` objects when the same options are set.
+- [ ] No-config WordSpell launch defaults to `mode: 'recall'`,
+      `roundsInOrder: false`.
+- [ ] Simple-form launch defaults to `mode: 'recall'`.
+- [ ] No `scramble` references remain in production code; type union is
+      narrowed to `'picture' | 'recall' | 'sentence-gap'`.
+- [ ] `yarn typecheck`, `yarn lint`, `yarn test` pass.
+- [ ] VR baselines stable (re-recorded once for the new defaults; subsequent
+      runs match without drift).
+- [ ] Curriculum-invariant test exists and passes for every
+      `(region, level)`.
+
+## Open Questions Deferred to Plan
+
+- Exact seed-injection point for the round-order shuffler — confirm by
+  reading `buildRoundOrder` and the engine `INIT_ROUND` / `RESUME_ROUND`
+  paths.
+- Whether to keep `WordSpellSimpleConfigForm` at all once Advanced has
+  parity, or whether the Simple form remains as a streamlined onboarding
+  view. Spec assumes the latter (status quo).


### PR DESCRIPTION
## Summary

Design spec for the WordSpell config overhaul covering five user-visible
changes plus regression coverage for the bug class that motivated the work:

- Fix Level 3+ — cumulative phoneme handling so library queries return playable word counts at every level
- Advanced ⊇ Simple — Advanced gains Level + Phonemes (currently Simple-only) and `distractorCount` (never exposed despite distractor mode being supported)
- `recall` becomes the default mode (replacing `picture`); library rounds have no images today, so picture mode silently degrades
- Random rounds by default (`roundsInOrder: false`), with a deterministic seed in test mode for VR stability
- Remove the unused `scramble` mode
- New parameterized regression tests over every (region, level) so the playable-pool contract is enforced going forward

## Test plan

- [ ] Spec only — `yarn lint:md` and `npx prettier --check` pass
- [ ] Implementation plan to follow as additional commits on this branch
- [ ] Implementation PR will land separately once plan is approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)