### PR TITLE
stories(components/GameGrid): retrofit per single-Playground pattern

### DIFF
--- a/src/components/GameGrid.stories.tsx
+++ b/src/components/GameGrid.stories.tsx
@@ -1,52 +1,77 @@
+import { fn } from 'storybook/test';
+
 import { GameCard } from './GameCard';
 import { GameGrid } from './GameGrid';
 import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentType } from 'react';
 
-const SAMPLE_CARDS = [
-  <GameCard
-    key="wordspell"
-    variant="default"
-    gameId="word-spell"
-    title="Word Spell"
-    chips={['PK', 'K']}
-    onPlay={() => {}}
-    onOpenCog={() => {}}
-  />,
-  <GameCard
-    key="numbermatch"
-    variant="default"
-    gameId="number-match"
-    title="Match the Number"
-    chips={['1', '2']}
-    onPlay={() => {}}
-    onOpenCog={() => {}}
-  />,
-  <GameCard
-    key="sortnumbers"
-    variant="default"
-    gameId="sort-numbers"
-    title="Sort Numbers"
-    chips={['K', '1']}
-    onPlay={() => {}}
-    onOpenCog={() => {}}
-  />,
+interface SampleCardSeed {
+  gameId: string;
+  title: string;
+  chips: string[];
+}
+
+const SAMPLE_CARD_SEEDS: readonly SampleCardSeed[] = [
+  { gameId: 'word-spell', title: 'Word Spell', chips: ['PK', 'K'] },
+  {
+    gameId: 'number-match',
+    title: 'Match the Number',
+    chips: ['1', '2'],
+  },
+  { gameId: 'sort-numbers', title: 'Sort Numbers', chips: ['K', '1'] },
 ];
 
-const meta: Meta<typeof GameGrid> = {
-  component: GameGrid,
+const MAX_CARDS = 12;
+
+interface StoryArgs {
+  cardCount: number;
+  onPlay: () => void;
+  onOpenCog: () => void;
+  // Raw GameGrid prop intentionally hidden — `cards` is built from
+  // `cardCount` in render and is never meaningful as a control.
+  cards?: never;
+}
+
+const meta: Meta<StoryArgs> = {
+  component: GameGrid as unknown as ComponentType<StoryArgs>,
   tags: ['autodocs'],
   args: {
-    cards: SAMPLE_CARDS,
+    cardCount: 3,
+    onPlay: fn(),
+    onOpenCog: fn(),
+  },
+  argTypes: {
+    cardCount: {
+      control: { type: 'range', min: 0, max: MAX_CARDS, step: 1 },
+      description:
+        'Number of sample GameCards rendered into the grid. Cycles through the 3 sample seeds (word-spell, number-match, sort-numbers).',
+    },
+    onPlay: { table: { disable: true } },
+    onOpenCog: { table: { disable: true } },
+    cards: { table: { disable: true } },
+  },
+  render: ({ cardCount, onPlay, onOpenCog }) => {
+    const cards = Array.from({ length: cardCount }, (_, index) => {
+      // Modulo by a positive constant always yields a valid index;
+      // noUncheckedIndexedAccess can't see that, so assert it.
+      const seed = SAMPLE_CARD_SEEDS[index % SAMPLE_CARD_SEEDS.length]!;
+      return (
+        <GameCard
+          key={`${seed.gameId}-${index}`}
+          variant="default"
+          gameId={seed.gameId}
+          title={seed.title}
+          chips={seed.chips}
+          onPlay={onPlay}
+          onOpenCog={onOpenCog}
+        />
+      );
+    });
+    return <GameGrid cards={cards} />;
   },
 };
 export default meta;
 
-type Story = StoryObj<typeof GameGrid>;
+type Story = StoryObj<StoryArgs>;
 
-export const Default: Story = {};
-
-export const Empty: Story = {
-  args: {
-    cards: [],
-  },
-};
+export const Playground: Story = {};


### PR DESCRIPTION
## Summary

Tier 3, file 1 of 5 — retrofits `src/components/GameGrid.stories.tsx` to the single-Playground pattern + Controls Policy from #125.

- Single `Playground` story (renamed from `Default` per PR #208's canonical naming).
- `cardCount` range control (0–12) drives how many `GameCard`s render — covers every prior state (`Default` → 3, `Empty` → 0, plus everything in between).
- `cards` prop is shadowed (`?: never` + `table: { disable: true }`) — this story is about the responsive grid layout, not card content; meaningful card variation lives in `GameCard.stories.tsx`.
- Sample cards built from a 3-seed pool (word-spell / number-match / sort-numbers), cycled by index for unique keys.
- `onPlay` / `onOpenCog` wired to `fn()` spies (Actions panel logs each invocation).
- No per-file skin wrapper — the global `withDefaultSkin` decorator (PR #154) handles classic-skin tokens.

Closes #203 (part of #125).

## Test plan

- [x] `yarn typecheck` green
- [x] `yarn lint` green (eslint + knip)
- [x] `yarn test --run src/components/GameGrid` green
- [x] Pre-push pipeline (lint-staged → eslint → prettier → typecheck → vitest related → markdownlint → actionlint → shellcheck → knip) green
- [ ] `yarn test:storybook` green (runs in CI)
- [ ] Controls panel drives the single `Playground` export (cardCount slider reaches 0, 3, and 12 cards visibly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)