### PR TITLE
docs: require plan authors to consult project skills before prescribing code

### DIFF
--- a/.claude/skills/write-storybook/SKILL.md
+++ b/.claude/skills/write-storybook/SKILL.md
@@ -5,6 +5,18 @@ description: Use when adding, writing, or refactoring Storybook stories for Reac
 
 # Write Storybook
 
+## For plan authors
+
+If you are writing an implementation plan that will create or modify `*.stories.tsx` files, **read this skill before prescribing the story shape**. Plans are binding source of truth for executor agents — boilerplate templates that contradict this skill (e.g. multiple named stories per component, raw JSON controls, `Default` instead of `Playground`) get shipped verbatim because executors trust the plan over their own judgement.
+
+The non-negotiables this skill enforces — flag a **Spec Delta** at the top of the plan if you intend to deviate from any of these:
+
+- A single `Playground` story per component (named exactly `Playground`, not `Default`).
+- Every UI-affecting prop wired as a proper control (select / radio / boolean / range / color / text), never raw JSON in args.
+- Auxiliary named stories only when a scenario genuinely cannot be expressed by toggling Playground controls.
+
+See PR #182 / issue #183 for the incident that motivated this preamble.
+
 ## Overview
 
 Stories live co-located with their component (`ComponentName.stories.tsx`). This project uses `@storybook/react` with TanStack Router and `next-themes`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,21 @@ This file is for **any** coding agent (Cursor, Claude Code, Copilot, etc.). Pref
 - Never commit to `master`. Branch → PR → merge.
 - Project rules also live in `.cursor/rules/` (see `git-workflow.mdc`); this file and those rules should agree.
 
+## Before writing a plan
+
+Plans are binding source of truth for executor agents. If a plan will create or modify any of the following, **invoke the corresponding project skill before prescribing code**, and let the skill override plan boilerplate:
+
+| Plan touches                                 | Required skill                                       |
+| -------------------------------------------- | ---------------------------------------------------- |
+| `*.stories.tsx`                              | `write-storybook`                                    |
+| `tests-vr/**`, `tests-e2e/**`, `*.e2e.ts`    | `write-e2e-vr-tests`                                 |
+| `*.md` authored by an agent                  | Markdown Authoring rules in [CLAUDE.md](./CLAUDE.md) |
+| Architecture docs (`*.mdx` under game state) | `update-architecture-docs`                           |
+
+If a plan's code sample conflicts with a skill, flag it as a **Spec Delta** at the top of the plan and justify the deviation — don't silently ship boilerplate that contradicts project convention. Executors must load the corresponding skill into context when the plan prescribes matching files; if the plan and skill disagree and there is no Spec Delta, treat the skill as authoritative and flag the conflict before coding.
+
+See [CLAUDE.md → Before writing a plan](./CLAUDE.md#before-writing-a-plan) for the canonical version.
+
 ## Commits (baby steps)
 
 - After each **coherent** chunk of work (feature slice, bugfix + test, doc section, rule tweak), **commit** with a clear message. Do not wait until the end of a large task to make one giant commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,21 @@ Agents using Cursor or other tools: read [AGENTS.md](./AGENTS.md) first for the 
 
 Analyse the [eslint.config.js](./eslint.config.js) to decide what approach to write the code. For example we don't use functions, but const(react/function-component-definition)
 
+## Before writing a plan
+
+Plans are binding source of truth for executor agents. If a plan will create or modify any of the following, **invoke the corresponding project skill before prescribing code**, and let the skill override plan boilerplate:
+
+| Plan touches                                 | Required skill                 |
+| -------------------------------------------- | ------------------------------ |
+| `*.stories.tsx`                              | `write-storybook`              |
+| `tests-vr/**`, `tests-e2e/**`, `*.e2e.ts`    | `write-e2e-vr-tests`           |
+| `*.md` authored by an agent                  | Markdown Authoring rules below |
+| Architecture docs (`*.mdx` under game state) | `update-architecture-docs`     |
+
+If a plan's code sample conflicts with a skill, flag it as a **Spec Delta** at the top of the plan and justify the deviation — don't silently ship boilerplate that contradicts project convention.
+
+Executors must mirror this: when the plan prescribes files matching the table above, load the corresponding skill into the implementer's context as the authoritative reference. If the plan and skill disagree and there is no Spec Delta, treat the skill as authoritative and flag the conflict to the user before coding.
+
 ## Git Workflow
 
 **Never commit directly to `master`.** All changes must be made on a branch via a git worktree.


### PR DESCRIPTION
## Summary

- Adds a "Before writing a plan" section to `CLAUDE.md` and `AGENTS.md` mapping common plan-touched file patterns to the skill that owns each one (`*.stories.tsx` → `write-storybook`, `tests-vr/**` etc. → `write-e2e-vr-tests`, agent-authored `*.md` → Markdown Authoring rules, game-state `*.mdx` → `update-architecture-docs`).
- Requires a "Spec Delta" callout when a plan deliberately diverges from a skill, so executors don't silently ship boilerplate that contradicts project convention.
- Adds a "For plan authors" preamble to the `write-storybook` skill (the one that triggered the incident in PR #182), so plan authors hit the rule from either entry point.

## Why

PR #182 (Word Authoring, Task 15) shipped four named Storybook stories per component because the plan's template prescribed that exact shape — even though `write-storybook` enforces the single-`Playground` pattern. The planner didn't consult the skill; the executor followed the plan's code block over the prose mention of the skill. Without this rule, any skill-enforced convention (Storybook pattern, VR/E2E test anatomy, markdown formatting, commit discipline) can be silently overridden by plan boilerplate.

## Test plan

- [x] `yarn lint:md` — 0 errors across 125 markdown files
- [x] `npx prettier --check CLAUDE.md AGENTS.md .claude/skills/write-storybook/SKILL.md`
- [x] Pre-commit hooks passed (lint-staged + unit tests)
- [x] Pre-push hooks passed (prettier + markdownlint)
- [ ] Verify CI green
- [ ] Sanity-check next plan touching `*.stories.tsx` or `tests-vr/**` references the corresponding skill or carries a Spec Delta — see Success criteria in #183

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)