### PR TITLE
fix(hooks): pre-commit honors detect-buckets gate for staged files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,37 @@
-npx lint-staged
-yarn test
+#!/usr/bin/env bash
+# .husky/pre-commit — staged-file-gated quality gate.
+#
+# Runs only the checks whose triggers match staged files
+# (see scripts/detect-buckets.mjs). Issue #224: a markdown-only commit
+# must not run unit tests or TypeScript on src/.
+#
+# Skip env vars (mirror pre-push):
+#   SKIP_PREPUSH=1     bypass every pre-commit check
+#   SKIP_LINT=1        skip lint-staged
+#   SKIP_TYPECHECK=1   skip typecheck
+
+if [ "${SKIP_PREPUSH:-0}" = "1" ]; then
+  echo "  ⚠ All pre-commit checks (skipped — SKIP_PREPUSH=1)"
+  exit 0
+fi
+
+set -euo pipefail
+
+# 1. Per-file formatters/linters. lint-staged is itself file-aware via
+#    .lintstagedrc.mjs, so a markdown-only stage runs only markdownlint +
+#    prettier on the staged .md files.
+if [ "${SKIP_LINT:-0}" != "1" ]; then
+  npx lint-staged
+fi
+
+# 2. Compute which atomic checks the staged files trigger.
+CHECKS=$(node scripts/detect-buckets.mjs --staged)
+
+# 3. TypeScript — only if a staged file affects type-checking.
+case " $CHECKS " in
+  *" typecheck "*)
+    if [ "${SKIP_TYPECHECK:-0}" != "1" ]; then
+      yarn typecheck
+    fi
+    ;;
+esac

