### PR TITLE
fix(word-spell): stop hyphenating multi-syllable words in WordSpellRound

### DIFF
--- a/src/data/words/adapters.test.ts
+++ b/src/data/words/adapters.test.ts
@@ -11,17 +11,36 @@ describe('toWordSpellRound', () => {
     provenance: 'shipped',
   };
 
-  it('uses syllables joined by - when present', () => {
+  it('uses the raw word even when syllables are present', () => {
     const round = toWordSpellRound({
       ...base,
       word: 'sunset',
       syllables: ['sun', 'set'],
       syllableCount: 2,
     });
-    expect(round.word).toBe('sun-set');
+    expect(round.word).toBe('sunset');
   });
 
-  it('falls back to raw word when no syllables', () => {
+  it('uses the raw word when no syllables are present', () => {
     expect(toWordSpellRound(base).word).toBe('cat');
+  });
+
+  it('does not hyphenate multi-syllable words like "magic" or "liquid"', () => {
+    expect(
+      toWordSpellRound({
+        ...base,
+        word: 'magic',
+        syllables: ['mag', 'ic'],
+        syllableCount: 2,
+      }).word,
+    ).toBe('magic');
+    expect(
+      toWordSpellRound({
+        ...base,
+        word: 'liquid',
+        syllables: ['liq', 'uid'],
+        syllableCount: 2,
+      }).word,
+    ).toBe('liquid');
   });
 });

--- a/src/data/words/adapters.ts
+++ b/src/data/words/adapters.ts
@@ -2,5 +2,5 @@ import type { WordHit } from './types';
 import type { WordSpellRound } from '@/games/word-spell/types';
 
 export const toWordSpellRound = (hit: WordHit): WordSpellRound => ({
-  word: hit.syllables ? hit.syllables.join('-') : hit.word,
+  word: hit.word,
 });


### PR DESCRIPTION
## Summary

- `toWordSpellRound` was writing `hit.syllables.join('-')` into the WordSpell round's `word` field, so every entry the recent hypher codegen populated with a `syllables` array got persisted into `wordSpellRounds` as the hyphenated form (`mag-ic`, `liq-uid`, `sun-set`, …). The game then asked players to spell the hyphenated string instead of the real word.
- Always use `hit.word`. The `syllables` field stays untouched and is still consumed by `WordLibraryExplorer` (interpunct display) and the `syllables.join('') === word` data invariant in `builders.ts` — we just don't want it leaking into WordSpell's target word.
- Regression test pins `magic` and `liquid` from the original report plus the previous `sunset` case.

## Test plan

- [x] `yarn vitest run src/data/words/adapters.test.ts` — 3/3 pass
- [x] `yarn vitest run src/data/words/ src/games/word-spell/` — 794/794 pass
- [x] Pre-push suite (lint, typecheck, related unit) — green
- [ ] Manual: load WordSpell on a level whose entries have `syllables` (e.g. core/level4) and confirm the prompt shows `magic`, not `mag-ic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)