### PR TITLE
feat(word-spell): picture toggle + level/recall mode coupling (#264)

### DIFF
--- a/src/components/answer-game/InstructionsOverlay/InstructionsOverlay.tsx
+++ b/src/components/answer-game/InstructionsOverlay/InstructionsOverlay.tsx
@@ -15,7 +15,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { getSimpleConfigFormRenderer } from '@/games/config-fields-registry';
+import {
+  getSimpleConfigFormRenderer,
+  isPlayableConfig,
+} from '@/games/config-fields-registry';
 import { resolveCover } from '@/games/cover';
 import { DEFAULT_GAME_COLOR, GAME_COLORS } from '@/lib/game-colors';
 import { cancelSpeech, speak } from '@/lib/speech/SpeechOutput';
@@ -157,6 +160,7 @@ export const InstructionsOverlay = ({
   const resolvedCover = resolveCover({ cover }, gameId);
 
   const SimpleForm = getSimpleConfigFormRenderer(gameId);
+  const playable = isPlayableConfig(gameId, config);
 
   const modalMode =
     customGameId && customGameName
@@ -170,6 +174,7 @@ export const InstructionsOverlay = ({
       : ({ kind: 'default' } as const);
 
   const handlePlay = () => {
+    if (!playable) return;
     if (customGameId && customGameName && onUpdateCustomGame) {
       void (async () => {
         try {
@@ -285,7 +290,9 @@ export const InstructionsOverlay = ({
           <button
             type="button"
             onClick={handlePlay}
-            className="h-14 w-full rounded-2xl bg-primary text-xl font-bold text-primary-foreground shadow-md active:scale-95"
+            disabled={!playable}
+            aria-disabled={!playable}
+            className="h-14 w-full rounded-2xl bg-primary text-xl font-bold text-primary-foreground shadow-md active:scale-95 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:shadow-none"
           >
             {t('instructions.lets-go')}
           </button>

--- a/src/games/config-fields-registry.test.ts
+++ b/src/games/config-fields-registry.test.ts
@@ -43,6 +43,40 @@ describe('isPlayableConfig — word-spell', () => {
       }),
     ).toBe(true);
   });
+
+  it('returns true for advanced default configs that supply a library source', () => {
+    expect(
+      isPlayableConfig('word-spell', {
+        mode: 'recall',
+        source: {
+          type: 'word-library',
+          filter: { region: 'aus', graphemesRequired: [] },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for advanced configs with explicit rounds', () => {
+    expect(
+      isPlayableConfig('word-spell', {
+        mode: 'recall',
+        rounds: [{ word: 'cat' }],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when selectedUnits is explicitly empty (user cleared chips)', () => {
+    expect(
+      isPlayableConfig('word-spell', {
+        mode: 'recall',
+        selectedUnits: [],
+        source: {
+          type: 'word-library',
+          filter: { region: 'aus' },
+        },
+      }),
+    ).toBe(false);
+  });
 });
 
 describe('isPlayableConfig — non-word-spell games', () => {

--- a/src/games/config-fields-registry.test.ts
+++ b/src/games/config-fields-registry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { isPlayableConfig } from './config-fields-registry';
+
+describe('isPlayableConfig — word-spell', () => {
+  it('returns true when at least one unit is selected (recall mode)', () => {
+    expect(
+      isPlayableConfig('word-spell', {
+        mode: 'recall',
+        selectedUnits: [{ g: 's', p: 's' }],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when no units are selected and mode is recall', () => {
+    expect(
+      isPlayableConfig('word-spell', {
+        mode: 'recall',
+        selectedUnits: [],
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when selectedUnits is missing entirely', () => {
+    expect(isPlayableConfig('word-spell', { mode: 'recall' })).toBe(
+      false,
+    );
+  });
+
+  it('returns true in picture mode regardless of selectedUnits', () => {
+    expect(
+      isPlayableConfig('word-spell', {
+        mode: 'picture',
+        selectedUnits: [],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true in sentence-gap mode regardless of selectedUnits', () => {
+    expect(
+      isPlayableConfig('word-spell', {
+        mode: 'sentence-gap',
+        selectedUnits: [],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('isPlayableConfig — non-word-spell games', () => {
+  it('always returns true for games without a validity rule', () => {
+    expect(isPlayableConfig('number-match', {})).toBe(true);
+    expect(isPlayableConfig('sort-numbers', { totalRounds: 0 })).toBe(
+      true,
+    );
+  });
+});

--- a/src/games/config-fields-registry.tsx
+++ b/src/games/config-fields-registry.tsx
@@ -75,8 +75,13 @@ export const getAdvancedHeaderRenderer = (
 
 /**
  * True when the config is sufficient to start play. Validation is per-game so
- * unrelated games can't gate each other. Today only word-spell guards against
- * empty-level recall configs; other games are always valid.
+ * unrelated games can't gate each other.
+ *
+ * For WordSpell the only invalid shape we currently care about is "recall mode
+ * with the simple-form library source but zero selected units" — that's the
+ * state #264 explicitly wants to block. Picture / sentence-gap modes are
+ * always playable (no level scope), and any advanced config that has already
+ * resolved a library source or carries explicit rounds is also playable.
  */
 export const isPlayableConfig = (
   gameId: string,
@@ -87,5 +92,12 @@ export const isPlayableConfig = (
     return true;
   }
   const units = config.selectedUnits;
-  return Array.isArray(units) && units.length > 0;
+  if (Array.isArray(units) && units.length > 0) return true;
+  // Empty/missing selectedUnits is only invalid for the simple-form path.
+  // Advanced configs with an already-shaped source or explicit rounds remain
+  // playable so we don't gate default game entries on every site load.
+  if (Array.isArray(units) && units.length === 0) return false;
+  if (config.source !== undefined) return true;
+  const rounds = config.rounds;
+  return Array.isArray(rounds) && rounds.length > 0;
 };

--- a/src/games/config-fields-registry.tsx
+++ b/src/games/config-fields-registry.tsx
@@ -72,3 +72,20 @@ export const getAdvancedHeaderRenderer = (
     }
   }
 };
+
+/**
+ * True when the config is sufficient to start play. Validation is per-game so
+ * unrelated games can't gate each other. Today only word-spell guards against
+ * empty-level recall configs; other games are always valid.
+ */
+export const isPlayableConfig = (
+  gameId: string,
+  config: Record<string, unknown>,
+): boolean => {
+  if (gameId !== 'word-spell') return true;
+  if (config.mode === 'picture' || config.mode === 'sentence-gap') {
+    return true;
+  }
+  const units = config.selectedUnits;
+  return Array.isArray(units) && units.length > 0;
+};

--- a/src/games/word-spell/WordSpellLibrarySource/WordSpellLibrarySource.tsx
+++ b/src/games/word-spell/WordSpellLibrarySource/WordSpellLibrarySource.tsx
@@ -26,10 +26,15 @@ const LEVELS = [1, 2, 3, 4, 5, 6, 7, 8] as const;
 const readSelected = (
   config: Record<string, unknown>,
 ): LevelGraphemeUnit[] => {
+  // Picture mode has no level scope. Always display an empty selection
+  // regardless of what selectedUnits the data layer carries — that way
+  // toggling mode through the legacy advanced <select> (which only writes
+  // config.mode) doesn't leave levels highlighted underneath the Picture
+  // toggle, or vice versa.
+  if (config.mode === 'picture') return [];
   const raw = config.selectedUnits;
-  return Array.isArray(raw)
-    ? (raw as LevelGraphemeUnit[])
-    : defaultSelection();
+  if (Array.isArray(raw)) return raw as LevelGraphemeUnit[];
+  return defaultSelection();
 };
 
 const readRegion = (config: Record<string, unknown>): Region =>

--- a/src/games/word-spell/WordSpellLibrarySource/WordSpellLibrarySource.tsx
+++ b/src/games/word-spell/WordSpellLibrarySource/WordSpellLibrarySource.tsx
@@ -7,6 +7,7 @@ import {
 } from '../level-unit-selection';
 import { resolveSimpleConfig } from '../resolve-simple-config';
 import { WordPreviewBar } from '../WordPreviewBar/WordPreviewBar';
+import type { WordSpellConfig } from '../types';
 import type {
   LevelGraphemeUnit,
   Region,
@@ -33,6 +34,16 @@ const readSelected = (
 
 const readRegion = (config: Record<string, unknown>): Region =>
   typeof config.region === 'string' ? (config.region as Region) : 'aus';
+
+const readMode = (
+  config: Record<string, unknown>,
+): WordSpellConfig['mode'] | undefined => {
+  const raw = config.mode;
+  if (raw === 'picture' || raw === 'recall' || raw === 'sentence-gap') {
+    return raw;
+  }
+  return undefined;
+};
 
 const maxLevelOf = (units: readonly LevelGraphemeUnit[]): number => {
   if (units.length === 0) return 1;
@@ -106,6 +117,32 @@ const headerBgClass = (
     }
   }
 };
+
+const PictureRow = ({
+  active,
+  onClick,
+}: {
+  active: boolean;
+  onClick: () => void;
+}): JSX.Element => (
+  <div className="flex flex-col gap-2">
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`flex items-center justify-between rounded-md px-3 py-2 text-sm font-semibold ${
+        active
+          ? 'bg-primary text-primary-foreground'
+          : 'bg-muted text-foreground'
+      }`}
+    >
+      <span>Picture</span>
+      <span className="text-xs font-normal" aria-hidden="true">
+        🖼️ image-prompted words
+      </span>
+    </button>
+  </div>
+);
 
 const LevelRow = ({
   level,
@@ -198,11 +235,28 @@ export const WordSpellLibrarySource = ({
 }: Props): JSX.Element => {
   const selected = readSelected(config);
   const region = readRegion(config);
-  const invalid = selected.length === 0;
+  const mode = readMode(config);
+  const pictureMode = mode === 'picture';
+  const invalid = !pictureMode && selected.length === 0;
   const maxLevel = maxLevelOf(selected);
 
+  // Any level/chip toggle implies recall mode — picture mode has no level scope
+  // and switching back to recall via a level click should also commit the user's
+  // intended level selection in one step.
   const setSelected = (next: LevelGraphemeUnit[]) => {
-    onChange({ ...config, selectedUnits: next });
+    onChange({ ...config, selectedUnits: next, mode: 'recall' });
+  };
+
+  const togglePicture = () => {
+    if (pictureMode) {
+      onChange({
+        ...config,
+        mode: 'recall',
+        selectedUnits: defaultSelection(),
+      });
+      return;
+    }
+    onChange({ ...config, mode: 'picture', selectedUnits: [] });
   };
 
   return (
@@ -210,6 +264,7 @@ export const WordSpellLibrarySource = ({
       className="flex flex-col gap-4"
       data-invalid={invalid ? 'true' : 'false'}
     >
+      <PictureRow active={pictureMode} onClick={togglePicture} />
       {LEVELS.map((n) => (
         <LevelRow
           key={n}

--- a/src/games/word-spell/WordSpellSimpleConfigForm/WordSpellSimpleConfigForm.test.tsx
+++ b/src/games/word-spell/WordSpellSimpleConfigForm/WordSpellSimpleConfigForm.test.tsx
@@ -95,6 +95,22 @@ describe('WordSpellSimpleConfigForm Picture toggle', () => {
     expect(sChip).toHaveAttribute('aria-pressed', 'true');
   });
 
+  it('does not show any level chips as selected while Picture is active, even if config.selectedUnits is stale', () => {
+    // Simulates the legacy advanced <select> writing mode='picture' while
+    // selectedUnits stays populated (e.g. user came from recall and only
+    // changed mode via the dropdown). Display must follow mode, not data.
+    render(<Harness initial={L1} initialMode="picture" />);
+    expect(
+      screen.getByRole('button', { name: /^picture/i }),
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(
+      screen.getByRole('button', { name: /^s \/s\/$/ }),
+    ).toHaveAttribute('aria-pressed', 'false');
+    expect(
+      screen.getByRole('button', { name: /^t \/t\/$/ }),
+    ).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('toggling Picture off (back to recall) defaults the selection to Level 1', async () => {
     const user = userEvent.setup();
     render(<Harness initial={[]} initialMode="picture" />);

--- a/src/games/word-spell/WordSpellSimpleConfigForm/WordSpellSimpleConfigForm.test.tsx
+++ b/src/games/word-spell/WordSpellSimpleConfigForm/WordSpellSimpleConfigForm.test.tsx
@@ -11,14 +11,17 @@ const L1 = [...(GRAPHEMES_BY_LEVEL[1] ?? [])];
 
 const Harness = ({
   initial,
+  initialMode,
 }: {
   initial: LevelGraphemeUnit[];
+  initialMode?: 'picture' | 'recall';
 }): JSX.Element => {
   const [config, setConfig] = useState<Record<string, unknown>>({
     configMode: 'simple',
     selectedUnits: initial,
     region: 'aus',
     inputMethod: 'drag',
+    ...(initialMode ? { mode: initialMode } : {}),
   });
   return (
     <WordSpellSimpleConfigForm config={config} onChange={setConfig} />
@@ -36,11 +39,20 @@ describe('WordSpellSimpleConfigForm', () => {
     ).toBeInTheDocument();
   });
 
-  it('flags data-invalid when selectedUnits is empty', () => {
+  it('flags data-invalid when selectedUnits is empty and mode is not picture', () => {
     const { container } = render(<Harness initial={[]} />);
     expect(
       container.firstElementChild?.firstElementChild,
     ).toHaveAttribute('data-invalid', 'true');
+  });
+
+  it('is valid when no levels are selected but picture mode is active', () => {
+    const { container } = render(
+      <Harness initial={[]} initialMode="picture" />,
+    );
+    expect(
+      container.firstElementChild?.firstElementChild,
+    ).toHaveAttribute('data-invalid', 'false');
   });
 
   it('marks aria-pressed=true after tapping a chip', async () => {
@@ -49,5 +61,52 @@ describe('WordSpellSimpleConfigForm', () => {
     const chip = screen.getByRole('button', { name: /m \/m\//i });
     await user.click(chip);
     expect(chip).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
+describe('WordSpellSimpleConfigForm Picture toggle', () => {
+  it('renders the Picture toggle button', () => {
+    render(<Harness initial={L1} />);
+    expect(
+      screen.getByRole('button', { name: /^picture/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('clicking Picture clears level chips and pressing it switches mode', async () => {
+    const user = userEvent.setup();
+    render(<Harness initial={L1} />);
+    const sChip = screen.getByRole('button', { name: /^s \/s\/$/ });
+    expect(sChip).toHaveAttribute('aria-pressed', 'true');
+    const picture = screen.getByRole('button', { name: /^picture/i });
+    await user.click(picture);
+    expect(picture).toHaveAttribute('aria-pressed', 'true');
+    // The Level 1 's' chip should be off after selecting Picture.
+    expect(sChip).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('clicking a level chip while Picture is active switches back to recall', async () => {
+    const user = userEvent.setup();
+    render(<Harness initial={[]} initialMode="picture" />);
+    const picture = screen.getByRole('button', { name: /^picture/i });
+    expect(picture).toHaveAttribute('aria-pressed', 'true');
+    const sChip = screen.getByRole('button', { name: /^s \/s\/$/ });
+    await user.click(sChip);
+    expect(picture).toHaveAttribute('aria-pressed', 'false');
+    expect(sChip).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('toggling Picture off (back to recall) defaults the selection to Level 1', async () => {
+    const user = userEvent.setup();
+    render(<Harness initial={[]} initialMode="picture" />);
+    const picture = screen.getByRole('button', { name: /^picture/i });
+    await user.click(picture);
+    expect(picture).toHaveAttribute('aria-pressed', 'false');
+    // Sample a couple of Level 1 chips to confirm the L1 default kicked in.
+    expect(
+      screen.getByRole('button', { name: /^s \/s\/$/ }),
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(
+      screen.getByRole('button', { name: /^t \/t\/$/ }),
+    ).toHaveAttribute('aria-pressed', 'true');
   });
 });

--- a/src/games/word-spell/resolve-simple-config.test.ts
+++ b/src/games/word-spell/resolve-simple-config.test.ts
@@ -21,6 +21,36 @@ describe('resolveSimpleConfig', () => {
     expect(full.source?.filter.region).toBe('aus');
   });
 
+  it('honors mode=picture from the simple config', () => {
+    const simple: WordSpellSimpleConfig = {
+      configMode: 'simple',
+      selectedUnits: [],
+      region: 'aus',
+      inputMethod: 'drag',
+      mode: 'picture',
+    };
+    const full = resolveSimpleConfig(simple);
+    expect(full.mode).toBe('picture');
+  });
+
+  it('picture mode opens the filter to all levels and skips required graphemes', () => {
+    const simple: WordSpellSimpleConfig = {
+      configMode: 'simple',
+      selectedUnits: [],
+      region: 'aus',
+      inputMethod: 'drag',
+      mode: 'picture',
+    };
+    const full = resolveSimpleConfig(simple);
+    const allowed = full.source?.filter.graphemesAllowed ?? [];
+    const required = full.source?.filter.graphemesRequired ?? [];
+    const hasG = (g: string) => allowed.some((u) => u.g === g);
+    // Cumulative through L8: L1's 's' AND a higher-level grapheme should be present.
+    expect(hasG('s')).toBe(true);
+    expect(hasG('sh')).toBe(true);
+    expect(required).toEqual([]);
+  });
+
   it('derives cumulative graphemesAllowed from maxLevel of selectedUnits', () => {
     const simple: WordSpellSimpleConfig = {
       configMode: 'simple',
@@ -190,5 +220,23 @@ describe('advancedToSimple', () => {
     } as WordSpellConfig;
     const simple = advancedToSimple(config);
     expect(simple.selectedUnits).toEqual(L1);
+  });
+
+  it('preserves picture mode and clears the level selection', () => {
+    const config = {
+      gameId: 'word-spell',
+      component: 'WordSpell',
+      mode: 'picture',
+      tileUnit: 'letter',
+      inputMethod: 'drag',
+      wrongTileBehavior: 'lock-manual',
+      ttsEnabled: true,
+      roundsInOrder: false,
+      totalRounds: 4,
+      tileBankMode: 'exact',
+    } as WordSpellConfig;
+    const simple = advancedToSimple(config);
+    expect(simple.mode).toBe('picture');
+    expect(simple.selectedUnits).toEqual([]);
   });
 });

--- a/src/games/word-spell/resolve-simple-config.ts
+++ b/src/games/word-spell/resolve-simple-config.ts
@@ -56,17 +56,23 @@ export const resolveSimpleConfig = (
     : unitsFromLegacy(raw);
   const region =
     typeof raw.region === 'string' ? (raw.region as 'aus') : 'aus';
+  const mode: 'picture' | 'recall' =
+    simple.mode === 'picture' ? 'picture' : 'recall';
 
-  const maxLevel = maxLevelOf(units);
+  // Picture mode rounds use cumulative graphemes from every level so the
+  // image-prompted word pool is as broad as possible without a required-grapheme
+  // gate forcing irrelevant level selections.
+  const maxLevel = mode === 'picture' ? 8 : maxLevelOf(units);
   const graphemesAllowed = cumulativeGraphemes(maxLevel);
-  const graphemesRequired = uniqueGraphemePairs(units);
+  const graphemesRequired =
+    mode === 'picture' ? [] : uniqueGraphemePairs(units);
 
   return {
     gameId: 'word-spell',
     component: 'WordSpell',
     configMode: 'simple',
     selectedUnits: units,
-    mode: 'recall',
+    mode,
     tileUnit: 'letter',
     inputMethod: simple.inputMethod,
     wrongTileBehavior: 'lock-manual',
@@ -90,6 +96,8 @@ export const advancedToSimple = (
 ): WordSpellSimpleConfig => {
   const filter = config.source?.filter;
   const region = filter?.region ?? 'aus';
+  const mode: 'picture' | 'recall' =
+    config.mode === 'picture' ? 'picture' : 'recall';
 
   if (
     typeof filter?.level === 'number' &&
@@ -108,13 +116,15 @@ export const advancedToSimple = (
       selectedUnits: out,
       region,
       inputMethod: config.inputMethod,
+      mode,
     };
   }
 
   return {
     configMode: 'simple',
-    selectedUnits: defaultSelection(),
+    selectedUnits: mode === 'picture' ? [] : defaultSelection(),
     region,
     inputMethod: config.inputMethod,
+    mode,
   };
 };

--- a/src/games/word-spell/types.ts
+++ b/src/games/word-spell/types.ts
@@ -11,6 +11,12 @@ export type WordSpellSimpleConfig = {
   selectedUnits: LevelGraphemeUnit[];
   region: Region;
   inputMethod: 'drag' | 'type' | 'both';
+  /**
+   * Simple form supports two kid-friendly modes:
+   *  - 'recall': pick one or more level grapheme units; word library filtered to that scope
+   *  - 'picture': image-prompted rounds, no level selection required
+   */
+  mode?: 'picture' | 'recall';
 };
 
 export interface GapDefinition {


### PR DESCRIPTION
## Summary

Closes #264.

- Adds a "Picture" radio above Levels 1-8 in `WordSpellLibrarySource` — the component shared between the simple form (`InstructionsOverlay`) and the advanced modal's header — so users can pick between picture-prompted and level-scoped recall play in one control.
- Picture and Levels are mutually exclusive: clicking Picture clears `selectedUnits` and sets `mode = picture`; clicking any level/chip sets `mode = recall`. Toggling Picture off (back to recall) defaults `selectedUnits` to Level 1 per the issue.
- `resolveSimpleConfig` now honors `mode`. In picture mode the filter opens to all 8 cumulative levels and drops `graphemesRequired` so an empty selection doesn't gate the word pool. `advancedToSimple` round-trips picture mode.
- Validation: new `isPlayableConfig(gameId, config)` in `config-fields-registry.tsx`. `InstructionsOverlay`'s "Let's go" is now `disabled` and `handlePlay` early-returns when WordSpell is in recall mode with no levels selected. The inline "Pick at least one sound" warning still renders.

## Notes / known follow-ups

- The advanced form's legacy `mode` `<select>` (from `wordSpellConfigFields`) still writes the same `config.mode` field, so it stays passively in sync. Reconciling/removing it lives under #254 (advanced-matches-simple redesign) — comment posted [there](https://github.com/leocaseiro/base-skill/issues/254#issuecomment-4351806515).
- Library-sourced rounds in picture mode currently render no visual prompt because `toWordSpellRound` doesn't attach an emoji or image — the data plumbing for that is its own scope. Filed as #266.

## Test plan

- [x] `yarn test src/games/word-spell src/games/config-fields-registry src/components/answer-game/InstructionsOverlay` — 111 tests pass, including new coverage for the Picture toggle, the recall-default-to-L1 rule, mode propagation through `resolveSimpleConfig`, and `isPlayableConfig`.
- [x] `yarn typecheck` — clean.
- [x] `yarn lint` — clean.
- [ ] Manual smoke in Storybook: `Games/WordSpell/ConfigForm` simple + advanced — verify Picture toggle clears chips, level click switches back to recall, "Let's go" gates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/267/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/267/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/267#issuecomment-)
<!-- /preview-urls -->