--- a/scripts/pre-commit.test.sh
+++ b/scripts/pre-commit.test.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# pre-commit.test.sh — Integration tests for .husky/pre-commit.
+#
+# Verifies the hook honors detect-buckets.mjs --staged so that a commit
+# touching only docs/markdown does not trigger unit tests or typecheck.
+#
+# Run from repo root:    bash scripts/pre-commit.test.sh
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK_SRC="$REPO_ROOT/.husky/pre-commit"
+DETECTOR_SRC="$REPO_ROOT/scripts/detect-buckets.mjs"
+
+if [[ ! -f "$HOOK_SRC" ]]; then
+  echo "missing hook: $HOOK_SRC" >&2
+  exit 2
+fi
+if [[ ! -f "$DETECTOR_SRC" ]]; then
+  echo "missing detector: $DETECTOR_SRC" >&2
+  exit 2
+fi
+
+if command -v tput &>/dev/null && tput colors &>/dev/null && [[ "$(tput colors)" -ge 8 ]]; then
+  GREEN="$(tput setaf 2)"
+  RED="$(tput setaf 1)"
+  RESET="$(tput sgr0)"
+else
+  GREEN=""
+  RED=""
+  RESET=""
+fi
+
+TMPDIR_TESTS="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TESTS"' EXIT
+
+# Shim yarn + npx so the hook's downstream commands are observed, not executed.
+BIN="$TMPDIR_TESTS/bin"
+mkdir -p "$BIN"
+LOG="$TMPDIR_TESTS/calls.log"
+cat >"$BIN/yarn" <<EOF
+#!/usr/bin/env bash
+printf 'yarn %s\n' "\$*" >>"$LOG"
+exit 0
+EOF
+cat >"$BIN/npx" <<EOF
+#!/usr/bin/env bash
+printf 'npx %s\n' "\$*" >>"$LOG"
+exit 0
+EOF
+chmod +x "$BIN/yarn" "$BIN/npx"
+
+# Build a minimal fixture repo: hook + detector + symlinked node_modules
+# (picomatch is required by detect-buckets.mjs).
+FIXTURE="$TMPDIR_TESTS/repo"
+mkdir -p "$FIXTURE/.husky" "$FIXTURE/scripts"
+cp "$HOOK_SRC" "$FIXTURE/.husky/pre-commit"
+cp "$DETECTOR_SRC" "$FIXTURE/scripts/detect-buckets.mjs"
+ln -s "$REPO_ROOT/node_modules" "$FIXTURE/node_modules"
+cp "$REPO_ROOT/package.json" "$FIXTURE/package.json"
+
+(
+  cd "$FIXTURE"
+  git init -q
+  git config user.email test@example.com
+  git config user.name test
+  git add .
+  git commit -qm init
+)
+
+run_hook() {
+  : >"$LOG"
+  (
+    cd "$FIXTURE"
+    PATH="$BIN:$PATH" bash .husky/pre-commit >/dev/null 2>&1
+  )
+}
+
+reset_repo() {
+  git -C "$FIXTURE" reset -q --hard HEAD
+  git -C "$FIXTURE" clean -qfd
+}
+
+pass=0
+fail=0
+
+assert_no_match() {
+  local pattern="$1" description="$2"
+  if grep -qE "$pattern" "$LOG"; then
+    echo "${RED}FAIL${RESET} — $description"
+    echo "  log:"
+    sed 's/^/    /' "$LOG"
+    fail=$((fail + 1))
+    return 1
+  fi
+  return 0
+}
+
+assert_match() {
+  local pattern="$1" description="$2"
+  if ! grep -qE "$pattern" "$LOG"; then
+    echo "${RED}FAIL${RESET} — $description"
+    echo "  log:"
+    sed 's/^/    /' "$LOG"
+    fail=$((fail + 1))
+    return 1
+  fi
+  return 0
+}
+
+# --- Test 1: markdown-only stage skips unit tests AND typecheck ---
+echo "# notes" >"$FIXTURE/NOTES.md"
+git -C "$FIXTURE" add NOTES.md
+run_hook
+ok=1
+assert_no_match '^yarn test( |$)' \
+  "markdown-only stage must NOT invoke yarn test (issue #224)" || ok=0
+assert_no_match '^yarn typecheck( |$)' \
+  "markdown-only stage must NOT invoke yarn typecheck" || ok=0
+assert_match '^npx lint-staged' \
+  "markdown-only stage still runs lint-staged" || ok=0
+if [[ "$ok" == "1" ]]; then
+  echo "${GREEN}PASS${RESET} — markdown-only stage skips unit + typecheck"
+  pass=$((pass + 1))
+fi
+reset_repo
+
+# --- Test 2: TypeScript stage triggers typecheck (and never blanket yarn test) ---
+mkdir -p "$FIXTURE/src"
+echo "export const x: number = 1;" >"$FIXTURE/src/foo.ts"
+git -C "$FIXTURE" add src/foo.ts
+run_hook
+ok=1
+assert_match '^yarn typecheck( |$)' \
+  "TypeScript stage triggers yarn typecheck" || ok=0
+assert_no_match '^yarn test( |$)' \
+  "TypeScript stage must not invoke blanket yarn test" || ok=0
+assert_match '^npx lint-staged' \
+  "TypeScript stage runs lint-staged" || ok=0
+if [[ "$ok" == "1" ]]; then
+  echo "${GREEN}PASS${RESET} — TypeScript stage triggers typecheck only"
+  pass=$((pass + 1))
+fi
+reset_repo
+
+# --- Test 3: SKIP_PREPUSH=1 bypasses everything ---
+mkdir -p "$FIXTURE/src"
+echo "export const y: number = 2;" >"$FIXTURE/src/bar.ts"
+git -C "$FIXTURE" add src/bar.ts
+: >"$LOG"
+(
+  cd "$FIXTURE"
+  PATH="$BIN:$PATH" SKIP_PREPUSH=1 bash .husky/pre-commit >/dev/null 2>&1
+)
+ok=1
+assert_no_match '^yarn ' \
+  "SKIP_PREPUSH=1 bypasses yarn invocations" || ok=0
+assert_no_match '^npx ' \
+  "SKIP_PREPUSH=1 bypasses npx invocations" || ok=0
+if [[ "$ok" == "1" ]]; then
+  echo "${GREEN}PASS${RESET} — SKIP_PREPUSH=1 bypasses every check"
+  pass=$((pass + 1))
+fi
+reset_repo
+
+echo ""
+echo "Total: $((pass + fail)) — ${GREEN}$pass passed${RESET}, ${RED}$fail failed${RESET}"
+if [[ $fail -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Replaces the blanket `yarn test` in `.husky/pre-commit` with a phase-gated `yarn typecheck` driven by `scripts/detect-buckets.mjs --staged`, completing the smart-pipelines design that landed in commit `d99daba1` only as a file-mode change.
- A markdown-only commit now skips the unit suite **and** TypeScript; lint-staged still runs (already file-aware via `.lintstagedrc.mjs`).
- Adds `scripts/pre-commit.test.sh`, a self-contained shell integration test that fixtures a temp git repo, shims `yarn`/`npx` via `PATH`, and asserts the hook honors the bucket gate (and `SKIP_PREPUSH=1`).

## Why

Issue #224: editing only `.md` files triggered the full Vitest suite — the pre-commit hook never consulted `detect-buckets`. CLAUDE.md and `docs/superpowers/specs/2026-04-14-smart-pipelines-design.md` §4 already document the intended behavior; only the hook was out of date.

## Test plan

- [x] `bash scripts/pre-commit.test.sh` — 3/3 pass (markdown stage skips unit+typecheck; TS stage runs typecheck only; `SKIP_PREPUSH=1` bypasses everything)
- [x] `yarn vitest run scripts/detect-buckets.test.mjs` — 30/30 pass (bucket logic unchanged)
- [x] `npx shellcheck .husky/pre-commit scripts/pre-commit.test.sh` — clean
- [x] Manual: committing this PR's own changes triggered only `shellcheck` (no unit, no typecheck)

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)