### PR TITLE
chore(release): v0.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-skill",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
Automated version bump from the deploy workflow.

The site has already been deployed to gh-pages with version `0.24.0` (see `dist/client/version.json`). Merging this PR lands the matching `package.json` bump on master and makes the `v0.24.0` tag reachable from master.

The bump type was derived from the merged PR's conventional-commit messages by `scripts/determine-bump.sh`.

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/279/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/279/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/279#issuecomment-)
<!-- /preview-urls -->
