### PR TITLE
fix: never display correct tile order for WordSpell and SortNumber

### DIFF
--- a/src/games/sort-numbers/build-sort-round.test.ts
+++ b/src/games/sort-numbers/build-sort-round.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   buildDistractorPool,
   buildSortRound,
@@ -6,6 +6,10 @@ import {
 } from './build-sort-round';
 
 describe('buildSortRound', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('creates zones in ascending order for ascending direction', () => {
     const { zones } = buildSortRound([3, 1, 2], 'ascending');
     expect(zones.map((z) => z.expectedValue)).toEqual(['1', '2', '3']);
@@ -39,6 +43,28 @@ describe('buildSortRound', () => {
     });
     // 3 sequence tiles + 2 distractor tiles
     expect(tiles).toHaveLength(5);
+  });
+
+  it('tiles are never in the correct ascending sorted order', () => {
+    const numbers = [1, 2, 3];
+    const correctOrder = ['1', '2', '3'];
+    for (let i = 0; i < 30; i++) {
+      vi.restoreAllMocks();
+      const { tiles } = buildSortRound(numbers, 'ascending');
+      const tileValues = tiles.map((t) => t.value);
+      expect(tileValues).not.toEqual(correctOrder);
+    }
+  });
+
+  it('tiles are never in the correct descending sorted order', () => {
+    const numbers = [1, 2, 3];
+    const correctOrder = ['3', '2', '1'];
+    for (let i = 0; i < 30; i++) {
+      vi.restoreAllMocks();
+      const { tiles } = buildSortRound(numbers, 'descending');
+      const tileValues = tiles.map((t) => t.value);
+      expect(tileValues).not.toEqual(correctOrder);
+    }
   });
 
   it('distractor tiles are not part of the zones expectedValue set', () => {

--- a/src/games/sort-numbers/build-sort-round.ts
+++ b/src/games/sort-numbers/build-sort-round.ts
@@ -9,6 +9,7 @@ import type {
   AnswerZone,
   TileItem,
 } from '@/components/answer-game/types';
+import { shuffleAvoidingOrder } from '@/lib/shuffle.js';
 
 export function buildDistractorPool(
   sequence: number[],
@@ -86,16 +87,16 @@ export function buildSortRound(
       ]
     : [...numbers];
 
-  // Shuffle tiles (Fisher-Yates)
-  for (let i = allNumbers.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [allNumbers[i], allNumbers[j]] = [allNumbers[j]!, allNumbers[i]!];
-  }
+  const correctOrderStrings = sorted.map(String);
+  const shuffledNumbers = shuffleAvoidingOrder(
+    allNumbers.map(String),
+    correctOrderStrings,
+  );
 
-  const tiles: TileItem[] = allNumbers.map((n) => ({
+  const tiles: TileItem[] = shuffledNumbers.map((n) => ({
     id: nanoid(),
-    label: String(n),
-    value: String(n),
+    label: n,
+    value: n,
   }));
 
   return { tiles, zones };

--- a/src/games/word-spell/WordSpell/WordSpell.tsx
+++ b/src/games/word-spell/WordSpell/WordSpell.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner';
 import { buildSentenceGapRound } from '../build-sentence-gap-round';
 import { LetterTileBank } from '../LetterTileBank/LetterTileBank';
 import { useLibraryRounds } from '../useLibraryRounds';
+import { buildTilesAndZones } from './build-tiles-and-zones';
 import {
   buildWordSpellInitialContent,
   hasWordSpellPersistedContent,
@@ -43,47 +44,6 @@ import { buildRoundOrder } from '@/games/build-round-order';
 import { getGameEventBus } from '@/lib/game-event-bus';
 import { useGameSkin } from '@/lib/skin';
 import { DbContext } from '@/providers/DbProvider';
-
-function segmentsForWord(
-  word: string,
-  tileUnit: WordSpellConfig['tileUnit'],
-): string[] {
-  const trimmed = word.trim();
-  if (tileUnit === 'word') return [trimmed];
-  if (tileUnit === 'syllable') {
-    const parts = trimmed.split(/[-\s]+/).filter(Boolean);
-    return parts.length > 0 ? parts : [trimmed];
-  }
-  return [...trimmed.toLowerCase()];
-}
-
-function buildTilesAndZones(
-  word: string,
-  tileUnit: WordSpellConfig['tileUnit'],
-): {
-  tiles: TileItem[];
-  zones: AnswerZone[];
-} {
-  const segments = segmentsForWord(word, tileUnit);
-  const values = segments.map((s) =>
-    tileUnit === 'letter' ? s.toLowerCase() : s.toUpperCase(),
-  );
-  const zones: AnswerZone[] = values.map((value, i) => ({
-    id: `z${i}`,
-    index: i,
-    expectedValue: value,
-    placedTileId: null,
-    isWrong: false,
-    isLocked: false,
-  }));
-  const shuffled = [...values].toSorted((a, b) => a.localeCompare(b));
-  const tiles: TileItem[] = shuffled.map((value) => ({
-    id: nanoid(),
-    label: value,
-    value,
-  }));
-  return { tiles, zones };
-}
 
 interface WordSpellProps {
   config: WordSpellConfig;

--- a/src/games/word-spell/WordSpell/build-tiles-and-zones.test.ts
+++ b/src/games/word-spell/WordSpell/build-tiles-and-zones.test.ts
@@ -1,0 +1,94 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { buildTilesAndZones } from './build-tiles-and-zones.js';
+
+describe('buildTilesAndZones', () => {
+  beforeEach(() => {
+    vi.spyOn(Math, 'random');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates zones with correct expectedValues for a word', () => {
+    vi.mocked(Math.random).mockReturnValue(0);
+    const { zones } = buildTilesAndZones('cent', 'letter');
+    expect(zones.map((z) => z.expectedValue)).toEqual([
+      'c',
+      'e',
+      'n',
+      't',
+    ]);
+  });
+
+  it('creates one tile per letter', () => {
+    vi.mocked(Math.random).mockReturnValue(0);
+    const { tiles } = buildTilesAndZones('cent', 'letter');
+    expect(tiles).toHaveLength(4);
+    expect(tiles.map((t) => t.value).toSorted()).toEqual([
+      'c',
+      'e',
+      'n',
+      't',
+    ]);
+  });
+
+  it('never displays tiles in the correct spelling order', () => {
+    // "cent" alphabetically sorted (old behavior) = c,e,n,t = correct order
+    // new behavior: must avoid the correct order
+    const correctOrder = ['c', 'e', 'n', 't'];
+    for (let i = 0; i < 30; i++) {
+      vi.restoreAllMocks();
+      const { tiles } = buildTilesAndZones('cent', 'letter');
+      const tileValues = tiles.map((t) => t.value);
+      expect(tileValues).not.toEqual(correctOrder);
+    }
+  });
+
+  it('each tile has a unique id', () => {
+    vi.mocked(Math.random).mockReturnValue(0);
+    const { tiles } = buildTilesAndZones('cent', 'letter');
+    const ids = new Set(tiles.map((t) => t.id));
+    expect(ids.size).toBe(4);
+  });
+
+  it('zones have correct structure', () => {
+    vi.mocked(Math.random).mockReturnValue(0);
+    const { zones } = buildTilesAndZones('cat', 'letter');
+    expect(zones[0]).toMatchObject({
+      id: 'z0',
+      index: 0,
+      expectedValue: 'c',
+      placedTileId: null,
+      isWrong: false,
+      isLocked: false,
+    });
+  });
+
+  it('handles single-letter words', () => {
+    vi.mocked(Math.random).mockReturnValue(0.99);
+    const { tiles, zones } = buildTilesAndZones('a', 'letter');
+    expect(tiles).toHaveLength(1);
+    expect(zones).toHaveLength(1);
+  });
+
+  it('handles syllable tileUnit', () => {
+    vi.mocked(Math.random).mockReturnValue(0);
+    const { tiles, zones } = buildTilesAndZones(
+      'butter-fly',
+      'syllable',
+    );
+    expect(zones.map((z) => z.expectedValue)).toEqual([
+      'BUTTER',
+      'FLY',
+    ]);
+    expect(tiles).toHaveLength(2);
+  });
+});

--- a/src/games/word-spell/WordSpell/build-tiles-and-zones.ts
+++ b/src/games/word-spell/WordSpell/build-tiles-and-zones.ts
@@ -1,0 +1,45 @@
+import { nanoid } from 'nanoid';
+import type { WordSpellConfig } from '../types.js';
+import type {
+  AnswerZone,
+  TileItem,
+} from '@/components/answer-game/types';
+import { shuffleAvoidingOrder } from '@/lib/shuffle.js';
+
+const segmentsForWord = (
+  word: string,
+  tileUnit: WordSpellConfig['tileUnit'],
+): string[] => {
+  const trimmed = word.trim();
+  if (tileUnit === 'word') return [trimmed];
+  if (tileUnit === 'syllable') {
+    const parts = trimmed.split(/[-\s]+/).filter(Boolean);
+    return parts.length > 0 ? parts : [trimmed];
+  }
+  return [...trimmed.toLowerCase()];
+};
+
+export const buildTilesAndZones = (
+  word: string,
+  tileUnit: WordSpellConfig['tileUnit'],
+): { tiles: TileItem[]; zones: AnswerZone[] } => {
+  const segments = segmentsForWord(word, tileUnit);
+  const values = segments.map((s) =>
+    tileUnit === 'letter' ? s.toLowerCase() : s.toUpperCase(),
+  );
+  const zones: AnswerZone[] = values.map((value, i) => ({
+    id: `z${i}`,
+    index: i,
+    expectedValue: value,
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  }));
+  const shuffled = shuffleAvoidingOrder(values, values);
+  const tiles: TileItem[] = shuffled.map((value) => ({
+    id: nanoid(),
+    label: value,
+    value,
+  }));
+  return { tiles, zones };
+};

--- a/src/lib/shuffle.test.ts
+++ b/src/lib/shuffle.test.ts
@@ -1,0 +1,87 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { shuffleArray, shuffleAvoidingOrder } from './shuffle.js';
+
+describe('shuffleArray', () => {
+  it('returns a new array with the same elements', () => {
+    const input = [1, 2, 3];
+    const result = shuffleArray(input);
+    expect(result).toHaveLength(3);
+    expect(result.toSorted((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+
+  it('does not mutate the input', () => {
+    const input = [1, 2, 3];
+    shuffleArray(input);
+    expect(input).toEqual([1, 2, 3]);
+  });
+
+  it('returns a copy for single-element arrays', () => {
+    const input = [42];
+    const result = shuffleArray(input);
+    expect(result).toEqual([42]);
+    expect(result).not.toBe(input);
+  });
+});
+
+describe('shuffleAvoidingOrder', () => {
+  beforeEach(() => {
+    vi.spyOn(Math, 'random');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns a copy for single-element arrays', () => {
+    const result = shuffleAvoidingOrder(['a'], ['a']);
+    expect(result).toEqual(['a']);
+  });
+
+  it('returns the array when correctOrder differs in length', () => {
+    const result = shuffleAvoidingOrder(['a', 'b'], ['a']);
+    expect(result).toHaveLength(2);
+    expect(result.toSorted()).toEqual(['a', 'b']);
+  });
+
+  it('retries until result does not match correctOrder', () => {
+    // For ['a', 'b'], Fisher-Yates with one step: i=1, j=floor(random*2)
+    // random=0.99 → j=1 → no swap → ['a','b'] (matches correctOrder)
+    // random=0    → j=0 → swap   → ['b','a'] (does not match)
+    let callCount = 0;
+    vi.mocked(Math.random).mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? 0.99 : 0;
+    });
+
+    const result = shuffleAvoidingOrder(['a', 'b'], ['a', 'b']);
+    expect(result).toEqual(['b', 'a']);
+  });
+
+  it('never returns the correct order across multiple independent runs', () => {
+    const correctOrder = ['c', 'e', 'n', 't'];
+    for (let i = 0; i < 50; i++) {
+      vi.restoreAllMocks();
+      const result = shuffleAvoidingOrder(
+        [...correctOrder],
+        correctOrder,
+      );
+      expect(result).not.toEqual(correctOrder);
+    }
+  });
+
+  it('preserves all elements', () => {
+    vi.mocked(Math.random).mockReturnValue(0);
+    const result = shuffleAvoidingOrder(
+      ['c', 'e', 'n', 't'],
+      ['c', 'e', 'n', 't'],
+    );
+    expect(result.toSorted()).toEqual(['c', 'e', 'n', 't']);
+  });
+});

--- a/src/lib/shuffle.ts
+++ b/src/lib/shuffle.ts
@@ -1,0 +1,28 @@
+export const shuffleArray = <T>(arr: T[]): T[] => {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j]!, result[i]!];
+  }
+  return result;
+};
+
+export const shuffleAvoidingOrder = <T>(
+  arr: T[],
+  correctOrder: T[],
+  maxAttempts = 10,
+): T[] => {
+  if (arr.length <= 1) return [...arr];
+  if (arr.length !== correctOrder.length) return shuffleArray(arr);
+
+  const isCorrectOrder = (candidate: T[]) =>
+    candidate.every((v, i) => v === correctOrder[i]);
+
+  let result = shuffleArray(arr);
+  let attempts = 0;
+  while (isCorrectOrder(result) && attempts < maxAttempts) {
+    result = shuffleArray(arr);
+    attempts++;
+  }
+  return result;
+};


### PR DESCRIPTION
## Summary

- WordSpell sorted tiles **alphabetically** (`toSorted + localeCompare`) instead of shuffling, so words like "cent" (c,e,n,t) always appeared in the correct spelling order, giving away the answer immediately
- SortNumbers used a plain Fisher-Yates shuffle that could land on the correct ascending/descending sequence by chance
- Adds a `shuffleAvoidingOrder` utility that retries the shuffle until the result does not match the correct answer order
- Extracts `buildTilesAndZones` from `WordSpell.tsx` into its own module (`build-tiles-and-zones.ts`) for isolated unit testing

Closes #263

## Test plan

- [ ] `src/lib/shuffle.test.ts` — `shuffleArray` and `shuffleAvoidingOrder` unit tests (8 tests)
- [ ] `src/games/word-spell/WordSpell/build-tiles-and-zones.test.ts` — verifies WordSpell tiles are never in the correct spelling order (7 tests)
- [ ] `src/games/sort-numbers/build-sort-round.test.ts` — verifies SortNumbers tiles are never in the correct sorted order for both ascending and descending direction (2 new tests)
- [ ] All 1629 existing tests continue to pass
- [ ] TypeScript typecheck passes
- [ ] All pre-push checks pass (ESLint, Prettier, Knip, TypeScript, unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/265/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/265/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/265#issuecomment-)
<!-- /preview-urls -->
