### PR TITLE
chore(storybook): add per-game ConfigForm stories (#153)

### DIFF
--- a/.claude/handoffs/2026-04-29-config-form-advanced-parity.md
+++ b/.claude/handoffs/2026-04-29-config-form-advanced-parity.md
@@ -1,0 +1,136 @@
+---
+name: ConfigForm advanced-form parity
+description: Pick up the per-game ConfigForm Storybook work — extend the advanced preview to match the in-app `AdvancedConfigModal` more closely
+---
+
+# Handoff: ConfigForm advanced-form parity
+
+**Date:** 2026-04-29
+**Branch:** `feat/issue-153`
+**Worktree:** `~/.worktrees/base-skill/bs-1` _(AO default — not the project's
+`<root>/worktrees/<name>` convention; see Notes)_
+**Worktree path:** `/Users/leocaseiro/.worktrees/base-skill/bs-1`
+**Git status:** 1 unpushed commit; `.claude/settings.json` modified (pre-existing,
+not mine), `.claude/metadata-updater.sh` untracked (also not mine)
+**Last commit:** `974803bf fix(storybook): render WordSpell advanced header in ConfigForm story (#153)`
+**PR:** [#214](https://github.com/leocaseiro/base-skill/pull/214) — open
+
+## Resume command
+
+```bash
+/resync
+cd ~/.worktrees/base-skill/bs-1
+# Decide whether to push 974803bf as-is, amend it, or extend the advanced
+# preview further (see "Next steps" below) before pushing.
+```
+
+## Current state
+
+**Task:** Issue #153 — per-game ConfigForm stories. The "add stories + simple/
+advanced toggle" work is committed; the latest commit also makes the WordSpell
+advanced preview render its header (`WordSpellLibrarySource`) the same way the
+real `AdvancedConfigModal` does.
+**Phase:** review / extend
+**Progress:** PR #214 has 5 commits; the user paused before pushing the 5th
+(`974803bf`) to look at the advanced form and decide if more parity work is
+needed before shipping.
+
+## What we did this session
+
+- Standardised every Storybook sidebar `title:` to PascalCase segments
+  (`AnswerGame/X`, `Games/SortNumbers/X`, `UI/X`, etc.). Documented the rule in
+  `CLAUDE.md → Storybook Sidebar Titles` and the write-storybook skill; saved
+  `feedback_storybook_title_pascalcase.md` in Claude memory.
+- Added a `mode: 'simple' | 'advanced'` radio control to all 3 per-game
+  ConfigForm stories. `scenario` is conditionally hidden when `mode === 'simple'`
+  via `if: { arg: 'mode', eq: 'advanced' }`. `onChange` is hidden from the
+  controls table (`table.disable: true`) — the `fn()` spy still wires into the
+  Actions panel.
+- Discovered the WordSpell advanced preview was missing the
+  `WordSpellLibrarySource` header that `AdvancedConfigModal` renders above
+  `<ConfigFormFields>`. Last commit pulls the renderer via
+  `getAdvancedHeaderRenderer('word-spell')` and renders it above the field list,
+  matching the app.
+
+## Decisions made
+
+- **PascalCase sidebar titles, not filesystem mirror.** User explicitly chose
+  option B on 2026-04-28: filesystem stays kebab-case (runtime `gameId` /
+  registry keys); Storybook is presentation. Saved as feedback memory so future
+  sessions don't re-derive.
+- **Use `getAdvancedHeaderRenderer` from the registry, not a hand-maintained
+  copy in the story.** Matches `AdvancedConfigModal` line 87 — keeps the story
+  in sync if more games register headers later.
+- **Hoist the registry call to module scope** to satisfy
+  `react-hooks/static-components` (calling it inside the harness component
+  triggers the lint rule).
+
+## Spec / Plan
+
+- Issue [#153](https://github.com/leocaseiro/base-skill/issues/153) — add
+  per-game ConfigForm scenarios out of `ConfigFormFields.stories.tsx`.
+- Reference component: `src/components/AdvancedConfigModal.tsx` — canonical
+  shape of what the advanced flow looks like in the app. The per-game ConfigForm
+  story should mirror its **field area** (header + ConfigFormFields), not the
+  modal chrome (CoverPicker, name input, color picker, save buttons).
+
+## Key files
+
+- `src/games/word-spell/WordSpell.config-form.stories.tsx:79–88` —
+  `AdvancedHeader` hoisted at module scope; rendered above `<ConfigFormFields>`
+  when `mode === 'advanced'`.
+- `src/games/sort-numbers/SortNumbers.config-form.stories.tsx`,
+  `src/games/number-match/NumberMatch.config-form.stories.tsx` — simple/advanced
+  toggle wired but **no header** (the registry returns `undefined` for these
+  games today).
+- `src/games/config-fields-registry.tsx:58–71` —
+  `getAdvancedHeaderRenderer(gameId)`. Only `word-spell` registers a header
+  (`WordSpellAdvancedHeader` → `WordSpellLibrarySource`).
+- `src/components/AdvancedConfigModal.tsx:240–247` — reference render: header
+  → `<ConfigFormFields>`. The story should match this stack ordering.
+- `CLAUDE.md → Storybook Sidebar Titles` — the PascalCase title rule, written
+  this session.
+
+## Open questions
+
+- [ ] Does the user want the story to render **more** of `AdvancedConfigModal`
+      (e.g. `<CoverPicker>`, the custom-game name input, the color picker)? Or is
+      "header + fields" enough? The intent of the `/handoff` ("to make the advanced
+      form after") suggests they want to keep iterating.
+- [ ] Should NumberMatch and SortNumbers stories also call
+      `getAdvancedHeaderRenderer(gameId)` (no-op today) for consistency, or leave
+      them lean? Symmetric pattern would survive a future header registration.
+- [ ] Is there a Storybook decorator missing for the WordSpell library source
+      (it imports `GRAPHEMES_BY_LEVEL` from `@/data/words` — pure module, but worth
+      confirming nothing depends on a runtime data fetch).
+
+## Next steps
+
+1. [ ] Pull this branch, restart Storybook, open `Games/WordSpell/ConfigForm`
+       in advanced mode and confirm the header renders correctly end-to-end.
+2. [ ] If parity looks good as-is, `git push` to ship the 5th commit on PR #214.
+3. [ ] If more parity is wanted, extend the harnesses (likely WordSpell first)
+       to render additional `AdvancedConfigModal` slots in a separate commit on the
+       same PR (or a follow-up PR).
+4. [ ] Audit NumberMatch and SortNumbers — do they have any pieces of advanced
+       UI in the app that the story currently skips? (`AdvancedConfigModal` is
+       shared, but the per-game `getAdvancedHeaderRenderer` is the only per-game
+       slot today; if other slots are added later, mirror them in the stories.)
+
+## Context to remember
+
+- **Worktree location:** This worktree was created by AO under `~/.worktrees/`
+  rather than the project's `<root>/worktrees/<branch>` convention. Existing
+  feedback memory `feedback_worktree_location.md` documents the user's
+  preference to keep worktrees inside the project root. Ask before moving an
+  in-flight branch — don't silently relocate a worktree with a live PR.
+- **PR #214 cadence:** User explicitly OK'd baby-step commits and pushing
+  features without confirmation, but **rejected** the push of `974803bf`
+  mid-flight to review the advanced form first. Treat that as a signal to ask
+  before re-pushing — don't auto-resume.
+- **AO orchestrator force-rebases the PR branch** while you're working —
+  expect `git push` to be rejected and need a `git pull --rebase
+origin feat/issue-153` cycle. Stash `.claude/settings.json` first; it's a
+  pre-existing local mod that gets in the way of rebase.
+- **No `Default` story; use `Playground`.** Project-wide rule from PR #208 —
+  the write-storybook skill enforces it.

--- a/.claude/skills/write-storybook/SKILL.md
+++ b/.claude/skills/write-storybook/SKILL.md
@@ -44,6 +44,7 @@ Additional named stories are only added when a scenario genuinely **cannot** be 
 - The Playground export **must be named exactly `Playground`** (not `Default`). Every reference story in this project uses this name — see [InstructionsOverlay](../../../src/components/answer-game/InstructionsOverlay/InstructionsOverlay.stories.tsx)
 - Use `tags: ['autodocs']` in meta unless there's a reason not to
 - Do NOT import `React` — JSX transform handles it
+- Story `title:` uses **PascalCase segments separated by `/`** — e.g. `AnswerGame/InstructionsOverlay`, `Games/SortNumbers/ConfigForm`. Sidebar titles do not mirror the kebab-case filesystem; see [CLAUDE.md → Storybook Sidebar Titles](../../../CLAUDE.md#storybook-sidebar-titles).
 - Auxiliary named stories are allowed only when a scenario can't be expressed by toggling controls on `Playground` (see "When to Add Auxiliary Stories")
 
 ## File Structure

--- a/.claude/skills/write-storybook/SKILL.md
+++ b/.claude/skills/write-storybook/SKILL.md
@@ -52,6 +52,27 @@ Additional named stories are only added when a scenario genuinely **cannot** be 
 src/components/MyComponent.stories.tsx
 ```
 
+### Per-game previews of generic components
+
+Some generic components (e.g. `ConfigFormFields`, `InstructionsOverlay`) are
+parameterised by per-game fixtures. Their generic story exercises the
+component's abstract rendering branches with synthetic fixtures and **must stay
+game-agnostic**. To preview a specific game's real fixture, add a co-located
+sibling story under that game's directory:
+
+```
+src/components/ConfigFormFields.stories.tsx          ← generic branches only
+src/games/sort-numbers/SortNumbers.config-form.stories.tsx
+src/games/number-match/NumberMatch.config-form.stories.tsx
+src/games/word-spell/WordSpell.config-form.stories.tsx
+```
+
+Pattern precedent: per-game `InstructionsOverlay` stories (#143). Per-game
+files import the game's actual `ConfigField[]` / fixture export — never
+hand-maintained copies — and follow the single-`Playground` pattern with a
+`scenario` select for meaningful presets. Game vocabulary stays out of the
+generic story.
+
 ## Minimal Template
 
 The Playground pattern: a single `Playground` story, with every UI-affecting prop wired as a control on `meta`. Props are set once in `meta.args` so they serve as the Playground's baseline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,22 @@ If a plan's code sample conflicts with a skill, flag it as a **Spec Delta** at t
 
 Executors must mirror this: when the plan prescribes files matching the table above, load the corresponding skill into the implementer's context as the authoritative reference. If the plan and skill disagree and there is no Spec Delta, treat the skill as authoritative and flag the conflict to the user before coding.
 
+## Storybook Sidebar Titles
+
+**One rule:** every story's `title:` uses **PascalCase** segments separated by `/`.
+
+| `title:` value                      | Verdict                                   |
+| ----------------------------------- | ----------------------------------------- |
+| `'AnswerGame/InstructionsOverlay'`  | ✅                                        |
+| `'Games/SortNumbers/ConfigForm'`    | ✅                                        |
+| `'answer-game/InstructionsOverlay'` | ❌ kebab-case top-level                   |
+| `'games/sort-numbers/ConfigForm'`   | ❌ mirrors filesystem, doesn't match rule |
+
+The Storybook sidebar is a presentation concern — it does **not** mirror the
+filesystem. Filesystem paths under `src/games/<game-id>/` stay kebab-case
+(they're runtime `gameId`s used by registries and URLs); Storybook titles
+PascalCase the same names for display.
+
 ## Git Workflow
 
 **Never commit directly to `master`.** All changes must be made on a branch via a git worktree.

--- a/src/components/ConfigFormFields.stories.tsx
+++ b/src/components/ConfigFormFields.stories.tsx
@@ -127,6 +127,7 @@ const scenarioData: Record<
 
 const meta: Meta<StoryArgs> = {
   component: ConfigFormFields as unknown as ComponentType<StoryArgs>,
+  title: 'Components/ConfigFormFields',
   tags: ['autodocs'],
   parameters: {
     docs: {

--- a/src/components/Footer.stories.tsx
+++ b/src/components/Footer.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Footer> = {
   component: Footer,
+  title: 'Components/Footer',
   tags: ['autodocs'],
   decorators: [withRouter],
   parameters: {

--- a/src/components/GameCard.stories.tsx
+++ b/src/components/GameCard.stories.tsx
@@ -30,6 +30,7 @@ interface StoryArgs {
 
 const meta: Meta<StoryArgs> = {
   component: GameCard as unknown as ComponentType<StoryArgs>,
+  title: 'Components/GameCard',
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',

--- a/src/components/GameGrid.stories.tsx
+++ b/src/components/GameGrid.stories.tsx
@@ -31,6 +31,7 @@ interface StoryArgs {
 
 const meta: Meta<StoryArgs> = {
   component: GameGrid as unknown as ComponentType<StoryArgs>,
+  title: 'Components/GameGrid',
   tags: ['autodocs'],
   parameters: {
     docs: {

--- a/src/components/GameNameChip.stories.tsx
+++ b/src/components/GameNameChip.stories.tsx
@@ -4,6 +4,7 @@ import { GAME_COLOR_KEYS } from '@/lib/game-colors';
 
 const meta: Meta<typeof GameNameChip> = {
   component: GameNameChip,
+  title: 'Components/GameNameChip',
   tags: ['autodocs'],
   parameters: {
     docs: {

--- a/src/components/Header.stories.tsx
+++ b/src/components/Header.stories.tsx
@@ -5,6 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Header> = {
   component: Header,
+  title: 'Components/Header',
   tags: ['autodocs'],
   decorators: [withDb, withRouter],
   parameters: {

--- a/src/components/OfflineIndicator.stories.tsx
+++ b/src/components/OfflineIndicator.stories.tsx
@@ -38,6 +38,7 @@ const OfflineHarness = ({ isOffline }: StoryArgs) => {
 
 const meta: Meta<StoryArgs> = {
   component: OfflineIndicator as unknown as ComponentType<StoryArgs>,
+  title: 'Components/OfflineIndicator',
   tags: ['autodocs'],
   parameters: {
     docs: {

--- a/src/components/ThemeToggle.stories.tsx
+++ b/src/components/ThemeToggle.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof ThemeToggle> = {
   component: ThemeToggle,
+  title: 'Components/ThemeToggle',
   tags: ['autodocs'],
   parameters: {
     docs: {

--- a/src/components/UpdateBanner.stories.tsx
+++ b/src/components/UpdateBanner.stories.tsx
@@ -25,6 +25,7 @@ const ServiceWorkerHarness = ({
 
 const meta: Meta<StoryArgs> = {
   component: UpdateBanner as unknown as ComponentType<StoryArgs>,
+  title: 'Components/UpdateBanner',
   tags: ['autodocs'],
   decorators: [withRouter],
   parameters: {

--- a/src/components/answer-game/AnswerGame/AnswerGame.flows.mdx
+++ b/src/components/answer-game/AnswerGame/AnswerGame.flows.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="answer-game/Flows" />
+<Meta title="AnswerGame/Flows" />
 
 # AnswerGame — Event Flows
 

--- a/src/components/answer-game/AnswerGame/AnswerGame.reference.mdx
+++ b/src/components/answer-game/AnswerGame/AnswerGame.reference.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="answer-game/Reference" />
+<Meta title="AnswerGame/Reference" />
 
 # AnswerGame — Reference
 

--- a/src/components/answer-game/AnswerGame/AnswerGame.stories.tsx
+++ b/src/components/answer-game/AnswerGame/AnswerGame.stories.tsx
@@ -25,7 +25,7 @@ interface StoryArgs {
 
 const meta: Meta<StoryArgs> = {
   component: AnswerGame as unknown as ComponentType<StoryArgs>,
-  title: 'answer-game/AnswerGame',
+  title: 'AnswerGame/AnswerGame',
   tags: ['autodocs'],
   decorators: [withDb],
   parameters: {

--- a/src/components/answer-game/EncouragementAnnouncer/EncouragementAnnouncer.stories.tsx
+++ b/src/components/answer-game/EncouragementAnnouncer/EncouragementAnnouncer.stories.tsx
@@ -58,7 +58,7 @@ const ShowTrigger = ({
 const meta: Meta<StoryArgs> = {
   component:
     EncouragementAnnouncer as unknown as ComponentType<StoryArgs>,
-  title: 'answer-game/EncouragementAnnouncer',
+  title: 'AnswerGame/EncouragementAnnouncer',
   tags: ['autodocs'],
   args: {
     message: 'Keep trying!',

--- a/src/components/answer-game/GameOverOverlay/GameOverOverlay.stories.tsx
+++ b/src/components/answer-game/GameOverOverlay/GameOverOverlay.stories.tsx
@@ -26,7 +26,7 @@ const retryCountForStars = (stars: number): number => {
 
 const meta: Meta<StoryArgs> = {
   component: GameOverOverlay as unknown as ComponentType<StoryArgs>,
-  title: 'answer-game/GameOverOverlay',
+  title: 'AnswerGame/GameOverOverlay',
   tags: ['autodocs'],
   args: {
     stars: 5,

--- a/src/components/answer-game/InstructionsOverlay/InstructionsOverlay.stories.tsx
+++ b/src/components/answer-game/InstructionsOverlay/InstructionsOverlay.stories.tsx
@@ -62,7 +62,7 @@ const GAME_ID_OPTIONS = [
 
 const meta: Meta<StoryArgs> = {
   component: InstructionsOverlay as unknown as ComponentType<StoryArgs>,
-  title: 'answer-game/InstructionsOverlay',
+  title: 'AnswerGame/InstructionsOverlay',
   tags: ['autodocs'],
   decorators: [withDb, withRouter],
   parameters: {

--- a/src/components/answer-game/LevelCompleteOverlay/LevelCompleteOverlay.stories.tsx
+++ b/src/components/answer-game/LevelCompleteOverlay/LevelCompleteOverlay.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof LevelCompleteOverlay> = {
   component: LevelCompleteOverlay,
-  title: 'answer-game/LevelCompleteOverlay',
+  title: 'AnswerGame/LevelCompleteOverlay',
   tags: ['autodocs'],
   args: {
     level: 1,

--- a/src/components/answer-game/ProgressHUD/ProgressHUD.stories.tsx
+++ b/src/components/answer-game/ProgressHUD/ProgressHUD.stories.tsx
@@ -20,7 +20,7 @@ interface StoryArgs {
 
 const meta: Meta<StoryArgs> = {
   component: ProgressHUD as unknown as ComponentType<StoryArgs>,
-  title: 'answer-game/ProgressHUD',
+  title: 'AnswerGame/ProgressHUD',
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',

--- a/src/components/answer-game/ScoreAnimation/ScoreAnimation.stories.tsx
+++ b/src/components/answer-game/ScoreAnimation/ScoreAnimation.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof ScoreAnimation> = {
   component: ScoreAnimation,
-  title: 'answer-game/ScoreAnimation',
+  title: 'AnswerGame/ScoreAnimation',
   tags: ['autodocs'],
   args: { visible: true },
   argTypes: {

--- a/src/components/answer-game/Slot/Slot.stories.tsx
+++ b/src/components/answer-game/Slot/Slot.stories.tsx
@@ -132,7 +132,7 @@ const PlaygroundInner = ({
 
 const meta: Meta<StoryArgs> = {
   component: SlotRow as unknown as ComponentType<StoryArgs>,
-  title: 'answer-game/Slot',
+  title: 'AnswerGame/Slot',
   tags: ['autodocs'],
   decorators: [withDb],
   args: {

--- a/src/components/phoneme-blender/PhonemeBlender.flows.mdx
+++ b/src/components/phoneme-blender/PhonemeBlender.flows.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Components/phoneme-blender/Flows" />
+<Meta title="Components/PhonemeBlender/Flows" />
 
 # PhonemeBlender — Interaction Flows
 

--- a/src/components/questions/AudioButton/AudioButton.stories.tsx
+++ b/src/components/questions/AudioButton/AudioButton.stories.tsx
@@ -12,6 +12,7 @@ interface StoryArgs {
 
 const meta: Meta<StoryArgs> = {
   component: AudioButton as unknown as ComponentType<StoryArgs>,
+  title: 'Questions/AudioButton',
   tags: ['autodocs'],
   decorators: [withDb],
   parameters: {

--- a/src/components/questions/DotGroupQuestion/DotGroupQuestion.stories.tsx
+++ b/src/components/questions/DotGroupQuestion/DotGroupQuestion.stories.tsx
@@ -22,6 +22,7 @@ const storyConfig: AnswerGameConfig = {
 
 const meta: Meta<StoryArgs> = {
   component: DotGroupQuestion as unknown as ComponentType<StoryArgs>,
+  title: 'Questions/DotGroupQuestion',
   tags: ['autodocs'],
   decorators: [
     withDb,

--- a/src/components/questions/ImageQuestion/ImageQuestion.stories.tsx
+++ b/src/components/questions/ImageQuestion/ImageQuestion.stories.tsx
@@ -27,7 +27,7 @@ const storyConfig: AnswerGameConfig = {
 
 const meta: Meta<StoryArgs> = {
   component: ImageQuestion,
-  title: 'questions/ImageQuestion',
+  title: 'Questions/ImageQuestion',
   tags: ['autodocs'],
   decorators: [
     withDb,

--- a/src/components/questions/TextQuestion/TextQuestion.stories.tsx
+++ b/src/components/questions/TextQuestion/TextQuestion.stories.tsx
@@ -20,6 +20,7 @@ const storyConfig: AnswerGameConfig = {
 
 const meta: Meta<StoryArgs> = {
   component: TextQuestion as unknown as ComponentType<StoryArgs>,
+  title: 'Questions/TextQuestion',
   tags: ['autodocs'],
   decorators: [
     withDb,

--- a/src/components/ui/alert-dialog.stories.tsx
+++ b/src/components/ui/alert-dialog.stories.tsx
@@ -28,6 +28,7 @@ interface StoryArgs {
 
 const meta: Meta<StoryArgs> = {
   component: AlertDialog as unknown as ComponentType<StoryArgs>,
+  title: 'UI/AlertDialog',
   tags: ['autodocs'],
   args: {
     triggerLabel: 'Delete account',

--- a/src/components/ui/button.stories.tsx
+++ b/src/components/ui/button.stories.tsx
@@ -5,6 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Button> = {
   component: Button,
+  title: 'UI/Button',
   tags: ['autodocs'],
   args: {
     onClick: fn(),

--- a/src/components/ui/card.stories.tsx
+++ b/src/components/ui/card.stories.tsx
@@ -19,6 +19,7 @@ interface StoryArgs {
 
 const meta: Meta<StoryArgs> = {
   component: Card as unknown as ComponentType<StoryArgs>,
+  title: 'UI/Card',
   tags: ['autodocs'],
   args: {
     title: 'Card Title',

--- a/src/components/ui/dropdown-menu.stories.tsx
+++ b/src/components/ui/dropdown-menu.stories.tsx
@@ -22,6 +22,7 @@ interface StoryArgs {
 
 const meta: Meta<StoryArgs> = {
   component: DropdownMenu as unknown as ComponentType<StoryArgs>,
+  title: 'UI/DropdownMenu',
   tags: ['autodocs'],
   args: {
     triggerLabel: 'Options',

--- a/src/components/ui/input.stories.tsx
+++ b/src/components/ui/input.stories.tsx
@@ -5,6 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Input> = {
   component: Input,
+  title: 'UI/Input',
   tags: ['autodocs'],
   args: {
     onChange: fn(),

--- a/src/components/ui/label.stories.tsx
+++ b/src/components/ui/label.stories.tsx
@@ -11,6 +11,7 @@ interface StoryArgs {
 
 const meta: Meta<StoryArgs> = {
   component: Label as unknown as ComponentType<StoryArgs>,
+  title: 'UI/Label',
   tags: ['autodocs'],
   args: {
     htmlFor: 'name',

--- a/src/components/ui/select.stories.tsx
+++ b/src/components/ui/select.stories.tsx
@@ -21,6 +21,7 @@ interface StoryArgs {
 
 const meta: Meta<StoryArgs> = {
   component: Select as unknown as ComponentType<StoryArgs>,
+  title: 'UI/Select',
   tags: ['autodocs'],
   args: {
     triggerLabel: 'Select a fruit',

--- a/src/components/ui/sheet.stories.tsx
+++ b/src/components/ui/sheet.stories.tsx
@@ -25,6 +25,7 @@ interface StoryArgs {
 
 const meta: Meta<StoryArgs> = {
   component: Sheet as unknown as ComponentType<StoryArgs>,
+  title: 'UI/Sheet',
   tags: ['autodocs'],
   args: {
     side: 'right',

--- a/src/components/ui/slider.stories.tsx
+++ b/src/components/ui/slider.stories.tsx
@@ -5,6 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Slider> = {
   component: Slider,
+  title: 'UI/Slider',
   tags: ['autodocs'],
   args: {
     onValueChange: fn(),

--- a/src/games/number-match/NumberMatch.config-form.stories.tsx
+++ b/src/games/number-match/NumberMatch.config-form.stories.tsx
@@ -1,0 +1,113 @@
+// Co-located preview of the NumberMatch config form, driven by the real
+// `numberMatchConfigFields` registry export.
+//
+// Pattern precedent: per-game `InstructionsOverlay` stories (PR #141).
+import { useState } from 'react';
+import { fn } from 'storybook/test';
+import { numberMatchConfigFields } from './types';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { JSX } from 'react';
+import { ConfigFormFields } from '@/components/ConfigFormFields';
+
+type Scenario =
+  | 'numeral-to-group'
+  | 'cardinal-to-ordinal'
+  | 'with-distractors';
+
+const scenarios: Record<Scenario, Record<string, unknown>> = {
+  'numeral-to-group': {
+    inputMethod: 'drag',
+    wrongTileBehavior: 'lock-manual',
+    mode: 'numeral-to-group',
+    tileStyle: 'dots',
+    tileBankMode: 'exact',
+    distractorCount: 3,
+    totalRounds: 5,
+    roundsInOrder: false,
+    range: { min: 1, max: 10 },
+    ttsEnabled: false,
+  },
+  'cardinal-to-ordinal': {
+    inputMethod: 'both',
+    wrongTileBehavior: 'reject',
+    mode: 'cardinal-to-ordinal',
+    tileStyle: 'objects',
+    tileBankMode: 'exact',
+    distractorCount: 3,
+    totalRounds: 8,
+    roundsInOrder: true,
+    range: { min: 1, max: 20 },
+    ttsEnabled: true,
+  },
+  'with-distractors': {
+    inputMethod: 'drag',
+    wrongTileBehavior: 'lock-auto-eject',
+    mode: 'group-to-numeral',
+    tileStyle: 'fingers',
+    tileBankMode: 'distractors',
+    distractorCount: 5,
+    totalRounds: 10,
+    roundsInOrder: false,
+    range: { min: 1, max: 10 },
+    ttsEnabled: true,
+  },
+};
+
+type HarnessProps = {
+  scenario: Scenario;
+  onChange: (config: Record<string, unknown>) => void;
+};
+
+const NumberMatchConfigFormHarness = ({
+  scenario,
+  onChange,
+}: HarnessProps): JSX.Element => {
+  const [config, setConfig] = useState<Record<string, unknown>>(
+    () => scenarios[scenario],
+  );
+  return (
+    <ConfigFormFields
+      fields={numberMatchConfigFields}
+      config={config}
+      onChange={(next) => {
+        setConfig(next);
+        onChange(next);
+      }}
+    />
+  );
+};
+
+const meta: Meta<typeof NumberMatchConfigFormHarness> = {
+  title: 'Games/NumberMatch/ConfigForm',
+  component: NumberMatchConfigFormHarness,
+  tags: ['autodocs'],
+  args: {
+    scenario: 'numeral-to-group',
+    onChange: fn(),
+  },
+  argTypes: {
+    scenario: {
+      control: { type: 'radio' },
+      options: [
+        'numeral-to-group',
+        'cardinal-to-ordinal',
+        'with-distractors',
+      ] satisfies Scenario[],
+      description:
+        'Preset covering NumberMatch modes: numeral↔group, cardinal↔ordinal, and a distractor-enabled config.',
+    },
+    onChange: { control: false },
+  },
+  render: ({ scenario, onChange }) => (
+    <NumberMatchConfigFormHarness
+      key={scenario}
+      scenario={scenario}
+      onChange={onChange}
+    />
+  ),
+};
+export default meta;
+
+type Story = StoryObj<typeof NumberMatchConfigFormHarness>;
+
+export const Playground: Story = {};

--- a/src/games/number-match/NumberMatch.config-form.stories.tsx
+++ b/src/games/number-match/NumberMatch.config-form.stories.tsx
@@ -1,13 +1,17 @@
 // Co-located preview of the NumberMatch config form, driven by the real
-// `numberMatchConfigFields` registry export.
+// `numberMatchConfigFields` registry export and `NumberMatchSimpleConfigForm`
+// for simple-mode preview.
 //
 // Pattern precedent: per-game `InstructionsOverlay` stories (PR #141).
 import { useState } from 'react';
 import { fn } from 'storybook/test';
+import { NumberMatchSimpleConfigForm } from './NumberMatchSimpleConfigForm/NumberMatchSimpleConfigForm';
 import { numberMatchConfigFields } from './types';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { JSX } from 'react';
 import { ConfigFormFields } from '@/components/ConfigFormFields';
+
+type Mode = 'simple' | 'advanced';
 
 type Scenario =
   | 'numeral-to-group'
@@ -53,26 +57,47 @@ const scenarios: Record<Scenario, Record<string, unknown>> = {
   },
 };
 
+const simpleBaseline: Record<string, unknown> = {
+  configMode: 'simple',
+  inputMethod: 'drag',
+  mode: 'numeral-to-group',
+  range: { min: 1, max: 10 },
+  distractorCount: 3,
+};
+
 type HarnessProps = {
+  mode: Mode;
   scenario: Scenario;
   onChange: (config: Record<string, unknown>) => void;
 };
 
 const NumberMatchConfigFormHarness = ({
+  mode,
   scenario,
   onChange,
 }: HarnessProps): JSX.Element => {
+  const initial =
+    mode === 'simple' ? simpleBaseline : scenarios[scenario];
   const [config, setConfig] = useState<Record<string, unknown>>(
-    () => scenarios[scenario],
+    () => initial,
   );
+  const handleChange = (next: Record<string, unknown>): void => {
+    setConfig(next);
+    onChange(next);
+  };
+  if (mode === 'simple') {
+    return (
+      <NumberMatchSimpleConfigForm
+        config={config}
+        onChange={handleChange}
+      />
+    );
+  }
   return (
     <ConfigFormFields
       fields={numberMatchConfigFields}
       config={config}
-      onChange={(next) => {
-        setConfig(next);
-        onChange(next);
-      }}
+      onChange={handleChange}
     />
   );
 };
@@ -82,10 +107,17 @@ const meta: Meta<typeof NumberMatchConfigFormHarness> = {
   component: NumberMatchConfigFormHarness,
   tags: ['autodocs'],
   args: {
+    mode: 'advanced',
     scenario: 'numeral-to-group',
     onChange: fn(),
   },
   argTypes: {
+    mode: {
+      control: { type: 'radio' },
+      options: ['simple', 'advanced'] satisfies Mode[],
+      description:
+        'Which form variant to preview: the kid-friendly Simple form or the full Advanced field list.',
+    },
     scenario: {
       control: { type: 'radio' },
       options: [
@@ -94,13 +126,15 @@ const meta: Meta<typeof NumberMatchConfigFormHarness> = {
         'with-distractors',
       ] satisfies Scenario[],
       description:
-        'Preset covering NumberMatch modes: numeral↔group, cardinal↔ordinal, and a distractor-enabled config.',
+        'Advanced-mode preset covering NumberMatch modes: numeral↔group, cardinal↔ordinal, and a distractor-enabled config.',
+      if: { arg: 'mode', eq: 'advanced' },
     },
-    onChange: { control: false },
+    onChange: { table: { disable: true } },
   },
-  render: ({ scenario, onChange }) => (
+  render: ({ mode, scenario, onChange }) => (
     <NumberMatchConfigFormHarness
-      key={scenario}
+      key={`${mode}:${scenario}`}
+      mode={mode}
       scenario={scenario}
       onChange={onChange}
     />

--- a/src/games/number-match/NumberMatch/NumberMatch.stories.tsx
+++ b/src/games/number-match/NumberMatch/NumberMatch.stories.tsx
@@ -21,6 +21,7 @@ const baseConfig: NumberMatchConfig = {
 
 const meta: Meta<typeof NumberMatch> = {
   component: NumberMatch,
+  title: 'Games/NumberMatch/NumberMatch',
   tags: ['autodocs'],
   args: { config: baseConfig },
   decorators: [withDb, withRouter],

--- a/src/games/number-match/NumeralTileBank/NumeralTileBank.stories.tsx
+++ b/src/games/number-match/NumeralTileBank/NumeralTileBank.stories.tsx
@@ -60,6 +60,7 @@ const InitWordProvider = ({ children }: { children: ReactNode }) => {
 
 const meta: Meta<typeof NumeralTileBank> = {
   component: NumeralTileBank,
+  title: 'Games/NumberMatch/NumeralTileBank',
   tags: ['autodocs'],
   args: { tileStyle: 'dots', tilesShowGroup: true },
   decorators: [

--- a/src/games/sort-numbers/SortNumbers.config-form.stories.tsx
+++ b/src/games/sort-numbers/SortNumbers.config-form.stories.tsx
@@ -1,0 +1,115 @@
+// Co-located preview of the SortNumbers config form, driven by the real
+// `sortNumbersConfigFields` registry export. The generic
+// `src/components/ConfigFormFields.stories.tsx` covers abstract rendering
+// branches; this story shows what a real game's form looks like end-to-end.
+//
+// Pattern precedent: per-game `InstructionsOverlay` stories (PR #141).
+import { useState } from 'react';
+import { fn } from 'storybook/test';
+import { sortNumbersConfigFields } from './types';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { JSX } from 'react';
+import { ConfigFormFields } from '@/components/ConfigFormFields';
+
+type Scenario = 'random' | 'by-mode' | 'distractors';
+
+const scenarios: Record<Scenario, Record<string, unknown>> = {
+  random: {
+    inputMethod: 'drag',
+    wrongTileBehavior: 'lock-manual',
+    tileBankMode: 'exact',
+    totalRounds: 3,
+    roundsInOrder: false,
+    direction: 'ascending',
+    quantity: 4,
+    range: { min: 2, max: 20 },
+    skip: { mode: 'random' },
+    distractors: { source: 'random', count: 2 },
+    ttsEnabled: false,
+  },
+  'by-mode': {
+    inputMethod: 'drag',
+    wrongTileBehavior: 'lock-manual',
+    tileBankMode: 'exact',
+    totalRounds: 3,
+    roundsInOrder: false,
+    direction: 'ascending',
+    quantity: 4,
+    range: { min: 2, max: 50 },
+    skip: { mode: 'by', step: 5, start: 'range-min' },
+    distractors: { source: 'random', count: 2 },
+    ttsEnabled: false,
+  },
+  distractors: {
+    inputMethod: 'drag',
+    wrongTileBehavior: 'lock-manual',
+    tileBankMode: 'distractors',
+    totalRounds: 3,
+    roundsInOrder: false,
+    direction: 'ascending',
+    quantity: 4,
+    range: { min: 2, max: 20 },
+    skip: { mode: 'random' },
+    distractors: { source: 'gaps-only', count: 3 },
+    ttsEnabled: false,
+  },
+};
+
+type HarnessProps = {
+  scenario: Scenario;
+  onChange: (config: Record<string, unknown>) => void;
+};
+
+const SortNumbersConfigFormHarness = ({
+  scenario,
+  onChange,
+}: HarnessProps): JSX.Element => {
+  const [config, setConfig] = useState<Record<string, unknown>>(
+    () => scenarios[scenario],
+  );
+  return (
+    <ConfigFormFields
+      fields={sortNumbersConfigFields}
+      config={config}
+      onChange={(next) => {
+        setConfig(next);
+        onChange(next);
+      }}
+    />
+  );
+};
+
+const meta: Meta<typeof SortNumbersConfigFormHarness> = {
+  title: 'Games/SortNumbers/ConfigForm',
+  component: SortNumbersConfigFormHarness,
+  tags: ['autodocs'],
+  args: {
+    scenario: 'random',
+    onChange: fn(),
+  },
+  argTypes: {
+    scenario: {
+      control: { type: 'radio' },
+      options: [
+        'random',
+        'by-mode',
+        'distractors',
+      ] satisfies Scenario[],
+      description:
+        'Preset matching SortNumbers config branches: random skip, by-mode skip (shows step + start), or distractor tile bank (shows source + count).',
+    },
+    onChange: { control: false },
+  },
+  render: ({ scenario, onChange }) => (
+    <SortNumbersConfigFormHarness
+      key={scenario}
+      scenario={scenario}
+      onChange={onChange}
+    />
+  ),
+};
+export default meta;
+
+type Story = StoryObj<typeof SortNumbersConfigFormHarness>;
+
+export const Playground: Story = {};

--- a/src/games/sort-numbers/SortNumbers.config-form.stories.tsx
+++ b/src/games/sort-numbers/SortNumbers.config-form.stories.tsx
@@ -1,15 +1,19 @@
 // Co-located preview of the SortNumbers config form, driven by the real
-// `sortNumbersConfigFields` registry export. The generic
+// `sortNumbersConfigFields` registry export and `SortNumbersSimpleConfigForm`
+// for simple-mode preview. The generic
 // `src/components/ConfigFormFields.stories.tsx` covers abstract rendering
 // branches; this story shows what a real game's form looks like end-to-end.
 //
 // Pattern precedent: per-game `InstructionsOverlay` stories (PR #141).
 import { useState } from 'react';
 import { fn } from 'storybook/test';
+import { SortNumbersSimpleConfigForm } from './SortNumbersSimpleConfigForm/SortNumbersSimpleConfigForm';
 import { sortNumbersConfigFields } from './types';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { JSX } from 'react';
 import { ConfigFormFields } from '@/components/ConfigFormFields';
+
+type Mode = 'simple' | 'advanced';
 
 type Scenario = 'random' | 'by-mode' | 'distractors';
 
@@ -55,26 +59,48 @@ const scenarios: Record<Scenario, Record<string, unknown>> = {
   },
 };
 
+const simpleBaseline: Record<string, unknown> = {
+  configMode: 'simple',
+  inputMethod: 'drag',
+  direction: 'ascending',
+  quantity: 5,
+  skip: { mode: 'by', step: 2, start: 2 },
+  distractors: false,
+};
+
 type HarnessProps = {
+  mode: Mode;
   scenario: Scenario;
   onChange: (config: Record<string, unknown>) => void;
 };
 
 const SortNumbersConfigFormHarness = ({
+  mode,
   scenario,
   onChange,
 }: HarnessProps): JSX.Element => {
+  const initial =
+    mode === 'simple' ? simpleBaseline : scenarios[scenario];
   const [config, setConfig] = useState<Record<string, unknown>>(
-    () => scenarios[scenario],
+    () => initial,
   );
+  const handleChange = (next: Record<string, unknown>): void => {
+    setConfig(next);
+    onChange(next);
+  };
+  if (mode === 'simple') {
+    return (
+      <SortNumbersSimpleConfigForm
+        config={config}
+        onChange={handleChange}
+      />
+    );
+  }
   return (
     <ConfigFormFields
       fields={sortNumbersConfigFields}
       config={config}
-      onChange={(next) => {
-        setConfig(next);
-        onChange(next);
-      }}
+      onChange={handleChange}
     />
   );
 };
@@ -84,10 +110,17 @@ const meta: Meta<typeof SortNumbersConfigFormHarness> = {
   component: SortNumbersConfigFormHarness,
   tags: ['autodocs'],
   args: {
+    mode: 'advanced',
     scenario: 'random',
     onChange: fn(),
   },
   argTypes: {
+    mode: {
+      control: { type: 'radio' },
+      options: ['simple', 'advanced'] satisfies Mode[],
+      description:
+        'Which form variant to preview: the kid-friendly Simple form or the full Advanced field list.',
+    },
     scenario: {
       control: { type: 'radio' },
       options: [
@@ -96,13 +129,15 @@ const meta: Meta<typeof SortNumbersConfigFormHarness> = {
         'distractors',
       ] satisfies Scenario[],
       description:
-        'Preset matching SortNumbers config branches: random skip, by-mode skip (shows step + start), or distractor tile bank (shows source + count).',
+        'Advanced-mode preset matching SortNumbers config branches: random skip, by-mode skip (shows step + start), or distractor tile bank (shows source + count).',
+      if: { arg: 'mode', eq: 'advanced' },
     },
-    onChange: { control: false },
+    onChange: { table: { disable: true } },
   },
-  render: ({ scenario, onChange }) => (
+  render: ({ mode, scenario, onChange }) => (
     <SortNumbersConfigFormHarness
-      key={scenario}
+      key={`${mode}:${scenario}`}
+      mode={mode}
       scenario={scenario}
       onChange={onChange}
     />

--- a/src/games/sort-numbers/SortNumbers/SortNumbers.stories.tsx
+++ b/src/games/sort-numbers/SortNumbers/SortNumbers.stories.tsx
@@ -59,6 +59,7 @@ const baseConfig: SortNumbersConfig = {
 
 const meta: Meta<StoryArgs> = {
   component: SortNumbers,
+  title: 'Games/SortNumbers/SortNumbers',
   tags: ['autodocs'],
   decorators: [withDb, withRouter],
   args: { config: baseConfig, skinId: 'classic' },

--- a/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.stories.tsx
+++ b/src/games/sort-numbers/SortNumbersTileBank/SortNumbersTileBank.stories.tsx
@@ -65,6 +65,7 @@ const withProvider = (Story: React.ComponentType) => (
 
 const meta: Meta<typeof SortNumbersTileBank> = {
   component: SortNumbersTileBank,
+  title: 'Games/SortNumbers/SortNumbersTileBank',
   tags: ['autodocs'],
   decorators: [withDb, withProvider],
 };

--- a/src/games/word-spell/LetterTileBank/LetterTileBank.stories.tsx
+++ b/src/games/word-spell/LetterTileBank/LetterTileBank.stories.tsx
@@ -44,6 +44,7 @@ const InitProvider = ({ children }: { children: ReactNode }) => {
 
 const meta: Meta<typeof LetterTileBank> = {
   component: LetterTileBank,
+  title: 'Games/WordSpell/LetterTileBank',
   tags: ['autodocs'],
   decorators: [
     withDb,

--- a/src/games/word-spell/WordSpell.config-form.stories.tsx
+++ b/src/games/word-spell/WordSpell.config-form.stories.tsx
@@ -10,6 +10,7 @@ import { WordSpellSimpleConfigForm } from './WordSpellSimpleConfigForm/WordSpell
 import type { Meta, StoryObj } from '@storybook/react';
 import type { JSX } from 'react';
 import { ConfigFormFields } from '@/components/ConfigFormFields';
+import { getAdvancedHeaderRenderer } from '@/games/config-fields-registry';
 
 type Mode = 'simple' | 'advanced';
 
@@ -61,6 +62,10 @@ type HarnessProps = {
   onChange: (config: Record<string, unknown>) => void;
 };
 
+// Match `AdvancedConfigModal`: render the per-game advanced header above the
+// generic field list. WordSpell's header is `WordSpellLibrarySource`.
+const AdvancedHeader = getAdvancedHeaderRenderer('word-spell');
+
 const WordSpellConfigFormHarness = ({
   mode,
   scenario,
@@ -84,11 +89,16 @@ const WordSpellConfigFormHarness = ({
     );
   }
   return (
-    <ConfigFormFields
-      fields={wordSpellConfigFields}
-      config={config}
-      onChange={handleChange}
-    />
+    <div className="flex flex-col gap-4">
+      {AdvancedHeader && (
+        <AdvancedHeader config={config} onChange={handleChange} />
+      )}
+      <ConfigFormFields
+        fields={wordSpellConfigFields}
+        config={config}
+        onChange={handleChange}
+      />
+    </div>
   );
 };
 

--- a/src/games/word-spell/WordSpell.config-form.stories.tsx
+++ b/src/games/word-spell/WordSpell.config-form.stories.tsx
@@ -1,0 +1,104 @@
+// Co-located preview of the WordSpell config form, driven by the real
+// `wordSpellConfigFields` registry export.
+//
+// Pattern precedent: per-game `InstructionsOverlay` stories (PR #141).
+import { useState } from 'react';
+import { fn } from 'storybook/test';
+import { wordSpellConfigFields } from './types';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { JSX } from 'react';
+import { ConfigFormFields } from '@/components/ConfigFormFields';
+
+type Scenario = 'picture' | 'scramble' | 'sentence-gap';
+
+const scenarios: Record<Scenario, Record<string, unknown>> = {
+  picture: {
+    inputMethod: 'drag',
+    wrongTileBehavior: 'lock-manual',
+    tileBankMode: 'exact',
+    totalRounds: 5,
+    mode: 'picture',
+    tileUnit: 'letter',
+    roundsInOrder: false,
+    ttsEnabled: true,
+  },
+  scramble: {
+    inputMethod: 'both',
+    wrongTileBehavior: 'reject',
+    tileBankMode: 'distractors',
+    totalRounds: 6,
+    mode: 'scramble',
+    tileUnit: 'letter',
+    roundsInOrder: true,
+    ttsEnabled: false,
+  },
+  'sentence-gap': {
+    inputMethod: 'drag',
+    wrongTileBehavior: 'lock-auto-eject',
+    tileBankMode: 'distractors',
+    totalRounds: 4,
+    mode: 'sentence-gap',
+    tileUnit: 'word',
+    roundsInOrder: false,
+    ttsEnabled: true,
+  },
+};
+
+type HarnessProps = {
+  scenario: Scenario;
+  onChange: (config: Record<string, unknown>) => void;
+};
+
+const WordSpellConfigFormHarness = ({
+  scenario,
+  onChange,
+}: HarnessProps): JSX.Element => {
+  const [config, setConfig] = useState<Record<string, unknown>>(
+    () => scenarios[scenario],
+  );
+  return (
+    <ConfigFormFields
+      fields={wordSpellConfigFields}
+      config={config}
+      onChange={(next) => {
+        setConfig(next);
+        onChange(next);
+      }}
+    />
+  );
+};
+
+const meta: Meta<typeof WordSpellConfigFormHarness> = {
+  title: 'Games/WordSpell/ConfigForm',
+  component: WordSpellConfigFormHarness,
+  tags: ['autodocs'],
+  args: {
+    scenario: 'picture',
+    onChange: fn(),
+  },
+  argTypes: {
+    scenario: {
+      control: { type: 'radio' },
+      options: [
+        'picture',
+        'scramble',
+        'sentence-gap',
+      ] satisfies Scenario[],
+      description:
+        'Preset covering meaningful WordSpell modes: picture (letters), scramble (letters with distractors), sentence-gap (word tiles).',
+    },
+    onChange: { control: false },
+  },
+  render: ({ scenario, onChange }) => (
+    <WordSpellConfigFormHarness
+      key={scenario}
+      scenario={scenario}
+      onChange={onChange}
+    />
+  ),
+};
+export default meta;
+
+type Story = StoryObj<typeof WordSpellConfigFormHarness>;
+
+export const Playground: Story = {};

--- a/src/games/word-spell/WordSpell.config-form.stories.tsx
+++ b/src/games/word-spell/WordSpell.config-form.stories.tsx
@@ -1,13 +1,17 @@
 // Co-located preview of the WordSpell config form, driven by the real
-// `wordSpellConfigFields` registry export.
+// `wordSpellConfigFields` registry export and `WordSpellSimpleConfigForm`
+// for simple-mode preview.
 //
 // Pattern precedent: per-game `InstructionsOverlay` stories (PR #141).
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 import { wordSpellConfigFields } from './types';
+import { WordSpellSimpleConfigForm } from './WordSpellSimpleConfigForm/WordSpellSimpleConfigForm';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { JSX } from 'react';
 import { ConfigFormFields } from '@/components/ConfigFormFields';
+
+type Mode = 'simple' | 'advanced';
 
 type Scenario = 'picture' | 'scramble' | 'sentence-gap';
 
@@ -44,26 +48,46 @@ const scenarios: Record<Scenario, Record<string, unknown>> = {
   },
 };
 
+const simpleBaseline: Record<string, unknown> = {
+  configMode: 'simple',
+  inputMethod: 'drag',
+  level: 1,
+  phonemesAllowed: [],
+};
+
 type HarnessProps = {
+  mode: Mode;
   scenario: Scenario;
   onChange: (config: Record<string, unknown>) => void;
 };
 
 const WordSpellConfigFormHarness = ({
+  mode,
   scenario,
   onChange,
 }: HarnessProps): JSX.Element => {
+  const initial =
+    mode === 'simple' ? simpleBaseline : scenarios[scenario];
   const [config, setConfig] = useState<Record<string, unknown>>(
-    () => scenarios[scenario],
+    () => initial,
   );
+  const handleChange = (next: Record<string, unknown>): void => {
+    setConfig(next);
+    onChange(next);
+  };
+  if (mode === 'simple') {
+    return (
+      <WordSpellSimpleConfigForm
+        config={config}
+        onChange={handleChange}
+      />
+    );
+  }
   return (
     <ConfigFormFields
       fields={wordSpellConfigFields}
       config={config}
-      onChange={(next) => {
-        setConfig(next);
-        onChange(next);
-      }}
+      onChange={handleChange}
     />
   );
 };
@@ -73,10 +97,17 @@ const meta: Meta<typeof WordSpellConfigFormHarness> = {
   component: WordSpellConfigFormHarness,
   tags: ['autodocs'],
   args: {
+    mode: 'advanced',
     scenario: 'picture',
     onChange: fn(),
   },
   argTypes: {
+    mode: {
+      control: { type: 'radio' },
+      options: ['simple', 'advanced'] satisfies Mode[],
+      description:
+        'Which form variant to preview: the kid-friendly Simple form or the full Advanced field list.',
+    },
     scenario: {
       control: { type: 'radio' },
       options: [
@@ -85,13 +116,15 @@ const meta: Meta<typeof WordSpellConfigFormHarness> = {
         'sentence-gap',
       ] satisfies Scenario[],
       description:
-        'Preset covering meaningful WordSpell modes: picture (letters), scramble (letters with distractors), sentence-gap (word tiles).',
+        'Advanced-mode preset covering meaningful WordSpell modes: picture (letters), scramble (letters with distractors), sentence-gap (word tiles).',
+      if: { arg: 'mode', eq: 'advanced' },
     },
-    onChange: { control: false },
+    onChange: { table: { disable: true } },
   },
-  render: ({ scenario, onChange }) => (
+  render: ({ mode, scenario, onChange }) => (
     <WordSpellConfigFormHarness
-      key={scenario}
+      key={`${mode}:${scenario}`}
+      mode={mode}
       scenario={scenario}
       onChange={onChange}
     />

--- a/src/games/word-spell/WordSpell/WordSpell.flows.mdx
+++ b/src/games/word-spell/WordSpell/WordSpell.flows.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Games/word-spell/Flows" />
+<Meta title="Games/WordSpell/Flows" />
 
 # WordSpell — End-to-End Flows
 

--- a/src/games/word-spell/WordSpell/WordSpell.stories.tsx
+++ b/src/games/word-spell/WordSpell/WordSpell.stories.tsx
@@ -23,6 +23,7 @@ const baseConfig: WordSpellConfig = {
 
 const meta: Meta<typeof WordSpell> = {
   component: WordSpell,
+  title: 'Games/WordSpell/WordSpell',
   tags: ['autodocs'],
   args: { config: baseConfig },
   decorators: [withDb, withRouter],

--- a/src/lib/game-engine/GameEngine.flows.mdx
+++ b/src/lib/game-engine/GameEngine.flows.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="game-engine/Flows" />
+<Meta title="GameEngine/Flows" />
 
 # GameEngine — Flows
 

--- a/src/lib/game-engine/GameEngine.reference.mdx
+++ b/src/lib/game-engine/GameEngine.reference.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="game-engine/Reference" />
+<Meta title="GameEngine/Reference" />
 
 # GameEngine — Reference
 

--- a/src/lib/game-engine/debugging.mdx
+++ b/src/lib/game-engine/debugging.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="game-engine/Debugging" />
+<Meta title="GameEngine/Debugging" />
 
 # Debugging the Game Engine
 


### PR DESCRIPTION
## Summary

- Adds three co-located stories that preview each game's real `ConfigField[]` registry export through `ConfigFormFields`:
  - `src/games/sort-numbers/SortNumbers.config-form.stories.tsx` — random / by-mode / distractors presets, covering all `visibleWhen` branches.
  - `src/games/number-match/NumberMatch.config-form.stories.tsx` — numeral↔group, cardinal↔ordinal, and a distractor-enabled config.
  - `src/games/word-spell/WordSpell.config-form.stories.tsx` — picture, scramble, and sentence-gap modes.
- Each file follows the single-`Playground` pattern with a `scenario` radio control mapped to real-shaped initial configs. The harness uses `useState` keyed by `scenario` so the form is interactive and resets cleanly when the preset changes; `onChange` is a `fn()` spy that surfaces in the Actions panel.
- Documents the per-game co-location pattern in `.claude/skills/write-storybook/SKILL.md`, referencing `#143` as precedent.
- Purely additive — `src/components/ConfigFormFields.stories.tsx` is untouched (PR #205 is the audit that makes it game-agnostic; this PR can land in either order).

Closes #153.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn lint:md`
- [x] `npx prettier --check`
- [x] `yarn test:storybook` — 50 suites / 178 tests passed, including the three new files
- [x] Pre-push hook (lint + typecheck + unit) green
- [ ] Manual: open each new per-game story in Storybook and flip through scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)