### PR TITLE
chore(release): v0.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-skill",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
Automated version bump from the deploy workflow.

The site has already been deployed to gh-pages with version `0.21.1` (see `dist/client/version.json`). Merging this PR lands the matching `package.json` bump on master and makes the `v0.21.1` tag reachable from master.

The bump type was derived from the merged PR's conventional-commit messages by `scripts/determine-bump.sh`.

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/268/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/268/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/268#issuecomment-)
<!-- /preview-urls -->
