### PR TITLE
feat(debug): add ?debug=1 panel to inspect game settings & rounds

### DIFF
--- a/docs/superpowers/specs/2026-04-29-debug-panel-design.md
+++ b/docs/superpowers/specs/2026-04-29-debug-panel-design.md
@@ -1,0 +1,209 @@
+# Debug Panel — Per-Game Settings & Round Inspector
+
+> Status: **Approved (design)** — autonomous implementation via AO
+> Date: 2026-04-29
+> Issue: [#233](https://github.com/leocaseiro/base-skill/issues/233)
+
+## Background
+
+Custom games and saved configs flow through several layers before they reach
+the active game:
+
+1. The route loader at `src/routes/$locale/_app/game/$gameId.tsx` fetches the
+   raw saved config from RxDB (`custom_games` keyed by `configId`, or the
+   per-game `saved_game_configs` "last session" doc as a fallback).
+2. Each game body (`WordSpellGameBody`, `NumberMatchGameBody`,
+   `SortNumbersGameBody`) runs the raw config through a `resolve*Config`
+   function that fills in defaults and migrates legacy shapes.
+3. The resolved config drives the live game; rounds (questions/answers) are
+   either taken directly from the config or sampled from the word library.
+4. An in-progress session (`session_history_index`) carries `initialLog`,
+   `draftState`, and `persistedContent` for resume flows.
+
+When something goes wrong — a tile mode mismatch, a stale local-storage
+config, a resume that picks up the wrong state, a level filter that yields
+zero words — there is currently no in-app way to see what the game actually
+received. We have to attach a debugger or read RxDB by hand.
+
+## Goals
+
+1. Add an opt-in **Debug Panel** that exposes everything a developer or QA
+   user needs to verify the game is running with the expected settings.
+2. Trigger via a query parameter so it never ships to a regular play
+   session and never affects layout for users who do not opt in.
+3. Work uniformly across all three games (`word-spell`, `number-match`,
+   `sort-numbers`) and across both Simple and Advanced config modes.
+4. Survive page refresh — i.e. it reads live state, so reloading the tab
+   shows whatever the route loader + resolver hydrated this time.
+
+## Non-Goals
+
+- No mutation of state from the panel. This release is read-only. (Editing
+  config from the panel is a possible follow-up but multiplies test surface.)
+- No persistence of "is the panel open" — open/close state is per-render.
+- No production telemetry, no metrics, no error reporting.
+
+## Trigger
+
+Add `debug` to the `validateSearch` of the existing game route:
+
+```ts
+debug: search.debug === '1' || search.debug === 'true' ? true : false,
+```
+
+Both `?debug=1` and `?debug=true` activate the panel. Anything else (absent,
+`?debug=0`, `?debug=false`) leaves it off. The flag is parsed once and
+passed into `GameBody` alongside the other loader data.
+
+The query param survives navigation within the route (TanStack Router keeps
+unmodified search params) and survives full reload (it's in the URL).
+
+## UI
+
+A floating, fixed-position panel anchored to the bottom-right of the
+viewport, above the game canvas:
+
+- **Collapsed:** a single chip "🛠️ Debug" that the user clicks to expand.
+- **Expanded:** a card (max-height 80vh, scrollable, max-width 480px on
+  desktop / full-width minus 16px on mobile) with sectioned content.
+
+Sections (each independently collapsible, all collapsed by default except
+**Resolved Config**):
+
+1. **Resolved Config** — the `cfg` state from the game body, i.e. the
+   exact object passed to `<WordSpell />` / `<NumberMatch />` /
+   `<SortNumbers />`. Rendered as a syntax-highlighted JSON tree.
+2. **Raw Saved Config** — the `gameSpecificConfig` returned from the route
+   loader (the unmigrated, unresolved RxDB doc). Helps spot
+   migration-vs-resolve bugs.
+3. **Custom Game** — `customGameId`, `customGameName`, `customGameColor`,
+   `customGameCover`. Empty section if not a custom game.
+4. **Session** — `sessionId`, `seed`, whether `draftState` is present,
+   whether `persistedContent` is present, and the in-progress phase if
+   resumed.
+5. **Rounds (Questions & Answers)** — table of every round in
+   `cfg.rounds` (or the resolved/sampled rounds for library-sourced
+   WordSpell). Columns vary per game:
+   - WordSpell: index, word, emoji, mode hint
+   - NumberMatch: index, value, range, tile style
+   - SortNumbers: index, sequence, direction, skip
+6. **Storage Snapshot** — keys & sizes for `localStorage` and the IndexedDB
+   collections that affect this game (`custom_games`, `saved_game_configs`,
+   `session_history_index`, `session_logs`). Shows count + sample IDs, not
+   full payloads (those live in the other sections).
+
+The panel is rendered through a portal so it sits above any game overlay
+(InstructionsOverlay, GameOverOverlay) but **below** the global app
+header (z-index between overlay layer and modal layer).
+
+## Implementation
+
+### Files
+
+```text
+src/components/DebugPanel/
+  DebugPanel.tsx          — the panel UI, takes a fully-typed snapshot prop
+  DebugPanel.test.tsx     — vitest unit tests
+  format-rounds.ts        — per-game round → row mapper
+  format-rounds.test.ts
+  index.ts                — barrel
+```
+
+### Wiring
+
+`src/routes/$locale/_app/game/$gameId.tsx`:
+
+- Extend `validateSearch` with `debug`.
+- Read it via `Route.useSearch()` inside `RouteComponent`, pass it into
+  `GameRoute`.
+- `GameRoute` passes it down to `GameBody`, which passes it to each
+  `*GameBody`.
+- Each `*GameBody` renders `<DebugPanel … />` after the game body when
+  `debug` is true.
+
+The DebugPanel signature:
+
+```ts
+interface DebugPanelProps {
+  gameId: string;
+  resolvedConfig: Record<string, unknown>;
+  rawSavedConfig: Record<string, unknown> | null;
+  customGame: {
+    id: string | null;
+    name: string | null;
+    color: string | null;
+    cover: Cover | null;
+  };
+  session: {
+    sessionId: string;
+    seed: string;
+    hasDraftState: boolean;
+    hasPersistedContent: boolean;
+  };
+  rounds: Array<Record<string, unknown>>;
+}
+```
+
+The host (route) is responsible for assembling this snapshot — the panel
+itself does not subscribe to RxDB or read from the loader. This keeps it
+testable and avoids the panel diverging from what the game sees.
+
+### Storage snapshot
+
+`localStorage` is read synchronously on render. IndexedDB collection
+counts come from a small async `useStorageSnapshot` hook that opens the
+existing database via `getOrCreateDatabase()` and reads the count of each
+collection. The hook lives next to DebugPanel and is **only invoked when
+`debug` is true** so production renders pay zero cost.
+
+### Styling
+
+Tailwind utility classes consistent with the rest of the codebase. Reuse
+the existing `Card` / `Button` UI primitives (`src/components/ui/`).
+`<details>`/`<summary>` for the collapsible sections — semantic, no
+extra state, keyboard-accessible by default.
+
+## Compatibility
+
+- **Simple mode** configs are first run through `resolve*Config` and only
+  then snapshotted, so the Resolved Config section always shows the
+  fully-hydrated shape. Raw Saved Config shows the simple-form payload
+  unchanged.
+- **Advanced mode** is the same code path; nothing special.
+- **WordSpell library-sourced configs** show the resolved rounds the
+  library returned this render. If the library returns zero (the bug
+  class motivating this issue), the Rounds section shows an empty table
+  with a "(library returned 0 words)" note rather than the raw fallback
+  emoji rounds.
+- **Resume / refresh** — because the panel reads live `cfg` state, a
+  reload that hydrates a different shape (e.g. an old saved config that
+  doesn't migrate cleanly) is immediately visible.
+
+## Testing
+
+`DebugPanel.test.tsx`:
+
+- Renders nothing when `debug={false}` is implied by parent (the route
+  conditional gates the render — covered as an integration smoke).
+- Collapsed → expanded toggle.
+- Sections render with provided data.
+- Custom Game section is empty when `customGame.id` is null.
+- Rounds table renders WordSpell / NumberMatch / SortNumbers shapes via
+  `format-rounds`.
+
+`format-rounds.test.ts`:
+
+- WordSpell rounds with and without emoji.
+- NumberMatch rounds.
+- SortNumbers rounds.
+- Empty rounds → empty array.
+
+Route-level integration is covered by adding a single test to
+`$gameId.test.tsx` that asserts the panel renders when `?debug=1` is in
+the URL.
+
+## Out of scope (follow-ups)
+
+- Editing config from the panel (mutating `cfg` and persisting back).
+- Exporting the snapshot as JSON.
+- Recording a play session for replay.

--- a/src/components/DebugPanel/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/DebugPanel.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DebugPanel } from './DebugPanel';
+import type { DebugPanelProps } from './DebugPanel';
+
+vi.mock('./useStorageSnapshot', () => ({
+  useStorageSnapshot: () => ({
+    localStorage: [{ key: 'app:setting', size: 12, preview: 'abc' }],
+    collections: [{ name: 'custom_games', count: 2 }],
+    loading: false,
+    error: null,
+  }),
+}));
+
+const baseProps: DebugPanelProps = {
+  gameId: 'word-spell',
+  resolvedConfig: { totalRounds: 3, mode: 'recall' },
+  rawSavedConfig: { configMode: 'simple', level: 1 },
+  customGame: {
+    id: 'custom-1',
+    name: 'My Game',
+    color: 'blue',
+    cover: { kind: 'emoji', emoji: '🎲' },
+  },
+  session: {
+    sessionId: 'sess-1',
+    seed: 'seed-1',
+    hasDraftState: true,
+    hasPersistedContent: false,
+  },
+  rounds: [
+    { word: 'cat', emoji: '🐱' },
+    { word: 'dog', emoji: '🐶' },
+  ],
+};
+
+describe('DebugPanel', () => {
+  it('renders the collapsed launcher button', () => {
+    render(<DebugPanel {...baseProps} />);
+    expect(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('expands to show resolved config and rounds when launcher is clicked', () => {
+    render(<DebugPanel {...baseProps} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    );
+
+    expect(screen.getByText(/Resolved Config/i)).toBeInTheDocument();
+    expect(screen.getByText(/totalRounds/i)).toBeInTheDocument();
+    expect(screen.getByText(/Rounds \(2\)/i)).toBeInTheDocument();
+    expect(screen.getByText('cat')).toBeInTheDocument();
+    expect(screen.getByText('dog')).toBeInTheDocument();
+  });
+
+  it('shows custom game data when id is set', () => {
+    render(<DebugPanel {...baseProps} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    );
+    expect(screen.getByText(/custom-1/)).toBeInTheDocument();
+  });
+
+  it('shows empty placeholder when not a custom game', () => {
+    render(
+      <DebugPanel
+        {...baseProps}
+        customGame={{ id: null, name: null, color: null, cover: null }}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    );
+    expect(screen.getByText(/not a custom game/i)).toBeInTheDocument();
+  });
+
+  it('shows empty rounds placeholder when rounds array is empty', () => {
+    render(<DebugPanel {...baseProps} rounds={[]} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    );
+    expect(
+      screen.getByText(/library or generator returned 0/i),
+    ).toBeInTheDocument();
+  });
+
+  it('collapses back when the close button is clicked', () => {
+    render(<DebugPanel {...baseProps} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /close debug panel/i }),
+    );
+    expect(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/DebugPanel/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/DebugPanel.test.tsx
@@ -194,8 +194,9 @@ describe('DebugPanel', () => {
       screen.getByRole('button', { name: /open debug panel/i }),
     );
 
+    expect(screen.getByText(/^Library Source$/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/Library Source \(0 matches\)/i),
+      screen.getByText(/Library Words \(0 matches\)/i),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/filter returned 0 words/i),

--- a/src/components/DebugPanel/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/DebugPanel.test.tsx
@@ -125,6 +125,32 @@ describe('DebugPanel', () => {
     expect(screen.getByText('sat')).toBeInTheDocument();
   });
 
+  it('renders Round Pool Preview for sort-numbers using its generator rules', () => {
+    render(
+      <DebugPanel
+        {...baseProps}
+        gameId="sort-numbers"
+        resolvedConfig={{
+          range: { min: 1, max: 20 },
+          quantity: 4,
+          skip: { mode: 'by', step: 2, start: 'range-min' },
+          direction: 'ascending',
+          totalRounds: 1,
+        }}
+        rounds={[]}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    );
+
+    expect(
+      screen.getByText(/Round Pool Preview \(12 samples\)/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Sample sequences/i)).toBeInTheDocument();
+    expect(screen.getAllByText('1, 3, 5, 7').length).toBeGreaterThan(0);
+  });
+
   it('renders the Library Source section when resolvedConfig has source.filter', () => {
     render(
       <DebugPanel

--- a/src/components/DebugPanel/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/DebugPanel.test.tsx
@@ -86,6 +86,47 @@ describe('DebugPanel', () => {
     ).toBeInTheDocument();
   });
 
+  it('copies JSON to clipboard when the section copy button is clicked', () => {
+    const writeText = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve());
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<DebugPanel {...baseProps} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /copy resolvedConfig to clipboard/i,
+      }),
+    );
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0]?.[0]).toContain('totalRounds');
+  });
+
+  it('logs to console when the section log button is clicked', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    render(<DebugPanel {...baseProps} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /log session to console/i }),
+    );
+
+    expect(log).toHaveBeenCalledWith(
+      '[debug:session]',
+      baseProps.session,
+    );
+
+    log.mockRestore();
+  });
+
   it('collapses back when the close button is clicked', () => {
     render(<DebugPanel {...baseProps} />);
     fireEvent.click(

--- a/src/components/DebugPanel/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/DebugPanel.test.tsx
@@ -6,7 +6,16 @@ import type { DebugPanelProps } from './DebugPanel';
 vi.mock('./useStorageSnapshot', () => ({
   useStorageSnapshot: () => ({
     localStorage: [{ key: 'app:setting', size: 12, preview: 'abc' }],
-    collections: [{ name: 'custom_games', count: 2 }],
+    collections: [
+      {
+        name: 'custom_games',
+        count: 2,
+        docs: [
+          { id: 'cg-1', name: 'Game 1' },
+          { id: 'cg-2', name: 'Game 2' },
+        ],
+      },
+    ],
     loading: false,
     error: null,
   }),
@@ -193,6 +202,20 @@ describe('DebugPanel', () => {
     );
 
     log.mockRestore();
+  });
+
+  it('dumps IndexedDB collection documents in the Storage section', () => {
+    render(<DebugPanel {...baseProps} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    );
+    expect(screen.getByText(/cg-1/)).toBeInTheDocument();
+    expect(screen.getByText(/Game 1/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /copy idb:custom_games to clipboard/i,
+      }),
+    ).toBeInTheDocument();
   });
 
   it('collapses back when the close button is clicked', () => {

--- a/src/components/DebugPanel/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/DebugPanel.test.tsx
@@ -82,7 +82,7 @@ describe('DebugPanel', () => {
       screen.getByRole('button', { name: /open debug panel/i }),
     );
     expect(
-      screen.getByText(/library or generator returned 0/i),
+      screen.getByText(/library or generator samples at runtime/i),
     ).toBeInTheDocument();
   });
 

--- a/src/components/DebugPanel/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/DebugPanel.test.tsx
@@ -88,6 +88,34 @@ describe('DebugPanel', () => {
     expect(screen.getByText(/not a custom game/i)).toBeInTheDocument();
   });
 
+  it('renders Live Rounds from persistedContent.wordSpellRounds for word-spell', () => {
+    render(
+      <DebugPanel
+        {...baseProps}
+        rounds={[]}
+        session={{
+          ...baseProps.session,
+          persistedContent: {
+            wordSpellRounds: [
+              { word: 'mat', emoji: '🪐' },
+              { word: 'sat', emoji: '🪑' },
+            ],
+            roundOrder: [0, 1],
+          },
+        }}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    );
+
+    expect(
+      screen.getByText(/Live Rounds in session \(2\)/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText('mat')).toBeInTheDocument();
+    expect(screen.getByText('sat')).toBeInTheDocument();
+  });
+
   it('renders the Library Source section when resolvedConfig has source.filter', () => {
     render(
       <DebugPanel

--- a/src/components/DebugPanel/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/DebugPanel.test.tsx
@@ -12,6 +12,16 @@ vi.mock('./useStorageSnapshot', () => ({
   }),
 }));
 
+vi.mock('./useLibraryPreview', () => ({
+  useLibraryPreview: () => ({
+    loading: false,
+    error: null,
+    hitCount: 0,
+    hits: [],
+    usedFallback: null,
+  }),
+}));
+
 const baseProps: DebugPanelProps = {
   gameId: 'word-spell',
   resolvedConfig: { totalRounds: 3, mode: 'recall' },
@@ -25,8 +35,8 @@ const baseProps: DebugPanelProps = {
   session: {
     sessionId: 'sess-1',
     seed: 'seed-1',
-    hasDraftState: true,
-    hasPersistedContent: false,
+    draftState: { phase: 'play', score: 0 },
+    persistedContent: null,
   },
   rounds: [
     { word: 'cat', emoji: '🐱' },
@@ -50,7 +60,9 @@ describe('DebugPanel', () => {
 
     expect(screen.getByText(/Resolved Config/i)).toBeInTheDocument();
     expect(screen.getByText(/totalRounds/i)).toBeInTheDocument();
-    expect(screen.getByText(/Rounds \(2\)/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Rounds in config \(2\)/i),
+    ).toBeInTheDocument();
     expect(screen.getByText('cat')).toBeInTheDocument();
     expect(screen.getByText('dog')).toBeInTheDocument();
   });
@@ -74,6 +86,34 @@ describe('DebugPanel', () => {
       screen.getByRole('button', { name: /open debug panel/i }),
     );
     expect(screen.getByText(/not a custom game/i)).toBeInTheDocument();
+  });
+
+  it('renders the Library Source section when resolvedConfig has source.filter', () => {
+    render(
+      <DebugPanel
+        {...baseProps}
+        resolvedConfig={{
+          totalRounds: 8,
+          roundsInOrder: false,
+          selectedUnits: [{ level: 1, grapheme: 'a', phoneme: 'æ' }],
+          source: {
+            filter: { region: 'aus', level: 1 },
+            limit: 8,
+          },
+        }}
+        rounds={[]}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    );
+
+    expect(
+      screen.getByText(/Library Source \(0 matches\)/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/filter returned 0 words/i),
+    ).toBeInTheDocument();
   });
 
   it('shows empty rounds placeholder when rounds array is empty', () => {

--- a/src/components/DebugPanel/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/DebugPanel.test.tsx
@@ -125,6 +125,29 @@ describe('DebugPanel', () => {
     expect(screen.getByText('sat')).toBeInTheDocument();
   });
 
+  it('renders Round Pool Preview for number-match listing the integer range', () => {
+    render(
+      <DebugPanel
+        {...baseProps}
+        gameId="number-match"
+        resolvedConfig={{
+          mode: 'numeral-to-group',
+          tileStyle: 'dots',
+          range: { min: 3, max: 7 },
+        }}
+        rounds={[]}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /open debug panel/i }),
+    );
+
+    expect(
+      screen.getByText(/Round Pool Preview \(5 values\)/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText('3, 4, 5, 6, 7')).toBeInTheDocument();
+  });
+
   it('renders Round Pool Preview for sort-numbers using its generator rules', () => {
     render(
       <DebugPanel

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { formatRounds } from './format-rounds';
-import { buildSortNumbersPreview } from './sort-numbers-preview';
+import {
+  buildNumberMatchPreview,
+  buildSortNumbersPreview,
+} from './numeric-game-previews';
 import { useLibraryPreview } from './useLibraryPreview';
 import { useStorageSnapshot } from './useStorageSnapshot';
 import type { WordFilter } from '@/data/words';
@@ -219,6 +222,13 @@ export const DebugPanel = ({
         : null,
     [gameId, resolvedConfig],
   );
+  const numberMatchPreview = useMemo(
+    () =>
+      gameId === 'number-match'
+        ? buildNumberMatchPreview(resolvedConfig)
+        : null,
+    [gameId, resolvedConfig],
+  );
   const libraryPreview = useLibraryPreview(
     open && librarySource.filter !== null,
     librarySource.filter,
@@ -293,6 +303,26 @@ export const DebugPanel = ({
                 <RoundsTable gameId={gameId} rounds={liveRounds} />
               </Section>
             ) : null}
+            {numberMatchPreview ? (
+              <Section
+                title={`Round Pool Preview (${numberMatchPreview.pool.length} values)`}
+              >
+                <p className="mb-1 text-zinc-400">
+                  All values that NumberMatch can pick from this
+                  config&apos;s range.
+                </p>
+                <JsonBlock
+                  label="numberMatchPreview"
+                  value={numberMatchPreview}
+                />
+                <p className="mb-1 mt-2 font-semibold text-zinc-300">
+                  Pool
+                </p>
+                <p className="rounded bg-zinc-950 p-2 font-mono text-[11px] text-zinc-100">
+                  {numberMatchPreview.pool.join(', ')}
+                </p>
+              </Section>
+            ) : null}
             {sortPreview ? (
               <Section
                 title={`Round Pool Preview (${sortPreview.samples.length} samples)`}
@@ -358,8 +388,16 @@ export const DebugPanel = ({
                       label="libraryHits"
                       value={libraryPreview.hits}
                     />
+                    <p
+                      data-testid="debug-word-preview-bar"
+                      className="mb-2 rounded bg-zinc-950 p-2 font-mono text-[11px] text-zinc-100"
+                    >
+                      {libraryPreview.hits
+                        .map((h) => h.word)
+                        .join(', ')}
+                    </p>
                     <ul className="space-y-0.5 font-mono text-[11px]">
-                      {libraryPreview.hits.slice(0, 50).map((h) => (
+                      {libraryPreview.hits.slice(0, 100).map((h) => (
                         <li
                           key={h.word}
                           className="flex justify-between text-zinc-200"
@@ -370,9 +408,9 @@ export const DebugPanel = ({
                           </span>
                         </li>
                       ))}
-                      {libraryPreview.hitCount > 50 ? (
+                      {libraryPreview.hitCount > 100 ? (
                         <li className="italic text-zinc-500">
-                          …and {libraryPreview.hitCount - 50} more
+                          …and {libraryPreview.hitCount - 100} more
                         </li>
                       ) : null}
                     </ul>

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -244,7 +244,7 @@ export const DebugPanel = ({
   const node = (
     <div
       data-testid="debug-panel"
-      className="pointer-events-none fixed inset-x-0 bottom-0 z-[60] flex justify-end p-4 sm:inset-x-auto sm:right-4"
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-[60] flex justify-start p-4 sm:inset-x-auto sm:left-4"
     >
       {open ? (
         <div className="pointer-events-auto flex max-h-[80vh] w-full flex-col overflow-hidden rounded-lg border border-zinc-700 bg-zinc-900 text-zinc-100 shadow-xl sm:w-[480px]">

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -350,13 +350,7 @@ export const DebugPanel = ({
               </Section>
             ) : null}
             {librarySource.source ? (
-              <Section
-                title={`Library Source${
-                  libraryPreview.loading
-                    ? ' (loading…)'
-                    : ` (${libraryPreview.hitCount} matches)`
-                }`}
-              >
+              <Section title="Library Source">
                 <JsonBlock
                   label="librarySource"
                   value={{
@@ -366,9 +360,17 @@ export const DebugPanel = ({
                     roundsInOrder: librarySource.roundsInOrder,
                   }}
                 />
-                <p className="mb-1 mt-2 font-semibold text-zinc-300">
-                  Matched words from library
-                </p>
+              </Section>
+            ) : null}
+            {librarySource.source ? (
+              <Section
+                title={`Library Words${
+                  libraryPreview.loading
+                    ? ' (loading…)'
+                    : ` (${libraryPreview.hitCount} matches)`
+                }`}
+                defaultOpen
+              >
                 {libraryPreview.error ? (
                   <Empty label={`(error: ${libraryPreview.error})`} />
                 ) : libraryPreview.loading ? (
@@ -397,7 +399,7 @@ export const DebugPanel = ({
                         .join(', ')}
                     </p>
                     <ul className="space-y-0.5 font-mono text-[11px]">
-                      {libraryPreview.hits.slice(0, 100).map((h) => (
+                      {libraryPreview.hits.map((h) => (
                         <li
                           key={h.word}
                           className="flex justify-between text-zinc-200"
@@ -408,11 +410,6 @@ export const DebugPanel = ({
                           </span>
                         </li>
                       ))}
-                      {libraryPreview.hitCount > 100 ? (
-                        <li className="italic text-zinc-500">
-                          …and {libraryPreview.hitCount - 100} more
-                        </li>
-                      ) : null}
                     </ul>
                   </>
                 )}

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -25,7 +25,7 @@ export interface DebugPanelProps {
   rawSavedConfig: Record<string, unknown> | null;
   customGame: DebugPanelCustomGame;
   session: DebugPanelSession;
-  rounds: unknown[];
+  rounds: unknown;
 }
 
 const Section = ({
@@ -63,12 +63,12 @@ const RoundsTable = ({
   rounds,
 }: {
   gameId: string;
-  rounds: unknown[];
+  rounds: unknown;
 }): JSX.Element => {
   const { columns, rows } = formatRounds(gameId, rounds);
   if (rows.length === 0) {
     return (
-      <Empty label="(no rounds — library or generator returned 0)" />
+      <Empty label="(no rounds in config — library or generator samples at runtime)" />
     );
   }
   return (
@@ -170,7 +170,9 @@ export const DebugPanel = ({
             <Section title="Session">
               <JsonBlock value={session} />
             </Section>
-            <Section title={`Rounds (${rounds.length})`}>
+            <Section
+              title={`Rounds (${Array.isArray(rounds) ? rounds.length : 0})`}
+            >
               <RoundsTable gameId={gameId} rounds={rounds} />
             </Section>
             <Section title="Storage">

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { formatRounds } from './format-rounds';
+import { buildSortNumbersPreview } from './sort-numbers-preview';
 import { useLibraryPreview } from './useLibraryPreview';
 import { useStorageSnapshot } from './useStorageSnapshot';
 import type { WordFilter } from '@/data/words';
@@ -211,6 +212,13 @@ export const DebugPanel = ({
     () => extractLiveRounds(gameId, session.persistedContent),
     [gameId, session.persistedContent],
   );
+  const sortPreview = useMemo(
+    () =>
+      gameId === 'sort-numbers'
+        ? buildSortNumbersPreview(resolvedConfig)
+        : null,
+    [gameId, resolvedConfig],
+  );
   const libraryPreview = useLibraryPreview(
     open && librarySource.filter !== null,
     librarySource.filter,
@@ -283,6 +291,32 @@ export const DebugPanel = ({
               >
                 <JsonActions label="liveRounds" value={liveRounds} />
                 <RoundsTable gameId={gameId} rounds={liveRounds} />
+              </Section>
+            ) : null}
+            {sortPreview ? (
+              <Section
+                title={`Round Pool Preview (${sortPreview.samples.length} samples)`}
+              >
+                <p className="mb-1 text-zinc-400">
+                  Simulated by running the SortNumbers generator with
+                  the current rules. Re-open the panel to reroll random
+                  modes.
+                </p>
+                <JsonBlock label="sortPreview" value={sortPreview} />
+                <p className="mb-1 mt-2 font-semibold text-zinc-300">
+                  Sample sequences
+                </p>
+                <ul className="space-y-0.5 font-mono text-[11px]">
+                  {sortPreview.samples.map((s, i) => (
+                    <li
+                      key={s.id}
+                      className="flex justify-between text-zinc-200"
+                    >
+                      <span>#{i + 1}</span>
+                      <span>{s.sequence.join(', ')}</span>
+                    </li>
+                  ))}
+                </ul>
               </Section>
             ) : null}
             {librarySource.source ? (

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { formatRounds } from './format-rounds';
+import { useLibraryPreview } from './useLibraryPreview';
 import { useStorageSnapshot } from './useStorageSnapshot';
+import type { WordFilter } from '@/data/words';
 import type { Cover } from '@/games/cover-type';
 import type { JSX } from 'react';
 
@@ -15,8 +17,8 @@ export interface DebugPanelCustomGame {
 export interface DebugPanelSession {
   sessionId: string;
   seed: string;
-  hasDraftState: boolean;
-  hasPersistedContent: boolean;
+  draftState: unknown;
+  persistedContent: unknown;
 }
 
 export interface DebugPanelProps {
@@ -151,6 +153,28 @@ const RoundsTable = ({
   );
 };
 
+const extractLibrarySource = (
+  resolvedConfig: Record<string, unknown>,
+): {
+  filter: WordFilter | null;
+  source: Record<string, unknown> | null;
+  selectedUnits: unknown;
+  totalRounds: unknown;
+  roundsInOrder: unknown;
+} => {
+  const source = resolvedConfig.source as
+    | Record<string, unknown>
+    | undefined;
+  const filter = (source?.filter ?? null) as WordFilter | null;
+  return {
+    filter,
+    source: source ?? null,
+    selectedUnits: resolvedConfig.selectedUnits,
+    totalRounds: resolvedConfig.totalRounds,
+    roundsInOrder: resolvedConfig.roundsInOrder,
+  };
+};
+
 export const DebugPanel = ({
   gameId,
   resolvedConfig,
@@ -162,6 +186,15 @@ export const DebugPanel = ({
   const [open, setOpen] = useState(false);
   const [hydrated, setHydrated] = useState(false);
   const storage = useStorageSnapshot(open);
+
+  const librarySource = useMemo(
+    () => extractLibrarySource(resolvedConfig),
+    [resolvedConfig],
+  );
+  const libraryPreview = useLibraryPreview(
+    open && librarySource.filter !== null,
+    librarySource.filter,
+  );
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration gate; portal target only exists on client
@@ -223,8 +256,69 @@ export const DebugPanel = ({
             <Section title="Session">
               <JsonBlock label="session" value={session} />
             </Section>
+            {librarySource.source ? (
+              <Section
+                title={`Library Source${
+                  libraryPreview.loading
+                    ? ' (loading…)'
+                    : ` (${libraryPreview.hitCount} matches)`
+                }`}
+              >
+                <JsonBlock
+                  label="librarySource"
+                  value={{
+                    source: librarySource.source,
+                    selectedUnits: librarySource.selectedUnits,
+                    totalRounds: librarySource.totalRounds,
+                    roundsInOrder: librarySource.roundsInOrder,
+                  }}
+                />
+                <p className="mb-1 mt-2 font-semibold text-zinc-300">
+                  Matched words from library
+                </p>
+                {libraryPreview.error ? (
+                  <Empty label={`(error: ${libraryPreview.error})`} />
+                ) : libraryPreview.loading ? (
+                  <Empty label="(loading…)" />
+                ) : libraryPreview.hitCount === 0 ? (
+                  <Empty label="(filter returned 0 words)" />
+                ) : (
+                  <>
+                    {libraryPreview.usedFallback ? (
+                      <p className="mb-1 text-amber-400">
+                        ⚠ fell back from{' '}
+                        {libraryPreview.usedFallback.from} →{' '}
+                        {libraryPreview.usedFallback.to}
+                      </p>
+                    ) : null}
+                    <JsonActions
+                      label="libraryHits"
+                      value={libraryPreview.hits}
+                    />
+                    <ul className="space-y-0.5 font-mono text-[11px]">
+                      {libraryPreview.hits.slice(0, 50).map((h) => (
+                        <li
+                          key={h.word}
+                          className="flex justify-between text-zinc-200"
+                        >
+                          <span>{h.word}</span>
+                          <span className="text-zinc-500">
+                            L{h.level}
+                          </span>
+                        </li>
+                      ))}
+                      {libraryPreview.hitCount > 50 ? (
+                        <li className="italic text-zinc-500">
+                          …and {libraryPreview.hitCount - 50} more
+                        </li>
+                      ) : null}
+                    </ul>
+                  </>
+                )}
+              </Section>
+            ) : null}
             <Section
-              title={`Rounds (${Array.isArray(rounds) ? rounds.length : 0})`}
+              title={`Rounds in config (${Array.isArray(rounds) ? rounds.length : 0})`}
             >
               {Array.isArray(rounds) && rounds.length > 0 ? (
                 <JsonActions label="rounds" value={rounds} />

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -153,6 +153,22 @@ const RoundsTable = ({
   );
 };
 
+const extractLiveRounds = (
+  gameId: string,
+  persistedContent: unknown,
+): unknown[] | null => {
+  if (gameId !== 'word-spell') return null;
+  if (
+    typeof persistedContent !== 'object' ||
+    persistedContent === null
+  ) {
+    return null;
+  }
+  const live = (persistedContent as { wordSpellRounds?: unknown })
+    .wordSpellRounds;
+  return Array.isArray(live) ? live : null;
+};
+
 const extractLibrarySource = (
   resolvedConfig: Record<string, unknown>,
 ): {
@@ -190,6 +206,10 @@ export const DebugPanel = ({
   const librarySource = useMemo(
     () => extractLibrarySource(resolvedConfig),
     [resolvedConfig],
+  );
+  const liveRounds = useMemo(
+    () => extractLiveRounds(gameId, session.persistedContent),
+    [gameId, session.persistedContent],
   );
   const libraryPreview = useLibraryPreview(
     open && librarySource.filter !== null,
@@ -256,6 +276,15 @@ export const DebugPanel = ({
             <Section title="Session">
               <JsonBlock label="session" value={session} />
             </Section>
+            {liveRounds && liveRounds.length > 0 ? (
+              <Section
+                title={`Live Rounds in session (${liveRounds.length})`}
+                defaultOpen
+              >
+                <JsonActions label="liveRounds" value={liveRounds} />
+                <RoundsTable gameId={gameId} rounds={liveRounds} />
+              </Section>
+            ) : null}
             {librarySource.source ? (
               <Section
                 title={`Library Source${

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -368,17 +368,36 @@ export const DebugPanel = ({
                   ) : storage.collections.length === 0 ? (
                     <Empty label="(none)" />
                   ) : (
-                    <ul className="mb-3 space-y-0.5">
+                    <div className="mb-3 space-y-1">
                       {storage.collections.map((c) => (
-                        <li
+                        <details
                           key={c.name}
-                          className="flex justify-between font-mono text-[11px]"
+                          className="rounded bg-zinc-950"
                         >
-                          <span>{c.name}</span>
-                          <span>{c.count}</span>
-                        </li>
+                          <summary className="flex cursor-pointer select-none justify-between px-2 py-1 font-mono text-[11px] text-zinc-200 hover:bg-zinc-900">
+                            <span>{c.name}</span>
+                            <span className="text-zinc-400">
+                              {c.count}
+                            </span>
+                          </summary>
+                          <div className="px-2 pb-2">
+                            {c.count === 0 ? (
+                              <Empty label="(empty)" />
+                            ) : (
+                              <>
+                                <JsonActions
+                                  label={`idb:${c.name}`}
+                                  value={c.docs}
+                                />
+                                <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-all rounded bg-zinc-900 p-2 font-mono text-[11px] leading-snug text-zinc-100">
+                                  {JSON.stringify(c.docs, null, 2)}
+                                </pre>
+                              </>
+                            )}
+                          </div>
+                        </details>
                       ))}
-                    </ul>
+                    </div>
                   )}
                   <p className="mb-1 font-semibold text-zinc-300">
                     localStorage ({storage.localStorage.length} keys)

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -28,6 +28,43 @@ export interface DebugPanelProps {
   rounds: unknown;
 }
 
+const copyToClipboard = (text: string): void => {
+  if (typeof navigator !== 'undefined') {
+    void navigator.clipboard.writeText(text);
+  }
+};
+
+const JsonActions = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: unknown;
+}): JSX.Element => (
+  <div className="mb-1 flex gap-1">
+    <button
+      type="button"
+      onClick={() => copyToClipboard(JSON.stringify(value, null, 2))}
+      className="rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] font-medium text-zinc-200 hover:bg-zinc-700"
+      aria-label={`Copy ${label} to clipboard`}
+      title="Copy JSON to clipboard"
+    >
+      📋 Copy
+    </button>
+    <button
+      type="button"
+      onClick={() => {
+        console.log(`[debug:${label}]`, value);
+      }}
+      className="rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] font-medium text-zinc-200 hover:bg-zinc-700"
+      aria-label={`Log ${label} to console`}
+      title="Dump to browser console"
+    >
+      🖨️ Log
+    </button>
+  </div>
+);
+
 const Section = ({
   title,
   defaultOpen,
@@ -48,10 +85,19 @@ const Section = ({
   </details>
 );
 
-const JsonBlock = ({ value }: { value: unknown }): JSX.Element => (
-  <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-all rounded bg-zinc-950 p-2 font-mono text-[11px] leading-snug text-zinc-100">
-    {JSON.stringify(value, null, 2)}
-  </pre>
+const JsonBlock = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: unknown;
+}): JSX.Element => (
+  <>
+    <JsonActions label={label} value={value} />
+    <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-all rounded bg-zinc-950 p-2 font-mono text-[11px] leading-snug text-zinc-100">
+      {JSON.stringify(value, null, 2)}
+    </pre>
+  </>
 );
 
 const Empty = ({ label }: { label: string }): JSX.Element => (
@@ -144,11 +190,17 @@ export const DebugPanel = ({
           </div>
           <div className="flex-1 overflow-auto">
             <Section title="Resolved Config" defaultOpen>
-              <JsonBlock value={resolvedConfig} />
+              <JsonBlock
+                label="resolvedConfig"
+                value={resolvedConfig}
+              />
             </Section>
             <Section title="Raw Saved Config">
               {rawSavedConfig ? (
-                <JsonBlock value={rawSavedConfig} />
+                <JsonBlock
+                  label="rawSavedConfig"
+                  value={rawSavedConfig}
+                />
               ) : (
                 <Empty label="(no saved config — using defaults)" />
               )}
@@ -156,6 +208,7 @@ export const DebugPanel = ({
             <Section title="Custom Game">
               {customGame.id ? (
                 <JsonBlock
+                  label="customGame"
                   value={{
                     id: customGame.id,
                     name: customGame.name,
@@ -168,11 +221,14 @@ export const DebugPanel = ({
               )}
             </Section>
             <Section title="Session">
-              <JsonBlock value={session} />
+              <JsonBlock label="session" value={session} />
             </Section>
             <Section
               title={`Rounds (${Array.isArray(rounds) ? rounds.length : 0})`}
             >
+              {Array.isArray(rounds) && rounds.length > 0 ? (
+                <JsonActions label="rounds" value={rounds} />
+              ) : null}
               <RoundsTable gameId={gameId} rounds={rounds} />
             </Section>
             <Section title="Storage">
@@ -180,6 +236,7 @@ export const DebugPanel = ({
                 <Empty label="(loading…)" />
               ) : (
                 <>
+                  <JsonActions label="storage" value={storage} />
                   <p className="mb-1 font-semibold text-zinc-300">
                     IndexedDB collections
                   </p>

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { formatRounds } from './format-rounds';
+import { useStorageSnapshot } from './useStorageSnapshot';
+import type { Cover } from '@/games/cover-type';
+import type { JSX } from 'react';
+
+export interface DebugPanelCustomGame {
+  id: string | null;
+  name: string | null;
+  color: string | null;
+  cover: Cover | null;
+}
+
+export interface DebugPanelSession {
+  sessionId: string;
+  seed: string;
+  hasDraftState: boolean;
+  hasPersistedContent: boolean;
+}
+
+export interface DebugPanelProps {
+  gameId: string;
+  resolvedConfig: Record<string, unknown>;
+  rawSavedConfig: Record<string, unknown> | null;
+  customGame: DebugPanelCustomGame;
+  session: DebugPanelSession;
+  rounds: unknown[];
+}
+
+const Section = ({
+  title,
+  defaultOpen,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}): JSX.Element => (
+  <details
+    className="border-t border-zinc-700 first:border-t-0"
+    open={defaultOpen}
+  >
+    <summary className="cursor-pointer select-none bg-zinc-800 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-zinc-200 hover:bg-zinc-700">
+      {title}
+    </summary>
+    <div className="px-3 py-2 text-xs text-zinc-100">{children}</div>
+  </details>
+);
+
+const JsonBlock = ({ value }: { value: unknown }): JSX.Element => (
+  <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-all rounded bg-zinc-950 p-2 font-mono text-[11px] leading-snug text-zinc-100">
+    {JSON.stringify(value, null, 2)}
+  </pre>
+);
+
+const Empty = ({ label }: { label: string }): JSX.Element => (
+  <p className="italic text-zinc-400">{label}</p>
+);
+
+const RoundsTable = ({
+  gameId,
+  rounds,
+}: {
+  gameId: string;
+  rounds: unknown[];
+}): JSX.Element => {
+  const { columns, rows } = formatRounds(gameId, rounds);
+  if (rows.length === 0) {
+    return (
+      <Empty label="(no rounds — library or generator returned 0)" />
+    );
+  }
+  return (
+    <div className="overflow-auto">
+      <table className="w-full border-collapse text-left text-[11px]">
+        <thead>
+          <tr className="bg-zinc-900">
+            {columns.map((c) => (
+              <th
+                key={c}
+                className="border-b border-zinc-700 px-2 py-1 font-medium text-zinc-300"
+              >
+                {c}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.index} className="even:bg-zinc-900/50">
+              {columns.map((c) => (
+                <td
+                  key={c}
+                  className="border-b border-zinc-800 px-2 py-1 align-top text-zinc-100"
+                >
+                  {row.cells[c] ?? ''}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export const DebugPanel = ({
+  gameId,
+  resolvedConfig,
+  rawSavedConfig,
+  customGame,
+  session,
+  rounds,
+}: DebugPanelProps): JSX.Element | null => {
+  const [open, setOpen] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
+  const storage = useStorageSnapshot(open);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration gate; portal target only exists on client
+    setHydrated(true);
+  }, []);
+
+  if (!hydrated || typeof document === 'undefined') return null;
+
+  const node = (
+    <div
+      data-testid="debug-panel"
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-[60] flex justify-end p-4 sm:inset-x-auto sm:right-4"
+    >
+      {open ? (
+        <div className="pointer-events-auto flex max-h-[80vh] w-full flex-col overflow-hidden rounded-lg border border-zinc-700 bg-zinc-900 text-zinc-100 shadow-xl sm:w-[480px]">
+          <div className="flex items-center justify-between bg-zinc-950 px-3 py-2 text-xs font-semibold">
+            <span>🛠️ Debug · {gameId}</span>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="rounded px-2 py-0.5 text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
+              aria-label="Close debug panel"
+            >
+              ✕
+            </button>
+          </div>
+          <div className="flex-1 overflow-auto">
+            <Section title="Resolved Config" defaultOpen>
+              <JsonBlock value={resolvedConfig} />
+            </Section>
+            <Section title="Raw Saved Config">
+              {rawSavedConfig ? (
+                <JsonBlock value={rawSavedConfig} />
+              ) : (
+                <Empty label="(no saved config — using defaults)" />
+              )}
+            </Section>
+            <Section title="Custom Game">
+              {customGame.id ? (
+                <JsonBlock
+                  value={{
+                    id: customGame.id,
+                    name: customGame.name,
+                    color: customGame.color,
+                    cover: customGame.cover,
+                  }}
+                />
+              ) : (
+                <Empty label="(not a custom game)" />
+              )}
+            </Section>
+            <Section title="Session">
+              <JsonBlock value={session} />
+            </Section>
+            <Section title={`Rounds (${rounds.length})`}>
+              <RoundsTable gameId={gameId} rounds={rounds} />
+            </Section>
+            <Section title="Storage">
+              {storage.loading ? (
+                <Empty label="(loading…)" />
+              ) : (
+                <>
+                  <p className="mb-1 font-semibold text-zinc-300">
+                    IndexedDB collections
+                  </p>
+                  {storage.error ? (
+                    <Empty label={`(error: ${storage.error})`} />
+                  ) : storage.collections.length === 0 ? (
+                    <Empty label="(none)" />
+                  ) : (
+                    <ul className="mb-3 space-y-0.5">
+                      {storage.collections.map((c) => (
+                        <li
+                          key={c.name}
+                          className="flex justify-between font-mono text-[11px]"
+                        >
+                          <span>{c.name}</span>
+                          <span>{c.count}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                  <p className="mb-1 font-semibold text-zinc-300">
+                    localStorage ({storage.localStorage.length} keys)
+                  </p>
+                  {storage.localStorage.length === 0 ? (
+                    <Empty label="(empty)" />
+                  ) : (
+                    <ul className="space-y-1">
+                      {storage.localStorage.map((entry) => (
+                        <li
+                          key={entry.key}
+                          className="rounded bg-zinc-950 p-1.5 font-mono text-[11px]"
+                        >
+                          <div className="flex justify-between text-zinc-300">
+                            <span className="truncate pr-2">
+                              {entry.key}
+                            </span>
+                            <span>{entry.size}b</span>
+                          </div>
+                          <div className="break-all text-zinc-500">
+                            {entry.preview}
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </>
+              )}
+            </Section>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="pointer-events-auto rounded-full bg-zinc-900 px-3 py-2 text-xs font-medium text-zinc-100 shadow-lg ring-1 ring-zinc-700 hover:bg-zinc-800"
+          aria-label="Open debug panel"
+        >
+          🛠️ Debug
+        </button>
+      )}
+    </div>
+  );
+
+  return createPortal(node, document.body);
+};

--- a/src/components/DebugPanel/format-rounds.test.ts
+++ b/src/components/DebugPanel/format-rounds.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { formatRounds } from './format-rounds';
+
+describe('formatRounds', () => {
+  it('returns empty columns/rows when rounds is empty', () => {
+    expect(formatRounds('word-spell', [])).toEqual({
+      columns: [],
+      rows: [],
+    });
+  });
+
+  it('returns empty when rounds is not an array', () => {
+    expect(formatRounds('word-spell', null)).toEqual({
+      columns: [],
+      rows: [],
+    });
+  });
+
+  it('formats word-spell rounds with word + emoji columns', () => {
+    const result = formatRounds('word-spell', [
+      { word: 'cat', emoji: '🐱' },
+      { word: 'dog' },
+    ]);
+    expect(result.columns).toEqual(['#', 'word', 'emoji']);
+    expect(result.rows).toEqual([
+      { index: 0, cells: { '#': '1', word: 'cat', emoji: '🐱' } },
+      { index: 1, cells: { '#': '2', word: 'dog', emoji: '' } },
+    ]);
+  });
+
+  it('formats number-match rounds with value column', () => {
+    const result = formatRounds('number-match', [
+      { value: 5 },
+      { value: 8 },
+    ]);
+    expect(result.columns).toEqual(['#', 'value']);
+    expect(result.rows[0]?.cells.value).toBe('5');
+    expect(result.rows[1]?.cells.value).toBe('8');
+  });
+
+  it('formats sort-numbers rounds joining sequence/answer arrays', () => {
+    const result = formatRounds('sort-numbers', [
+      { sequence: [2, 4, 6, 8], answer: [2, 4, 6, 8] },
+    ]);
+    expect(result.columns).toEqual(['#', 'sequence', 'answer']);
+    expect(result.rows[0]?.cells.sequence).toBe('2, 4, 6, 8');
+    expect(result.rows[0]?.cells.answer).toBe('2, 4, 6, 8');
+  });
+
+  it('falls back to JSON dump for unknown gameId', () => {
+    const result = formatRounds('mystery-game', [{ foo: 'bar' }]);
+    expect(result.columns).toEqual(['#', 'json']);
+    expect(result.rows[0]?.cells.json).toBe('{"foo":"bar"}');
+  });
+});

--- a/src/components/DebugPanel/format-rounds.ts
+++ b/src/components/DebugPanel/format-rounds.ts
@@ -1,0 +1,89 @@
+export interface DebugRoundRow {
+  index: number;
+  cells: Record<string, string>;
+}
+
+const stringify = (value: unknown): string => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+export const formatRounds = (
+  gameId: string,
+  rounds: unknown,
+): { columns: string[]; rows: DebugRoundRow[] } => {
+  if (!Array.isArray(rounds) || rounds.length === 0) {
+    return { columns: [], rows: [] };
+  }
+
+  if (gameId === 'word-spell') {
+    const columns = ['#', 'word', 'emoji'];
+    const rows = rounds.map((round, index) => {
+      const r = round as Record<string, unknown>;
+      return {
+        index,
+        cells: {
+          '#': String(index + 1),
+          word: stringify(r.word),
+          emoji: stringify(r.emoji),
+        },
+      };
+    });
+    return { columns, rows };
+  }
+
+  if (gameId === 'number-match') {
+    const columns = ['#', 'value'];
+    const rows = rounds.map((round, index) => {
+      const r = round as Record<string, unknown>;
+      return {
+        index,
+        cells: {
+          '#': String(index + 1),
+          value: stringify(r.value),
+        },
+      };
+    });
+    return { columns, rows };
+  }
+
+  if (gameId === 'sort-numbers') {
+    const columns = ['#', 'sequence', 'answer'];
+    const rows = rounds.map((round, index) => {
+      const r = round as Record<string, unknown>;
+      const sequence = Array.isArray(r.sequence)
+        ? (r.sequence as unknown[]).map((v) => stringify(v)).join(', ')
+        : stringify(r.sequence);
+      const answer = Array.isArray(r.answer)
+        ? (r.answer as unknown[]).map((v) => stringify(v)).join(', ')
+        : stringify(r.answer);
+      return {
+        index,
+        cells: {
+          '#': String(index + 1),
+          sequence,
+          answer,
+        },
+      };
+    });
+    return { columns, rows };
+  }
+
+  const columns = ['#', 'json'];
+  const rows = rounds.map((round, index) => ({
+    index,
+    cells: {
+      '#': String(index + 1),
+      json: stringify(round),
+    },
+  }));
+  return { columns, rows };
+};

--- a/src/components/DebugPanel/index.ts
+++ b/src/components/DebugPanel/index.ts
@@ -1,0 +1,6 @@
+export { DebugPanel } from './DebugPanel';
+export type {
+  DebugPanelProps,
+  DebugPanelCustomGame,
+  DebugPanelSession,
+} from './DebugPanel';

--- a/src/components/DebugPanel/numeric-game-previews.ts
+++ b/src/components/DebugPanel/numeric-game-previews.ts
@@ -4,6 +4,37 @@ import type {
 } from '@/games/sort-numbers/types';
 import { generateSortRounds } from '@/games/sort-numbers/build-sort-round';
 
+export interface NumberMatchPreview {
+  range: { min: number; max: number };
+  mode: string;
+  tileStyle: string;
+  pool: number[];
+}
+
+const NUMBER_MATCH_POOL_CAP = 200;
+
+export const buildNumberMatchPreview = (
+  resolvedConfig: Record<string, unknown>,
+): NumberMatchPreview | null => {
+  const range = resolvedConfig.range;
+  const mode = resolvedConfig.mode;
+  const tileStyle = resolvedConfig.tileStyle;
+
+  if (
+    !isRange(range) ||
+    typeof mode !== 'string' ||
+    typeof tileStyle !== 'string'
+  ) {
+    return null;
+  }
+
+  const span = range.max - range.min + 1;
+  const length = Math.min(Math.max(0, span), NUMBER_MATCH_POOL_CAP);
+  const pool = Array.from({ length }, (_, i) => range.min + i);
+
+  return { range, mode, tileStyle, pool };
+};
+
 export interface SortNumbersPreviewSample extends SortNumbersRound {
   id: string;
 }

--- a/src/components/DebugPanel/sort-numbers-preview.ts
+++ b/src/components/DebugPanel/sort-numbers-preview.ts
@@ -1,0 +1,74 @@
+import type {
+  SkipConfig,
+  SortNumbersRound,
+} from '@/games/sort-numbers/types';
+import { generateSortRounds } from '@/games/sort-numbers/build-sort-round';
+
+export interface SortNumbersPreviewSample extends SortNumbersRound {
+  id: string;
+}
+
+export interface SortNumbersPreview {
+  range: { min: number; max: number };
+  quantity: number;
+  skip: SkipConfig;
+  direction: 'ascending' | 'descending';
+  totalRounds: number;
+  samples: SortNumbersPreviewSample[];
+}
+
+const PREVIEW_COUNT = 12;
+
+const isRange = (v: unknown): v is { min: number; max: number } => {
+  if (typeof v !== 'object' || v === null) return false;
+  const r = v as { min?: unknown; max?: unknown };
+  return typeof r.min === 'number' && typeof r.max === 'number';
+};
+
+const isSkip = (v: unknown): v is SkipConfig => {
+  if (typeof v !== 'object' || v === null) return false;
+  const mode = (v as { mode?: unknown }).mode;
+  return mode === 'random' || mode === 'consecutive' || mode === 'by';
+};
+
+export const buildSortNumbersPreview = (
+  resolvedConfig: Record<string, unknown>,
+): SortNumbersPreview | null => {
+  const range = resolvedConfig.range;
+  const quantity = resolvedConfig.quantity;
+  const skip = resolvedConfig.skip;
+  const direction = resolvedConfig.direction;
+  const totalRounds = resolvedConfig.totalRounds;
+
+  if (
+    !isRange(range) ||
+    typeof quantity !== 'number' ||
+    !isSkip(skip) ||
+    (direction !== 'ascending' && direction !== 'descending') ||
+    typeof totalRounds !== 'number'
+  ) {
+    return null;
+  }
+
+  const generated = generateSortRounds({
+    range,
+    quantity,
+    skip,
+    totalRounds: PREVIEW_COUNT,
+  });
+  const samples: SortNumbersPreviewSample[] = generated.map(
+    (round, index) => ({
+      ...round,
+      id: `sample-${index}-${round.sequence.join(',')}`,
+    }),
+  );
+
+  return {
+    range,
+    quantity,
+    skip,
+    direction,
+    totalRounds,
+    samples,
+  };
+};

--- a/src/components/DebugPanel/useLibraryPreview.ts
+++ b/src/components/DebugPanel/useLibraryPreview.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { WordFilter } from '@/data/words';
-import { filterWords } from '@/data/words';
+import { filterSignature, filterWords } from '@/data/words';
 
 export interface LibraryPreview {
   loading: boolean;
@@ -26,9 +26,14 @@ export const useLibraryPreview = (
     enabled && filter ? { ...EMPTY, loading: true } : EMPTY,
   );
 
+  const signature = filter ? filterSignature(filter) : null;
+
   useEffect(() => {
     if (!enabled || !filter) return;
     const abort = new AbortController();
+    setState((prev) =>
+      prev.loading ? prev : { ...prev, loading: true },
+    );
     void (async () => {
       try {
         const result = await filterWords(filter);
@@ -57,7 +62,8 @@ export const useLibraryPreview = (
     return () => {
       abort.abort();
     };
-  }, [enabled, filter]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- signature replaces filter object identity, matching useFilteredWords pattern
+  }, [enabled, signature]);
 
   return state;
 };

--- a/src/components/DebugPanel/useLibraryPreview.ts
+++ b/src/components/DebugPanel/useLibraryPreview.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import type { WordFilter } from '@/data/words';
+import { filterWords } from '@/data/words';
+
+export interface LibraryPreview {
+  loading: boolean;
+  error: string | null;
+  hitCount: number;
+  hits: { word: string; level?: number }[];
+  usedFallback: { from: string; to: string } | null;
+}
+
+const EMPTY: LibraryPreview = {
+  loading: false,
+  error: null,
+  hitCount: 0,
+  hits: [],
+  usedFallback: null,
+};
+
+export const useLibraryPreview = (
+  enabled: boolean,
+  filter: WordFilter | null,
+): LibraryPreview => {
+  const [state, setState] = useState<LibraryPreview>(() =>
+    enabled && filter ? { ...EMPTY, loading: true } : EMPTY,
+  );
+
+  useEffect(() => {
+    if (!enabled || !filter) return;
+    const abort = new AbortController();
+    void (async () => {
+      try {
+        const result = await filterWords(filter);
+        if (abort.signal.aborted) return;
+        setState({
+          loading: false,
+          error: null,
+          hitCount: result.hits.length,
+          hits: result.hits.map((h) => ({
+            word: h.word,
+            level: h.level,
+          })),
+          usedFallback: result.usedFallback ?? null,
+        });
+      } catch (error) {
+        if (abort.signal.aborted) return;
+        setState({
+          loading: false,
+          error: error instanceof Error ? error.message : String(error),
+          hitCount: 0,
+          hits: [],
+          usedFallback: null,
+        });
+      }
+    })();
+    return () => {
+      abort.abort();
+    };
+  }, [enabled, filter]);
+
+  return state;
+};

--- a/src/components/DebugPanel/useStorageSnapshot.ts
+++ b/src/components/DebugPanel/useStorageSnapshot.ts
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import type { CollectionName } from '@/db/types';
+import { getOrCreateDatabase } from '@/db/create-database';
+
+export interface StorageSnapshot {
+  localStorage: { key: string; size: number; preview: string }[];
+  collections: { name: string; count: number }[];
+  loading: boolean;
+  error: string | null;
+}
+
+const TRACKED_COLLECTIONS: CollectionName[] = [
+  'custom_games',
+  'saved_game_configs',
+  'session_history_index',
+  'session_history',
+  'word_spell_seen_words',
+  'settings',
+  'bookmarks',
+];
+
+const readLocalStorage = (): StorageSnapshot['localStorage'] => {
+  if (typeof localStorage === 'undefined') return [];
+  const entries: StorageSnapshot['localStorage'] = [];
+  for (let i = 0; i < localStorage.length; i += 1) {
+    const key = localStorage.key(i);
+    if (!key) continue;
+    const value = localStorage.getItem(key) ?? '';
+    entries.push({
+      key,
+      size: value.length,
+      preview: value.length > 80 ? `${value.slice(0, 77)}...` : value,
+    });
+  }
+  return entries.toSorted((a, b) => a.key.localeCompare(b.key));
+};
+
+const initialSnapshot = (enabled: boolean): StorageSnapshot => ({
+  localStorage: enabled ? readLocalStorage() : [],
+  collections: [],
+  loading: enabled && typeof indexedDB !== 'undefined',
+  error: null,
+});
+
+export const useStorageSnapshot = (
+  enabled: boolean,
+): StorageSnapshot => {
+  const [snapshot, setSnapshot] = useState<StorageSnapshot>(() =>
+    initialSnapshot(enabled),
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof indexedDB === 'undefined') return;
+    const abort = new AbortController();
+    void (async () => {
+      try {
+        const db = await getOrCreateDatabase();
+        const counts = await Promise.all(
+          TRACKED_COLLECTIONS.map(async (name) => {
+            const collection = db[name];
+            const docs = await collection.find().exec();
+            return { name, count: docs.length };
+          }),
+        );
+        if (abort.signal.aborted) return;
+        setSnapshot({
+          localStorage: readLocalStorage(),
+          collections: counts,
+          loading: false,
+          error: null,
+        });
+      } catch (error) {
+        if (abort.signal.aborted) return;
+        setSnapshot({
+          localStorage: readLocalStorage(),
+          collections: [],
+          loading: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    })();
+    return () => {
+      abort.abort();
+    };
+  }, [enabled]);
+
+  return snapshot;
+};

--- a/src/components/DebugPanel/useStorageSnapshot.ts
+++ b/src/components/DebugPanel/useStorageSnapshot.ts
@@ -4,10 +4,26 @@ import { getOrCreateDatabase } from '@/db/create-database';
 
 export interface StorageSnapshot {
   localStorage: { key: string; size: number; preview: string }[];
-  collections: { name: string; count: number }[];
+  collections: {
+    name: string;
+    count: number;
+    docs: Record<string, unknown>[];
+  }[];
   loading: boolean;
   error: string | null;
 }
+
+const docToJson = (doc: unknown): Record<string, unknown> => {
+  if (
+    typeof doc === 'object' &&
+    doc !== null &&
+    typeof (doc as { toJSON?: () => unknown }).toJSON === 'function'
+  ) {
+    const json = (doc as { toJSON: () => unknown }).toJSON();
+    return json as Record<string, unknown>;
+  }
+  return doc as Record<string, unknown>;
+};
 
 const TRACKED_COLLECTIONS: CollectionName[] = [
   'custom_games',
@@ -56,17 +72,21 @@ export const useStorageSnapshot = (
     void (async () => {
       try {
         const db = await getOrCreateDatabase();
-        const counts = await Promise.all(
+        const collections = await Promise.all(
           TRACKED_COLLECTIONS.map(async (name) => {
             const collection = db[name];
             const docs = await collection.find().exec();
-            return { name, count: docs.length };
+            return {
+              name,
+              count: docs.length,
+              docs: docs.map((d) => docToJson(d)),
+            };
           }),
         );
         if (abort.signal.aborted) return;
         setSnapshot({
           localStorage: readLocalStorage(),
-          collections: counts,
+          collections,
           loading: false,
           error: null,
         });

--- a/src/routes/$locale/_app/game/$gameId.tsx
+++ b/src/routes/$locale/_app/game/$gameId.tsx
@@ -970,7 +970,8 @@ export const GameRoute = ({
 const RouteComponent = (): JSX.Element => {
   const data = Route.useLoaderData();
   const search = Route.useSearch();
-  return <GameRoute {...data} debug={search.debug === true} />;
+  const debug = search.debug === true || import.meta.env.DEV;
+  return <GameRoute {...data} debug={debug} />;
 };
 
 export const Route = createFileRoute('/$locale/_app/game/$gameId')({

--- a/src/routes/$locale/_app/game/$gameId.tsx
+++ b/src/routes/$locale/_app/game/$gameId.tsx
@@ -485,8 +485,8 @@ const WordSpellGameBody = ({
       session={{
         sessionId,
         seed,
-        hasDraftState: draftState !== null,
-        hasPersistedContent: persistedContent !== null,
+        draftState,
+        persistedContent,
       }}
       rounds={cfg.rounds as unknown[]}
     />
@@ -627,8 +627,8 @@ const NumberMatchGameBody = ({
       session={{
         sessionId,
         seed,
-        hasDraftState: draftState !== null,
-        hasPersistedContent: false,
+        draftState,
+        persistedContent: null,
       }}
       rounds={cfg.rounds as unknown[]}
     />
@@ -768,8 +768,8 @@ const SortNumbersGameBody = ({
       session={{
         sessionId,
         seed,
-        hasDraftState: draftState !== null,
-        hasPersistedContent: false,
+        draftState,
+        persistedContent: null,
       }}
       rounds={cfg.rounds as unknown[]}
     />

--- a/src/routes/$locale/_app/game/$gameId.tsx
+++ b/src/routes/$locale/_app/game/$gameId.tsx
@@ -24,6 +24,7 @@ import type {
 } from '@/lib/game-engine/types';
 import type { JSX } from 'react';
 import { InstructionsOverlay } from '@/components/answer-game/InstructionsOverlay/InstructionsOverlay';
+import { DebugPanel } from '@/components/DebugPanel';
 import { GameShell } from '@/components/game/GameShell';
 import { cumulativeGraphemes } from '@/data/words';
 import { getOrCreateDatabase } from '@/db/create-database';
@@ -428,6 +429,7 @@ const WordSpellGameBody = ({
   customGameColor,
   customGameCover,
   persistedContent,
+  debug,
 }: {
   gameId: string;
   sessionId: string;
@@ -439,6 +441,7 @@ const WordSpellGameBody = ({
   customGameColor: string | null;
   customGameCover: Cover | null;
   persistedContent: Record<string, unknown> | null;
+  debug: boolean;
 }): JSX.Element => {
   const { t } = useTranslation('games');
   const { save, update, remove, customGames } = useCustomGames();
@@ -468,64 +471,94 @@ const WordSpellGameBody = ({
     cfg as unknown as Record<string, unknown>,
   );
 
+  const debugPanel = debug ? (
+    <DebugPanel
+      gameId={gameId}
+      resolvedConfig={cfg as unknown as Record<string, unknown>}
+      rawSavedConfig={gameSpecificConfig}
+      customGame={{
+        id: customGameId,
+        name: customGameName,
+        color: customGameColor,
+        cover: customGameCover,
+      }}
+      session={{
+        sessionId,
+        seed,
+        hasDraftState: draftState !== null,
+        hasPersistedContent: persistedContent !== null,
+      }}
+      rounds={cfg.rounds as unknown[]}
+    />
+  ) : null;
+
   if (showInstructions) {
     return (
-      <InstructionsOverlay
-        text={t('instructions.word-spell')}
-        onStart={() => setShowInstructions(false)}
-        ttsEnabled={cfg.ttsEnabled}
-        gameTitle={t('word-spell')}
-        gameId={gameId}
-        cover={customGameCover ?? undefined}
-        customGameId={customGameId ?? undefined}
-        customGameName={customGameName ?? undefined}
-        customGameColor={
-          (customGameColor ?? undefined) as GameColorKey | undefined
-        }
-        config={cfg as unknown as Record<string, unknown>}
-        onConfigChange={(c) => setCfg(resolveWordSpellConfig(c))}
-        onSaveCustomGame={async ({ name, color, config, cover }) =>
-          save({
-            gameId,
-            name,
-            color,
-            config,
-            cover,
-          })
-        }
-        onUpdateCustomGame={
-          customGameId
-            ? async (name, config, extras) => {
-                await update(customGameId, config, name, extras);
-              }
-            : undefined
-        }
-        onDeleteCustomGame={
-          customGameId
-            ? async (id) => {
-                await remove(id);
-                await navigate({
-                  search: (prev) => ({ ...prev, configId: undefined }),
-                });
-              }
-            : undefined
-        }
-        existingCustomGameNames={existingCustomGameNames}
-        isBookmarked={isBookmarked(bookmarkTarget)}
-        onToggleBookmark={() => void toggle(bookmarkTarget)}
-      />
+      <>
+        <InstructionsOverlay
+          text={t('instructions.word-spell')}
+          onStart={() => setShowInstructions(false)}
+          ttsEnabled={cfg.ttsEnabled}
+          gameTitle={t('word-spell')}
+          gameId={gameId}
+          cover={customGameCover ?? undefined}
+          customGameId={customGameId ?? undefined}
+          customGameName={customGameName ?? undefined}
+          customGameColor={
+            (customGameColor ?? undefined) as GameColorKey | undefined
+          }
+          config={cfg as unknown as Record<string, unknown>}
+          onConfigChange={(c) => setCfg(resolveWordSpellConfig(c))}
+          onSaveCustomGame={async ({ name, color, config, cover }) =>
+            save({
+              gameId,
+              name,
+              color,
+              config,
+              cover,
+            })
+          }
+          onUpdateCustomGame={
+            customGameId
+              ? async (name, config, extras) => {
+                  await update(customGameId, config, name, extras);
+                }
+              : undefined
+          }
+          onDeleteCustomGame={
+            customGameId
+              ? async (id) => {
+                  await remove(id);
+                  await navigate({
+                    search: (prev) => ({
+                      ...prev,
+                      configId: undefined,
+                    }),
+                  });
+                }
+              : undefined
+          }
+          existingCustomGameNames={existingCustomGameNames}
+          isBookmarked={isBookmarked(bookmarkTarget)}
+          onToggleBookmark={() => void toggle(bookmarkTarget)}
+        />
+        {debugPanel}
+      </>
     );
   }
 
   return (
-    <WordSpell
-      key={cfg.inputMethod}
-      config={cfg}
-      initialState={draftState ?? undefined}
-      sessionId={sessionId}
-      seed={seed}
-      persistedContent={persistedContent}
-    />
+    <>
+      <WordSpell
+        key={cfg.inputMethod}
+        config={cfg}
+        initialState={draftState ?? undefined}
+        sessionId={sessionId}
+        seed={seed}
+        persistedContent={persistedContent}
+      />
+      {debugPanel}
+    </>
   );
 };
 
@@ -539,6 +572,7 @@ const NumberMatchGameBody = ({
   customGameName,
   customGameColor,
   customGameCover,
+  debug,
 }: {
   gameId: string;
   sessionId: string;
@@ -549,6 +583,7 @@ const NumberMatchGameBody = ({
   customGameName: string | null;
   customGameColor: string | null;
   customGameCover: Cover | null;
+  debug: boolean;
 }): JSX.Element => {
   const { t } = useTranslation('games');
   const { save, update, remove, customGames } = useCustomGames();
@@ -578,63 +613,93 @@ const NumberMatchGameBody = ({
     cfg as unknown as Record<string, unknown>,
   );
 
+  const debugPanel = debug ? (
+    <DebugPanel
+      gameId={gameId}
+      resolvedConfig={cfg as unknown as Record<string, unknown>}
+      rawSavedConfig={gameSpecificConfig}
+      customGame={{
+        id: customGameId,
+        name: customGameName,
+        color: customGameColor,
+        cover: customGameCover,
+      }}
+      session={{
+        sessionId,
+        seed,
+        hasDraftState: draftState !== null,
+        hasPersistedContent: false,
+      }}
+      rounds={cfg.rounds as unknown[]}
+    />
+  ) : null;
+
   if (showInstructions) {
     return (
-      <InstructionsOverlay
-        text={t('instructions.number-match')}
-        onStart={() => setShowInstructions(false)}
-        ttsEnabled={cfg.ttsEnabled}
-        gameTitle={t('number-match')}
-        gameId={gameId}
-        cover={customGameCover ?? undefined}
-        customGameId={customGameId ?? undefined}
-        customGameName={customGameName ?? undefined}
-        customGameColor={
-          (customGameColor ?? undefined) as GameColorKey | undefined
-        }
-        config={cfg as unknown as Record<string, unknown>}
-        onConfigChange={(c) => setCfg(resolveNumberMatchConfig(c))}
-        onSaveCustomGame={async ({ name, color, config, cover }) =>
-          save({
-            gameId,
-            name,
-            color,
-            config,
-            cover,
-          })
-        }
-        onUpdateCustomGame={
-          customGameId
-            ? async (name, config, extras) => {
-                await update(customGameId, config, name, extras);
-              }
-            : undefined
-        }
-        onDeleteCustomGame={
-          customGameId
-            ? async (id) => {
-                await remove(id);
-                await navigate({
-                  search: (prev) => ({ ...prev, configId: undefined }),
-                });
-              }
-            : undefined
-        }
-        existingCustomGameNames={existingCustomGameNames}
-        isBookmarked={isBookmarked(bookmarkTarget)}
-        onToggleBookmark={() => void toggle(bookmarkTarget)}
-      />
+      <>
+        <InstructionsOverlay
+          text={t('instructions.number-match')}
+          onStart={() => setShowInstructions(false)}
+          ttsEnabled={cfg.ttsEnabled}
+          gameTitle={t('number-match')}
+          gameId={gameId}
+          cover={customGameCover ?? undefined}
+          customGameId={customGameId ?? undefined}
+          customGameName={customGameName ?? undefined}
+          customGameColor={
+            (customGameColor ?? undefined) as GameColorKey | undefined
+          }
+          config={cfg as unknown as Record<string, unknown>}
+          onConfigChange={(c) => setCfg(resolveNumberMatchConfig(c))}
+          onSaveCustomGame={async ({ name, color, config, cover }) =>
+            save({
+              gameId,
+              name,
+              color,
+              config,
+              cover,
+            })
+          }
+          onUpdateCustomGame={
+            customGameId
+              ? async (name, config, extras) => {
+                  await update(customGameId, config, name, extras);
+                }
+              : undefined
+          }
+          onDeleteCustomGame={
+            customGameId
+              ? async (id) => {
+                  await remove(id);
+                  await navigate({
+                    search: (prev) => ({
+                      ...prev,
+                      configId: undefined,
+                    }),
+                  });
+                }
+              : undefined
+          }
+          existingCustomGameNames={existingCustomGameNames}
+          isBookmarked={isBookmarked(bookmarkTarget)}
+          onToggleBookmark={() => void toggle(bookmarkTarget)}
+        />
+        {debugPanel}
+      </>
     );
   }
 
   return (
-    <NumberMatch
-      key={cfg.inputMethod}
-      config={cfg}
-      initialState={draftState ?? undefined}
-      sessionId={sessionId}
-      seed={seed}
-    />
+    <>
+      <NumberMatch
+        key={cfg.inputMethod}
+        config={cfg}
+        initialState={draftState ?? undefined}
+        sessionId={sessionId}
+        seed={seed}
+      />
+      {debugPanel}
+    </>
   );
 };
 
@@ -648,6 +713,7 @@ const SortNumbersGameBody = ({
   customGameName,
   customGameColor,
   customGameCover,
+  debug,
 }: {
   gameId: string;
   sessionId: string;
@@ -658,6 +724,7 @@ const SortNumbersGameBody = ({
   customGameName: string | null;
   customGameColor: string | null;
   customGameCover: Cover | null;
+  debug: boolean;
 }): JSX.Element => {
   const { t } = useTranslation('games');
   const { save, update, remove, customGames } = useCustomGames();
@@ -687,63 +754,93 @@ const SortNumbersGameBody = ({
     cfg as unknown as Record<string, unknown>,
   );
 
+  const debugPanel = debug ? (
+    <DebugPanel
+      gameId={gameId}
+      resolvedConfig={cfg as unknown as Record<string, unknown>}
+      rawSavedConfig={gameSpecificConfig}
+      customGame={{
+        id: customGameId,
+        name: customGameName,
+        color: customGameColor,
+        cover: customGameCover,
+      }}
+      session={{
+        sessionId,
+        seed,
+        hasDraftState: draftState !== null,
+        hasPersistedContent: false,
+      }}
+      rounds={cfg.rounds as unknown[]}
+    />
+  ) : null;
+
   if (showInstructions) {
     return (
-      <InstructionsOverlay
-        text={t('instructions.sort-numbers')}
-        onStart={() => setShowInstructions(false)}
-        ttsEnabled={cfg.ttsEnabled}
-        gameTitle={t('sort-numbers')}
-        gameId={gameId}
-        cover={customGameCover ?? undefined}
-        customGameId={customGameId ?? undefined}
-        customGameName={customGameName ?? undefined}
-        customGameColor={
-          (customGameColor ?? undefined) as GameColorKey | undefined
-        }
-        config={cfg as unknown as Record<string, unknown>}
-        onConfigChange={(c) => setCfg(resolveSortNumbersConfig(c))}
-        onSaveCustomGame={async ({ name, color, config, cover }) =>
-          save({
-            gameId,
-            name,
-            color,
-            config,
-            cover,
-          })
-        }
-        onUpdateCustomGame={
-          customGameId
-            ? async (name, config, extras) => {
-                await update(customGameId, config, name, extras);
-              }
-            : undefined
-        }
-        onDeleteCustomGame={
-          customGameId
-            ? async (id) => {
-                await remove(id);
-                await navigate({
-                  search: (prev) => ({ ...prev, configId: undefined }),
-                });
-              }
-            : undefined
-        }
-        existingCustomGameNames={existingCustomGameNames}
-        isBookmarked={isBookmarked(bookmarkTarget)}
-        onToggleBookmark={() => void toggle(bookmarkTarget)}
-      />
+      <>
+        <InstructionsOverlay
+          text={t('instructions.sort-numbers')}
+          onStart={() => setShowInstructions(false)}
+          ttsEnabled={cfg.ttsEnabled}
+          gameTitle={t('sort-numbers')}
+          gameId={gameId}
+          cover={customGameCover ?? undefined}
+          customGameId={customGameId ?? undefined}
+          customGameName={customGameName ?? undefined}
+          customGameColor={
+            (customGameColor ?? undefined) as GameColorKey | undefined
+          }
+          config={cfg as unknown as Record<string, unknown>}
+          onConfigChange={(c) => setCfg(resolveSortNumbersConfig(c))}
+          onSaveCustomGame={async ({ name, color, config, cover }) =>
+            save({
+              gameId,
+              name,
+              color,
+              config,
+              cover,
+            })
+          }
+          onUpdateCustomGame={
+            customGameId
+              ? async (name, config, extras) => {
+                  await update(customGameId, config, name, extras);
+                }
+              : undefined
+          }
+          onDeleteCustomGame={
+            customGameId
+              ? async (id) => {
+                  await remove(id);
+                  await navigate({
+                    search: (prev) => ({
+                      ...prev,
+                      configId: undefined,
+                    }),
+                  });
+                }
+              : undefined
+          }
+          existingCustomGameNames={existingCustomGameNames}
+          isBookmarked={isBookmarked(bookmarkTarget)}
+          onToggleBookmark={() => void toggle(bookmarkTarget)}
+        />
+        {debugPanel}
+      </>
     );
   }
 
   return (
-    <SortNumbers
-      key={cfg.inputMethod}
-      config={cfg}
-      initialState={draftState ?? undefined}
-      sessionId={sessionId}
-      seed={seed}
-    />
+    <>
+      <SortNumbers
+        key={cfg.inputMethod}
+        config={cfg}
+        initialState={draftState ?? undefined}
+        sessionId={sessionId}
+        seed={seed}
+      />
+      {debugPanel}
+    </>
   );
 };
 
@@ -758,6 +855,7 @@ const GameBody = ({
   customGameColor,
   customGameCover,
   persistedContent,
+  debug,
 }: {
   gameId: string;
   sessionId: string;
@@ -769,6 +867,7 @@ const GameBody = ({
   customGameColor: string | null;
   customGameCover: Cover | null;
   persistedContent: Record<string, unknown> | null;
+  debug: boolean;
 }): JSX.Element => {
   if (gameId === 'sort-numbers') {
     return (
@@ -782,6 +881,7 @@ const GameBody = ({
         customGameName={customGameName}
         customGameColor={customGameColor}
         customGameCover={customGameCover}
+        debug={debug}
       />
     );
   }
@@ -799,6 +899,7 @@ const GameBody = ({
         customGameColor={customGameColor}
         customGameCover={customGameCover}
         persistedContent={persistedContent}
+        debug={debug}
       />
     );
   }
@@ -815,6 +916,7 @@ const GameBody = ({
         customGameName={customGameName}
         customGameColor={customGameColor}
         customGameCover={customGameCover}
+        debug={debug}
       />
     );
   }
@@ -839,7 +941,8 @@ export const GameRoute = ({
   customGameColor,
   customGameCover,
   persistedContent,
-}: GameRouteLoaderData): JSX.Element => (
+  debug = false,
+}: GameRouteLoaderData & { debug?: boolean }): JSX.Element => (
   <GameShell
     config={config}
     moves={{}}
@@ -859,20 +962,33 @@ export const GameRoute = ({
       customGameColor={customGameColor}
       customGameCover={customGameCover}
       persistedContent={persistedContent}
+      debug={debug}
     />
   </GameShell>
 );
 
 const RouteComponent = (): JSX.Element => {
   const data = Route.useLoaderData();
-  return <GameRoute {...data} />;
+  const search = Route.useSearch();
+  return <GameRoute {...data} debug={search.debug === true} />;
 };
 
 export const Route = createFileRoute('/$locale/_app/game/$gameId')({
-  validateSearch: (search: Record<string, unknown>) => ({
-    configId:
-      typeof search.configId === 'string' ? search.configId : undefined,
-  }),
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { configId: string | undefined; debug?: true } => {
+    const debug =
+      search.debug === '1' ||
+      search.debug === 'true' ||
+      search.debug === true;
+    return {
+      configId:
+        typeof search.configId === 'string'
+          ? search.configId
+          : undefined,
+      ...(debug ? { debug: true as const } : {}),
+    };
+  },
   loaderDeps: ({ search }) => ({ configId: search.configId }),
   loader: async ({ params, deps }): Promise<GameRouteLoaderData> => {
     const { gameId } = params;


### PR DESCRIPTION
## Summary

Closes #233. Adds an opt-in **Debug Panel** that exposes everything a developer or QA user needs to verify a game is running with the expected settings.

Trigger: `?debug=1` (or `?debug=true`) on any game route. Anything else leaves it off.

The panel is portal-mounted, fixed bottom-right, collapsed to a small `🛠️ Debug` chip until clicked. When expanded it shows six independently collapsible sections:

1. **Resolved Config** (open by default) — the exact `cfg` passed into the game body, after defaults + migrations + simple→advanced resolution.
2. **Raw Saved Config** — the unmigrated RxDB doc.
3. **Custom Game** — `id`, `name`, `color`, `cover`. Empty placeholder when not a custom game.
4. **Session** — `sessionId`, `seed`, whether `draftState` is present, whether `persistedContent` is present.
5. **Rounds (Questions & Answers)** — per-game columns:
   - WordSpell: word, emoji
   - NumberMatch: value
   - SortNumbers: sequence, answer
6. **Storage** — IndexedDB collection counts (`custom_games`, `saved_game_configs`, `session_history_index`, `session_history`, `word_spell_seen_words`, `settings`, `bookmarks`) plus all `localStorage` keys with size + preview.

## Why

Custom games and saved configs flow through several layers (loader → resolver → game body) before they reach the live game. When something goes wrong — a stale localStorage config, a tile-mode mismatch, a resume that picks up the wrong state, a level filter that yields zero words — there was no in-app way to see what the game actually received. This panel surfaces all of it.

Spec: `docs/superpowers/specs/2026-04-29-debug-panel-design.md`.

## Compatibility

- Works for **word-spell**, **number-match**, **sort-numbers**.
- Works in **simple** and **advanced** config modes (the panel snapshots after `resolve*Config`).
- Survives **page refresh** because it reads live `cfg` state — reload to see whatever the route loader + resolver hydrated this time.
- IDB read is async and only fires when the panel is open; production renders pay zero cost.

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] `yarn test` — 1067/1067 passing (12 new tests across `format-rounds.test.ts` + `DebugPanel.test.tsx`)
- [x] Pre-push gate green
- [ ] Manual smoke: open any game with `?debug=1`, confirm panel chip appears bottom-right, expand, walk through sections, confirm rounds match what's playing
- [ ] Manual smoke: reload tab — panel re-appears with the hydrated state
- [ ] Manual smoke: navigate without `?debug=1` — panel does not render

## Notes

- Read-only by design. Editing config from the panel and exporting snapshots are listed as follow-ups in the spec.
- The pre-existing `.claude/settings.json` and `.claude/metadata-updater.sh` diffs in this worktree are AO orchestrator infrastructure unrelated to issue #233 — left out of this PR intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)