### PR TITLE
docs: fast-tap queue design spec and implementation plan (#276)

### DIFF
--- a/.claude/handoffs/2026-05-01-fast-tap-queue-spec.md
+++ b/.claude/handoffs/2026-05-01-fast-tap-queue-spec.md
@@ -1,0 +1,72 @@
+# Handoff: Fast-tap queue design spec (#276)
+
+**Date:** 2026-05-01
+**Branch:** 276-fast-tap-queue
+**Worktree:** worktrees/276-fast-tap-queue
+**Worktree path:** /Users/leocaseiro/Sites/base-skill/worktrees/276-fast-tap-queue
+**Git status:** clean
+**Last commit:** a307fb9f docs(spec): apply doc review findings to fast-tap queue design
+**PR:** #282 — open
+
+## Resume command
+
+```
+/resync
+cd worktrees/276-fast-tap-queue
+```
+
+Then invoke `superpowers:writing-plans` against the spec to create the implementation plan.
+
+## Current state
+
+**Task:** Fix false error bounces on rapid Android taps (issue #276)
+**Phase:** planning
+**Progress:** Design spec complete and doc-reviewed; implementation plan not yet written
+
+## What we did
+
+Brainstormed, designed, and wrote a design spec for the fast-tap queue fix. The spec was doc-reviewed by 4 personas (coherence, feasibility, scope-guardian, adversarial) — 6 findings applied, 1 deferred to Open Questions (screen reader a11y), 1 skipped. Also raised follow-up issue #280 for the lock-manual sequential wrong tile blocking bug discovered during brainstorming.
+
+## Decisions made
+
+- **Pre-validate at bank, not in reducer** — for tap/click in `lock-auto-eject` and `reject` modes, check tile correctness before dispatching. Wrong tiles shake in the bank instead of traveling to a slot and bouncing back. `lock-manual` is unchanged (wrong tiles still go to slot).
+- **Ref-based write-ahead log, not flushSync or debounce** — a shared `pendingPlacements` ref tracks claimed slots synchronously, bypassing React's batching delay. Second tap sees slot 0 is claimed and targets slot 1.
+- **Shared ref scope** — the `pendingPlacements` ref must be shared across all hook instances (AnswerGameProvider context or module scope), not per-hook. Drain condition: `zones[entry.zoneIndex].placedTileId === entry.tileId`. Clear on `INIT_ROUND`/`ADVANCE_ROUND`/`ADVANCE_LEVEL`.
+- **placeInNextSlot returns result object** — `{ placed: boolean; zoneIndex: number; rejected: boolean }` instead of void, so callers can branch on outcome.
+- **Throttle re-taps during shake** — if `animate-shake` is already active, ignore subsequent taps. Prevents orphaned `animationend` listeners that would leave `is-wrong` class permanently applied.
+- **Full reject feedback on all input methods** — `reject` mode gets shake + wrong sound + red flash on tap, click, AND drag (previously silent discard only).
+- **`expected` field on GameEvaluateEvent** — additive, no IndexedDB migration needed. Provides confusion pair for future SRS/Anki implementation.
+- **REJECT_TAP reducer action** — increments `retryCount` only, no zone mutations.
+- **Follow-up issue #280** — lock-manual sequential wrong tile blocking is a separate bug, out of scope for this PR.
+
+## Spec / Plan
+
+- docs/superpowers/specs/2026-05-01-fast-tap-queue-design.md
+
+## Key files
+
+- `src/components/answer-game/useAutoNextSlot.ts` — core of the bug; `placeInNextSlot` reads stale `zones`/`activeSlotIndex` from closure
+- `src/components/answer-game/useDraggableTile.ts:129-132` — `handleClick` where pre-validation + shake will be wired
+- `src/components/answer-game/useTileEvaluation.ts:24-50` — `placeTile` where `expected` field gets added to game:evaluate emits
+- `src/components/answer-game/answer-game-reducer.ts:119-125` — existing `reject` mode silent discard; new `REJECT_TAP` case goes here
+- `src/components/answer-game/types.ts` — `AnswerGameAction` union type, add `REJECT_TAP`
+- `src/types/game-events.ts` — `GameEvaluateEvent`, add `expected: string`
+- `src/components/answer-game/Slot/slot-animations.ts` — `triggerShake` reused for bank tile shake
+
+## Open questions / blockers
+
+- [ ] Screen reader announcements for rejected taps — deferred from doc review (Open Questions in spec)
+
+## Next steps
+
+1. [ ] Invoke `superpowers:writing-plans` to create the implementation plan from the spec
+2. [ ] Implement following TDD: write failing tests first, then production code
+3. [ ] Test on Android device to confirm the stale-closure race is resolved
+
+## Context to remember
+
+- Mouse clicks cannot reproduce the bug (insufficient speed) — only Android touch
+- Drag-and-drop is unaffected (user targets a specific slot)
+- The fix applies to SortNumbers too since it shares the answer-game layer
+- `wrongTileBehavior` has three modes: `lock-auto-eject`, `lock-manual`, `reject` — each behaves differently per the behavior matrix in the spec
+- No iOS reproduction found, but fix is platform-agnostic

--- a/.claude/handoffs/2026-05-01-fast-tap-queue-spec.md
+++ b/.claude/handoffs/2026-05-01-fast-tap-queue-spec.md
@@ -1,11 +1,10 @@
-# Handoff: Fast-tap queue design spec (#276)
+# Handoff: Fast-tap queue implementation (#276)
 
 **Date:** 2026-05-01
 **Branch:** 276-fast-tap-queue
 **Worktree:** worktrees/276-fast-tap-queue
 **Worktree path:** /Users/leocaseiro/Sites/base-skill/worktrees/276-fast-tap-queue
 **Git status:** clean
-**Last commit:** a307fb9f docs(spec): apply doc review findings to fast-tap queue design
 **PR:** #282 — open
 
 ## Resume command
@@ -15,58 +14,73 @@
 cd worktrees/276-fast-tap-queue
 ```
 
-Then invoke `superpowers:writing-plans` against the spec to create the implementation plan.
+Then execute the plan using `superpowers:subagent-driven-development` or `superpowers:executing-plans`.
 
 ## Current state
 
 **Task:** Fix false error bounces on rapid Android taps (issue #276)
-**Phase:** planning
-**Progress:** Design spec complete and doc-reviewed; implementation plan not yet written
+**Phase:** ready to implement
+**Progress:** Design spec, implementation plan, and doc review all complete. Plan has 8 tasks (7 implementation + 1 architecture docs). 15 doc review findings were applied (14 walk-through + 1 auto-fix).
 
 ## What we did
 
-Brainstormed, designed, and wrote a design spec for the fast-tap queue fix. The spec was doc-reviewed by 4 personas (coherence, feasibility, scope-guardian, adversarial) — 6 findings applied, 1 deferred to Open Questions (screen reader a11y), 1 skipped. Also raised follow-up issue #280 for the lock-manual sequential wrong tile blocking bug discovered during brainstorming.
+1. Brainstormed, designed, and wrote a design spec. Spec was doc-reviewed by 4 personas — 6 findings applied, 1 deferred (screen reader a11y), 1 skipped.
+2. Wrote an 8-task TDD implementation plan with full code blocks.
+3. Plan was doc-reviewed by 4 personas (coherence, feasibility, scope-guardian, adversarial) — 15 findings applied across all severity levels. Key fixes:
+   - Made `expected` field optional on `GameEvaluateEvent` (was required, broke 4+ existing emit sites)
+   - Added `data-shaking` throttle attribute (replaced `classList.contains` TOCTOU guard)
+   - Added CSS variable fallback values for red flash
+   - Added `zones.length` to `useEffect` deps (fixes consecutive `INIT_ROUND`)
+   - Added Task 8 for architecture docs update per CLAUDE.md
+   - Merged Task 5/6 test mocks into forward-compatible definition
+   - Added dispatch-ownership comments for REJECT_TAP invariant
+   - Added UX change rationale for lock-auto-eject bank-shake
+   - Added missing test cases (isWrong+null, no-slot-available)
 
 ## Decisions made
 
-- **Pre-validate at bank, not in reducer** — for tap/click in `lock-auto-eject` and `reject` modes, check tile correctness before dispatching. Wrong tiles shake in the bank instead of traveling to a slot and bouncing back. `lock-manual` is unchanged (wrong tiles still go to slot).
-- **Ref-based write-ahead log, not flushSync or debounce** — a shared `pendingPlacements` ref tracks claimed slots synchronously, bypassing React's batching delay. Second tap sees slot 0 is claimed and targets slot 1.
-- **Shared ref scope** — the `pendingPlacements` ref must be shared across all hook instances (AnswerGameProvider context or module scope), not per-hook. Drain condition: `zones[entry.zoneIndex].placedTileId === entry.tileId`. Clear on `INIT_ROUND`/`ADVANCE_ROUND`/`ADVANCE_LEVEL`.
-- **placeInNextSlot returns result object** — `{ placed: boolean; zoneIndex: number; rejected: boolean }` instead of void, so callers can branch on outcome.
-- **Throttle re-taps during shake** — if `animate-shake` is already active, ignore subsequent taps. Prevents orphaned `animationend` listeners that would leave `is-wrong` class permanently applied.
-- **Full reject feedback on all input methods** — `reject` mode gets shake + wrong sound + red flash on tap, click, AND drag (previously silent discard only).
-- **`expected` field on GameEvaluateEvent** — additive, no IndexedDB migration needed. Provides confusion pair for future SRS/Anki implementation.
+- **Pre-validate at bank, not in reducer** — for tap/click in `lock-auto-eject` and `reject` modes, check tile correctness before dispatching. Wrong tiles shake in the bank instead of traveling to a slot and bouncing back. `lock-manual` is unchanged.
+- **Ref-based write-ahead log, not flushSync or debounce** — a shared `pendingPlacements` ref tracks claimed slots synchronously. Second tap sees slot 0 is claimed and targets slot 1.
+- **Module-scoped pendingPlacements** — single-instance assumption documented. For multi-instance, lift to AnswerGameProvider context.
+- **placeInNextSlot returns PlaceResult** — `{ placed: boolean; zoneIndex: number; rejected: boolean }`.
+- **Throttle via data-shaking attribute** — robust to triggerShake's internal remove-reflow-add cycle (not classList.contains which has TOCTOU).
+- **expected field is optional** — `expected?: string` on `GameEvaluateEvent`, matching spec's "non-breaking additive change" claim.
+- **REJECT_TAP dispatch ownership** — tap/click dispatches in `handleClick`; drag dispatches in `placeTile`. Mutually exclusive, documented with comments.
+- **Full reject feedback on all input methods** — `reject` mode gets shake + wrong sound + red flash on tap, click, AND drag.
 - **REJECT_TAP reducer action** — increments `retryCount` only, no zone mutations.
-- **Follow-up issue #280** — lock-manual sequential wrong tile blocking is a separate bug, out of scope for this PR.
+- **Follow-up issue #280** — lock-manual sequential wrong tile blocking is a separate bug.
 
 ## Spec / Plan
 
 - docs/superpowers/specs/2026-05-01-fast-tap-queue-design.md
+- docs/superpowers/plans/2026-05-01-fast-tap-queue.md
 
 ## Key files
 
-- `src/components/answer-game/useAutoNextSlot.ts` — core of the bug; `placeInNextSlot` reads stale `zones`/`activeSlotIndex` from closure
-- `src/components/answer-game/useDraggableTile.ts:129-132` — `handleClick` where pre-validation + shake will be wired
-- `src/components/answer-game/useTileEvaluation.ts:24-50` — `placeTile` where `expected` field gets added to game:evaluate emits
-- `src/components/answer-game/answer-game-reducer.ts:119-125` — existing `reject` mode silent discard; new `REJECT_TAP` case goes here
-- `src/components/answer-game/types.ts` — `AnswerGameAction` union type, add `REJECT_TAP`
-- `src/types/game-events.ts` — `GameEvaluateEvent`, add `expected: string`
-- `src/components/answer-game/Slot/slot-animations.ts` — `triggerShake` reused for bank tile shake
+- `src/components/answer-game/useAutoNextSlot.ts` — core of the bug; pendingPlacements queue + pre-validation
+- `src/components/answer-game/useDraggableTile.ts:129-132` — `handleClick` pre-validation + shake
+- `src/components/answer-game/useTileEvaluation.ts:24-50` — `placeTile` with `expected` field and drag-reject
+- `src/components/answer-game/answer-game-reducer.ts:119-125` — `REJECT_TAP` case
+- `src/components/answer-game/types.ts` — `AnswerGameAction` union with `REJECT_TAP`
+- `src/types/game-events.ts` — `GameEvaluateEvent` with optional `expected`
+- `src/components/answer-game/AnswerGame/AnswerGame.flows.mdx` — architecture docs (Task 8)
 
 ## Open questions / blockers
 
-- [ ] Screen reader announcements for rejected taps — deferred from doc review (Open Questions in spec)
+- [ ] Screen reader announcements for rejected taps — deferred from doc review
 
 ## Next steps
 
-1. [ ] Invoke `superpowers:writing-plans` to create the implementation plan from the spec
-2. [ ] Implement following TDD: write failing tests first, then production code
-3. [ ] Test on Android device to confirm the stale-closure race is resolved
+1. [x] Invoke `superpowers:writing-plans` to create the implementation plan
+2. [x] Doc review the plan (4 personas, 15 findings applied)
+3. [ ] Execute plan using `superpowers:subagent-driven-development` or `superpowers:executing-plans`
+4. [ ] Test on Android device to confirm the stale-closure race is resolved
 
 ## Context to remember
 
 - Mouse clicks cannot reproduce the bug (insufficient speed) — only Android touch
 - Drag-and-drop is unaffected (user targets a specific slot)
 - The fix applies to SortNumbers too since it shares the answer-game layer
-- `wrongTileBehavior` has three modes: `lock-auto-eject`, `lock-manual`, `reject` — each behaves differently per the behavior matrix in the spec
+- `wrongTileBehavior` has three modes: `lock-auto-eject`, `lock-manual`, `reject`
 - No iOS reproduction found, but fix is platform-agnostic
+- CSS variables `--skin-wrong-bg` and `--skin-wrong-border` — verify they exist at game container scope; fallbacks added

--- a/docs/superpowers/plans/2026-05-01-fast-tap-queue.md
+++ b/docs/superpowers/plans/2026-05-01-fast-tap-queue.md
@@ -1,0 +1,1408 @@
+# Fast-Tap Queue Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix false error bounces on rapid Android taps by pre-validating tiles at the bank and using a ref-based pending-placements queue to prevent stale-closure races.
+
+**Architecture:** A module-scoped `pendingPlacements` ref acts as a write-ahead log so concurrent taps see each other's claimed slots without waiting for React's batched re-render. Wrong tiles are caught at the bank (pre-validation) instead of traveling to a slot and bouncing back. A new `REJECT_TAP` reducer action tracks retries without zone mutations.
+
+**Tech Stack:** React 19, TypeScript, Vitest, @testing-library/react
+
+**Spec:** `docs/superpowers/specs/2026-05-01-fast-tap-queue-design.md`
+
+## Spec Delta
+
+**Red flash styling — inline styles instead of CSS class:** The spec says
+"Add the `.is-wrong` styles to the existing DraggableTile CSS module." However,
+there is no DraggableTile CSS module — bank tiles use inline styles via
+`tileStyle()` (which sets `background: linear-gradient(...)`) and Tailwind
+utility classes. A CSS class cannot override inline styles without `!important`.
+This plan uses direct `el.style` assignment and `animationend` cleanup instead,
+achieving the same visual result (skin-wrong-bg/border flash for shake duration)
+without needing `!important` hacks or a new CSS module.
+
+---
+
+## File Structure
+
+### Modified files
+
+| File                                                | Responsibility                                                                                     |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `src/components/answer-game/types.ts`               | Add `REJECT_TAP` to `AnswerGameAction` union                                                       |
+| `src/types/game-events.ts`                          | Add `expected` field to `GameEvaluateEvent`                                                        |
+| `src/components/answer-game/answer-game-reducer.ts` | Handle `REJECT_TAP` action                                                                         |
+| `src/components/answer-game/useTileEvaluation.ts`   | Add `expected` to emits; dispatch `REJECT_TAP` for reject-mode wrong on drag; return `{ correct }` |
+| `src/components/answer-game/useAutoNextSlot.ts`     | Pending queue, pre-validation, `PlaceResult` return type                                           |
+| `src/components/answer-game/useDraggableTile.ts`    | Pre-validate on click with shake/sound feedback; drag-reject shake                                 |
+
+### Modified test files
+
+| File                                                     | Responsibility                                     |
+| -------------------------------------------------------- | -------------------------------------------------- |
+| `src/components/answer-game/answer-game-reducer.test.ts` | `REJECT_TAP` handler tests                         |
+| `src/components/answer-game/useTileEvaluation.test.tsx`  | `expected` field + reject-dispatch tests           |
+| `src/components/answer-game/useAutoNextSlot.test.tsx`    | Pending queue, pre-validation, `PlaceResult` tests |
+| `src/components/answer-game/useDraggableTile.test.tsx`   | Click reject path + drag-reject tests              |
+
+---
+
+## Task 1: Add REJECT_TAP action and expected field to types
+
+**Files:**
+
+- Modify: `src/components/answer-game/types.ts:101-121`
+- Modify: `src/types/game-events.ts:51-58`
+
+- [ ] **Step 1: Add REJECT_TAP to AnswerGameAction union**
+
+In `src/components/answer-game/types.ts`, add to the union after the `SET_ACTIVE_SLOT` member (line 121):
+
+```typescript
+  | { type: 'SET_ACTIVE_SLOT'; zoneIndex: number }
+  | { type: 'REJECT_TAP'; tileId: string; zoneIndex: number };
+```
+
+- [ ] **Step 2: Add expected field to GameEvaluateEvent**
+
+In `src/types/game-events.ts`, add after the `zoneIndex` field (line 57):
+
+```typescript
+export interface GameEvaluateEvent extends BaseGameEvent {
+  type: 'game:evaluate';
+  answer: string | string[] | number;
+  correct: boolean;
+  nearMiss: boolean;
+  /** Index of the slot the tile was placed into. */
+  zoneIndex: number;
+  /** Expected value for the target slot — provides confusion pair for SRS. */
+  expected: string;
+}
+```
+
+- [ ] **Step 3: Run typecheck to verify**
+
+Run: `yarn typecheck`
+
+Expected: Type errors in files that emit `game:evaluate` without `expected` (useTileEvaluation.ts, possibly useDraggableTile.ts). This is expected — we fix those emits in Tasks 3 and 5.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/answer-game/types.ts src/types/game-events.ts
+git commit -m "feat(answer-game): add REJECT_TAP action type and expected field to GameEvaluateEvent (#276)"
+```
+
+---
+
+## Task 2: Handle REJECT_TAP in reducer
+
+**Files:**
+
+- Modify: `src/components/answer-game/answer-game-reducer.ts:104`
+- Test: `src/components/answer-game/answer-game-reducer.test.ts`
+
+- [ ] **Step 1: Write failing test for REJECT_TAP**
+
+Add to the end of the `describe('answerGameReducer', ...)` block in `answer-game-reducer.test.ts`:
+
+```typescript
+describe('REJECT_TAP', () => {
+  it('increments retryCount without mutating zones or bank', () => {
+    const state = answerGameReducer(makeInitialState(config), {
+      type: 'INIT_ROUND',
+      tiles,
+      zones,
+    });
+
+    const next = answerGameReducer(state, {
+      type: 'REJECT_TAP',
+      tileId: 't2',
+      zoneIndex: 0,
+    });
+
+    expect(next.retryCount).toBe(state.retryCount + 1);
+    expect(next.zones).toEqual(state.zones);
+    expect(next.bankTileIds).toEqual(state.bankTileIds);
+    expect(next.activeSlotIndex).toBe(state.activeSlotIndex);
+    expect(next.phase).toBe('playing');
+  });
+
+  it('preserves existing retryCount accumulation', () => {
+    let state = answerGameReducer(makeInitialState(config), {
+      type: 'INIT_ROUND',
+      tiles,
+      zones,
+    });
+    state = answerGameReducer(state, {
+      type: 'REJECT_TAP',
+      tileId: 't2',
+      zoneIndex: 0,
+    });
+    state = answerGameReducer(state, {
+      type: 'REJECT_TAP',
+      tileId: 't2',
+      zoneIndex: 0,
+    });
+
+    expect(state.retryCount).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/answer-game/answer-game-reducer.test.ts`
+
+Expected: FAIL — `REJECT_TAP` is not handled by the reducer (falls through to default, returns unchanged state, retryCount stays 0).
+
+- [ ] **Step 3: Implement REJECT_TAP handler**
+
+In `answer-game-reducer.ts`, add a new case before the closing `default:` of the switch statement. Insert after the `RESUME_ROUND` case block (after line 104, before `case 'PLACE_TILE':`):
+
+```typescript
+    case 'REJECT_TAP': {
+      return {
+        ...state,
+        retryCount: state.retryCount + 1,
+      };
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/answer-game/answer-game-reducer.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/answer-game/answer-game-reducer.ts src/components/answer-game/answer-game-reducer.test.ts
+git commit -m "feat(answer-game): handle REJECT_TAP reducer action (#276)"
+```
+
+---
+
+## Task 3: Add expected field to game:evaluate emits and reject-mode dispatch
+
+**Files:**
+
+- Modify: `src/components/answer-game/useTileEvaluation.ts:9-10,24-50,52-83`
+- Test: `src/components/answer-game/useTileEvaluation.test.tsx`
+
+This task modifies `placeTile` to:
+
+1. Include `expected` in all `game:evaluate` emits
+2. Return `{ correct: boolean }` so callers can react to the outcome
+3. Dispatch `REJECT_TAP` instead of `PLACE_TILE` for wrong tiles in `reject` mode
+
+- [ ] **Step 1: Write failing tests**
+
+First, update the mock for `getGameEventBus` so we can capture emitted events. Replace the existing mock at the top of `useTileEvaluation.test.tsx`:
+
+```typescript
+const mockEmit = vi.fn();
+vi.mock('@/lib/game-event-bus', () => ({
+  getGameEventBus: () => ({ emit: mockEmit, subscribe: vi.fn() }),
+}));
+```
+
+Add a `beforeEach` to clear the mock (add inside or alongside existing `beforeEach`):
+
+```typescript
+beforeEach(() => {
+  mockEmit.mockClear();
+});
+```
+
+Then add these tests at the end of the test file's describe block:
+
+```typescript
+describe('expected field on game:evaluate', () => {
+  it('includes expected value from zone in placeTile emit', () => {
+    const Wrapper = createWrapper(baseConfig);
+    function useHarness() {
+      const dispatch = useAnswerGameDispatch();
+      const state = useAnswerGameContext();
+      if (state.zones.length === 0)
+        dispatch({ type: 'INIT_ROUND', tiles, zones });
+      const { placeTile } = useTileEvaluation();
+      return { state, placeTile };
+    }
+
+    const { result } = renderHook(() => useHarness(), {
+      wrapper: Wrapper,
+    });
+    act(() => result.current.placeTile('t1', 0));
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'game:evaluate',
+        expected: 'C',
+      }),
+    );
+  });
+});
+
+describe('placeTile return value', () => {
+  it('returns { correct: true } for correct placement', () => {
+    const Wrapper = createWrapper(baseConfig);
+    function useHarness() {
+      const dispatch = useAnswerGameDispatch();
+      const state = useAnswerGameContext();
+      if (state.zones.length === 0)
+        dispatch({ type: 'INIT_ROUND', tiles, zones });
+      const { placeTile } = useTileEvaluation();
+      return { placeTile };
+    }
+
+    const { result } = renderHook(() => useHarness(), {
+      wrapper: Wrapper,
+    });
+    let returnVal: { correct: boolean } | undefined;
+    act(() => {
+      returnVal = result.current.placeTile('t1', 0);
+    });
+
+    expect(returnVal).toEqual({ correct: true });
+  });
+
+  it('returns { correct: false } for wrong placement', () => {
+    const Wrapper = createWrapper(baseConfig);
+    function useHarness() {
+      const dispatch = useAnswerGameDispatch();
+      const state = useAnswerGameContext();
+      if (state.zones.length === 0)
+        dispatch({ type: 'INIT_ROUND', tiles, zones });
+      const { placeTile } = useTileEvaluation();
+      return { placeTile };
+    }
+
+    const { result } = renderHook(() => useHarness(), {
+      wrapper: Wrapper,
+    });
+    let returnVal: { correct: boolean } | undefined;
+    act(() => {
+      returnVal = result.current.placeTile('t2', 0);
+    });
+
+    expect(returnVal).toEqual({ correct: false });
+  });
+});
+
+describe('reject mode dispatches REJECT_TAP', () => {
+  it('dispatches REJECT_TAP instead of PLACE_TILE for wrong tile in reject mode', () => {
+    const rejectConfig: AnswerGameConfig = {
+      ...baseConfig,
+      wrongTileBehavior: 'reject',
+    };
+    const Wrapper = createWrapper(rejectConfig);
+    function useHarness() {
+      const dispatch = useAnswerGameDispatch();
+      const state = useAnswerGameContext();
+      if (state.zones.length === 0)
+        dispatch({ type: 'INIT_ROUND', tiles, zones });
+      const { placeTile } = useTileEvaluation();
+      return { state, placeTile };
+    }
+
+    const { result } = renderHook(() => useHarness(), {
+      wrapper: Wrapper,
+    });
+    act(() => result.current.placeTile('t2', 0));
+
+    expect(result.current.state.retryCount).toBe(1);
+    expect(result.current.state.zones[0].placedTileId).toBeNull();
+  });
+
+  it('dispatches PLACE_TILE for wrong tile in lock-auto-eject mode', () => {
+    const Wrapper = createWrapper(baseConfig);
+    function useHarness() {
+      const dispatch = useAnswerGameDispatch();
+      const state = useAnswerGameContext();
+      if (state.zones.length === 0)
+        dispatch({ type: 'INIT_ROUND', tiles, zones });
+      const { placeTile } = useTileEvaluation();
+      return { state, placeTile };
+    }
+
+    const { result } = renderHook(() => useHarness(), {
+      wrapper: Wrapper,
+    });
+    act(() => result.current.placeTile('t2', 0));
+
+    expect(result.current.state.zones[0].placedTileId).toBe('t2');
+    expect(result.current.state.zones[0].isWrong).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/answer-game/useTileEvaluation.test.tsx`
+
+Expected: FAIL — `expected` field missing from emit, `placeTile` returns void, reject mode still dispatches `PLACE_TILE`.
+
+- [ ] **Step 3: Implement changes in useTileEvaluation.ts**
+
+Update the `TileEvaluation` interface:
+
+```typescript
+export interface TileEvaluation {
+  placeTile: (
+    tileId: string,
+    zoneIndex: number,
+  ) => { correct: boolean };
+  typeTile: (value: string, zoneIndex: number) => void;
+}
+```
+
+Update `placeTile` implementation:
+
+```typescript
+const placeTile = useCallback(
+  (tileId: string, zoneIndex: number): { correct: boolean } => {
+    const tile = state.allTiles.find((t) => t.id === tileId);
+    const zone = state.zones[zoneIndex];
+    if (!tile || !zone) return { correct: false };
+
+    const correct = tile.value === zone.expectedValue;
+    if (!skin.suppressDefaultSounds) {
+      playSound(correct ? 'correct' : 'wrong', 0.8);
+    }
+
+    if (!correct && state.config.wrongTileBehavior === 'reject') {
+      dispatch({ type: 'REJECT_TAP', tileId, zoneIndex });
+    } else {
+      dispatch({ type: 'PLACE_TILE', tileId, zoneIndex });
+    }
+
+    getGameEventBus().emit({
+      type: 'game:evaluate',
+      gameId: state.config.gameId,
+      sessionId: '',
+      profileId: '',
+      timestamp: Date.now(),
+      roundIndex: state.roundIndex,
+      answer: tileId,
+      correct,
+      nearMiss: false,
+      zoneIndex,
+      expected: zone.expectedValue,
+    });
+
+    return { correct };
+  },
+  [state, dispatch, skin],
+);
+```
+
+Update `typeTile` to add `expected` to its emit:
+
+```typescript
+getGameEventBus().emit({
+  type: 'game:evaluate',
+  gameId: state.config.gameId,
+  sessionId: '',
+  profileId: '',
+  timestamp: Date.now(),
+  roundIndex: state.roundIndex,
+  answer: value,
+  correct,
+  nearMiss: false,
+  zoneIndex,
+  expected: zone.expectedValue,
+});
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/answer-game/useTileEvaluation.test.tsx`
+
+Expected: PASS
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `yarn typecheck`
+
+Expected: PASS (or errors only in files we haven't touched yet — useDraggableTile emit sites).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/answer-game/useTileEvaluation.ts src/components/answer-game/useTileEvaluation.test.tsx
+git commit -m "feat(answer-game): add expected field to game:evaluate emits and reject-mode dispatch (#276)"
+```
+
+---
+
+## Task 4: Refactor useAutoNextSlot — pending queue and pre-validation
+
+**Files:**
+
+- Modify: `src/components/answer-game/useAutoNextSlot.ts`
+- Test: `src/components/answer-game/useAutoNextSlot.test.tsx`
+
+This is the core fix. Changes:
+
+1. Module-scoped `pendingPlacements` array (write-ahead log)
+2. `PlaceResult` return type: `{ placed: boolean; zoneIndex: number; rejected: boolean }`
+3. Pre-validation against target slot's `expectedValue` (skipped for `lock-manual`)
+4. Drain logic removes entries the reducer has applied
+5. Clear on round transitions via `useEffect`
+6. Remove `isWrong` early-return guard (superseded by pre-validation)
+
+- [ ] **Step 1: Write failing tests**
+
+Replace the entire content of `useAutoNextSlot.test.tsx` with:
+
+```typescript
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AnswerGameProvider } from './AnswerGameProvider';
+import { useAnswerGameContext } from './useAnswerGameContext';
+import { useAnswerGameDispatch } from './useAnswerGameDispatch';
+import {
+  clearPendingPlacements,
+  useAutoNextSlot,
+} from './useAutoNextSlot';
+import type { AnswerGameConfig, AnswerZone, TileItem } from './types';
+import type { PlaceResult } from './useAutoNextSlot';
+import type { ReactNode } from 'react';
+
+vi.mock('@/lib/game-event-bus', () => ({
+  getGameEventBus: () => ({ emit: vi.fn(), subscribe: vi.fn() }),
+}));
+
+vi.mock('@/lib/audio/AudioFeedback', () => ({
+  playSound: vi.fn(),
+}));
+
+const gameConfig: AnswerGameConfig = {
+  gameId: 'test',
+  inputMethod: 'drag',
+  wrongTileBehavior: 'lock-auto-eject',
+  tileBankMode: 'exact',
+  totalRounds: 1,
+  ttsEnabled: false,
+};
+
+const tileItems: TileItem[] = [
+  { id: 't1', label: 'C', value: 'C' },
+  { id: 't2', label: 'A', value: 'A' },
+  { id: 't3', label: 'T', value: 'T' },
+];
+
+const answerZones: AnswerZone[] = [
+  {
+    id: 'z0',
+    index: 0,
+    expectedValue: 'C',
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  },
+  {
+    id: 'z1',
+    index: 1,
+    expectedValue: 'A',
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  },
+  {
+    id: 'z2',
+    index: 2,
+    expectedValue: 'T',
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  },
+];
+
+beforeEach(() => {
+  clearPendingPlacements();
+});
+
+function createWrapper(config: AnswerGameConfig) {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <AnswerGameProvider config={config}>{children}</AnswerGameProvider>
+  );
+  Wrapper.displayName = 'AutoNextSlotTestWrapper';
+  return Wrapper;
+}
+
+function useHarness(
+  tiles: TileItem[] = tileItems,
+  zones: AnswerZone[] = answerZones,
+) {
+  const dispatch = useAnswerGameDispatch();
+  const state = useAnswerGameContext();
+  if (state.zones.length === 0)
+    dispatch({ type: 'INIT_ROUND', tiles, zones });
+  const { placeInNextSlot } = useAutoNextSlot();
+  return { state, placeInNextSlot };
+}
+
+describe('useAutoNextSlot', () => {
+  describe('basic placement', () => {
+    it('places correct tile in activeSlotIndex zone', () => {
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
+
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t1');
+      });
+
+      expect(res).toEqual({ placed: true, zoneIndex: 0, rejected: false });
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+    });
+
+    it('advances activeSlotIndex after correct placement', () => {
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current.state.activeSlotIndex).toBe(0);
+      act(() => result.current.placeInNextSlot('t1'));
+      expect(result.current.state.activeSlotIndex).toBe(1);
+    });
+
+    it('skips locked zones when finding the next available slot', () => {
+      const lockedZones: AnswerZone[] = [
+        { ...answerZones[0], isLocked: true },
+        answerZones[1],
+        answerZones[2],
+      ];
+
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(
+        () => useHarness(tileItems, lockedZones),
+        { wrapper: Wrapper },
+      );
+
+      act(() => result.current.placeInNextSlot('t2'));
+      expect(result.current.state.zones[0]?.placedTileId).toBeNull();
+      expect(result.current.state.zones[1]?.placedTileId).toBe('t2');
+    });
+  });
+
+  describe('pre-validation', () => {
+    it('rejects wrong tile in lock-auto-eject mode', () => {
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
+
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t2');
+      });
+
+      expect(res).toEqual({ placed: false, zoneIndex: 0, rejected: true });
+      expect(result.current.state.zones[0]?.placedTileId).toBeNull();
+    });
+
+    it('rejects wrong tile in reject mode', () => {
+      const rejectConfig: AnswerGameConfig = {
+        ...gameConfig,
+        wrongTileBehavior: 'reject',
+      };
+      const Wrapper = createWrapper(rejectConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
+
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t2');
+      });
+
+      expect(res).toEqual({ placed: false, zoneIndex: 0, rejected: true });
+      expect(result.current.state.zones[0]?.placedTileId).toBeNull();
+    });
+
+    it('allows wrong tile through in lock-manual mode (no pre-validation)', () => {
+      const manualConfig: AnswerGameConfig = {
+        ...gameConfig,
+        wrongTileBehavior: 'lock-manual',
+      };
+      const Wrapper = createWrapper(manualConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
+
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t2');
+      });
+
+      expect(res).toEqual({ placed: true, zoneIndex: 0, rejected: false });
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t2');
+    });
+  });
+
+  describe('pending placements queue', () => {
+    it('prevents double-placement on rapid taps (stale closure fix)', () => {
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
+
+      act(() => {
+        result.current.placeInNextSlot('t1');
+        result.current.placeInNextSlot('t2');
+      });
+
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+      expect(result.current.state.zones[1]?.placedTileId).toBe('t2');
+    });
+
+    it('handles three rapid correct taps', () => {
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
+
+      act(() => {
+        result.current.placeInNextSlot('t1');
+        result.current.placeInNextSlot('t2');
+        result.current.placeInNextSlot('t3');
+      });
+
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+      expect(result.current.state.zones[1]?.placedTileId).toBe('t2');
+      expect(result.current.state.zones[2]?.placedTileId).toBe('t3');
+    });
+  });
+
+  describe('wrap-around', () => {
+    it('wraps around to fill earlier empty slots', () => {
+      const threeZones: AnswerZone[] = [
+        { ...answerZones[0], placedTileId: null },
+        { ...answerZones[1], placedTileId: 't2' },
+        { ...answerZones[2], placedTileId: null },
+      ];
+
+      const Wrapper = createWrapper(gameConfig);
+
+      function useHarnessWrap() {
+        const dispatch = useAnswerGameDispatch();
+        const state = useAnswerGameContext();
+        if (state.zones.length === 0) {
+          dispatch({
+            type: 'INIT_ROUND',
+            tiles: tileItems,
+            zones: threeZones,
+          });
+          dispatch({ type: 'PLACE_TILE', tileId: 't2', zoneIndex: 1 });
+        }
+        const { placeInNextSlot } = useAutoNextSlot();
+        return { state, placeInNextSlot };
+      }
+
+      const { result } = renderHook(() => useHarnessWrap(), {
+        wrapper: Wrapper,
+      });
+
+      act(() => result.current.placeInNextSlot('t3'));
+      act(() => result.current.placeInNextSlot('t1'));
+
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+    });
+  });
+
+  describe('isWrong guard removal', () => {
+    it('places correct tile in next slot even when active slot is wrong (lock-auto-eject drag)', () => {
+      const wrongZones: AnswerZone[] = [
+        {
+          ...answerZones[0],
+          placedTileId: 'tX',
+          isWrong: true,
+          isLocked: true,
+        },
+        answerZones[1],
+        answerZones[2],
+      ];
+
+      const tilesWithX: TileItem[] = [
+        ...tileItems,
+        { id: 'tX', label: 'X', value: 'X' },
+      ];
+
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(
+        () => useHarness(tilesWithX, wrongZones),
+        { wrapper: Wrapper },
+      );
+
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t2');
+      });
+
+      expect(res).toEqual({ placed: true, zoneIndex: 1, rejected: false });
+      expect(result.current.state.zones[1]?.placedTileId).toBe('t2');
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/answer-game/useAutoNextSlot.test.tsx`
+
+Expected: FAIL — `clearPendingPlacements` not exported, `PlaceResult` not exported, `placeInNextSlot` returns `void`, no pre-validation, no pending queue.
+
+- [ ] **Step 3: Implement the refactored useAutoNextSlot**
+
+Replace the entire content of `src/components/answer-game/useAutoNextSlot.ts`:
+
+```typescript
+import { useCallback, useEffect } from 'react';
+import { useAnswerGameContext } from './useAnswerGameContext';
+import { useTileEvaluation } from './useTileEvaluation';
+
+export interface PlaceResult {
+  placed: boolean;
+  zoneIndex: number;
+  rejected: boolean;
+}
+
+export interface AutoNextSlot {
+  placeInNextSlot: (tileId: string) => PlaceResult;
+}
+
+let pendingPlacements: Array<{ tileId: string; zoneIndex: number }> =
+  [];
+
+export const clearPendingPlacements = (): void => {
+  pendingPlacements = [];
+};
+
+export const useAutoNextSlot = (): AutoNextSlot => {
+  const state = useAnswerGameContext();
+  const { zones, activeSlotIndex, config, allTiles, roundIndex } =
+    state;
+  const { placeTile } = useTileEvaluation();
+
+  useEffect(() => {
+    clearPendingPlacements();
+  }, [roundIndex]);
+
+  const placeInNextSlot = useCallback(
+    (tileId: string): PlaceResult => {
+      pendingPlacements = pendingPlacements.filter(
+        (entry) =>
+          zones[entry.zoneIndex]?.placedTileId !== entry.tileId,
+      );
+
+      const claimedZones = new Set(
+        pendingPlacements.map((e) => e.zoneIndex),
+      );
+
+      const isAvailable = (i: number) =>
+        zones[i] &&
+        !zones[i].placedTileId &&
+        !zones[i].isLocked &&
+        !claimedZones.has(i);
+
+      let targetIndex = -1;
+      for (let i = activeSlotIndex; i < zones.length; i++) {
+        if (isAvailable(i)) {
+          targetIndex = i;
+          break;
+        }
+      }
+      if (targetIndex === -1) {
+        for (let i = 0; i < activeSlotIndex; i++) {
+          if (isAvailable(i)) {
+            targetIndex = i;
+            break;
+          }
+        }
+      }
+
+      if (targetIndex === -1) {
+        return { placed: false, zoneIndex: -1, rejected: false };
+      }
+
+      if (config.wrongTileBehavior !== 'lock-manual') {
+        const tile = allTiles.find((t) => t.id === tileId);
+        if (tile && tile.value !== zones[targetIndex].expectedValue) {
+          return {
+            placed: false,
+            zoneIndex: targetIndex,
+            rejected: true,
+          };
+        }
+      }
+
+      pendingPlacements.push({ tileId, zoneIndex: targetIndex });
+      placeTile(tileId, targetIndex);
+      return { placed: true, zoneIndex: targetIndex, rejected: false };
+    },
+    [
+      zones,
+      activeSlotIndex,
+      config.wrongTileBehavior,
+      allTiles,
+      placeTile,
+    ],
+  );
+
+  return { placeInNextSlot };
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/answer-game/useAutoNextSlot.test.tsx`
+
+Expected: PASS
+
+- [ ] **Step 5: Run full unit tests to check for regressions**
+
+Run: `npx vitest run src/components/answer-game/`
+
+Expected: PASS (some `useDraggableTile` tests may need updates due to changed `placeInNextSlot` return type — address in Task 5).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/answer-game/useAutoNextSlot.ts src/components/answer-game/useAutoNextSlot.test.tsx
+git commit -m "feat(answer-game): add pending-placements queue and pre-validation to useAutoNextSlot (#276)"
+```
+
+---
+
+## Task 5: Wire handleClick pre-validation and bank tile feedback
+
+**Files:**
+
+- Modify: `src/components/answer-game/useDraggableTile.ts:1-143`
+- Test: `src/components/answer-game/useDraggableTile.test.tsx`
+
+This task wires the `PlaceResult` from `placeInNextSlot` into `handleClick`:
+
+- Throttle re-taps during shake (`animate-shake` check)
+- On rejection: shake + wrong-state inline styles on bank tile, wrong sound, `REJECT_TAP` dispatch, `game:evaluate` emit
+- On placement: no change (already handled by `placeTile` inside `placeInNextSlot`)
+
+- [ ] **Step 1: Update useDraggableTile mock and write failing tests**
+
+In `useDraggableTile.test.tsx`, update the `useAutoNextSlot` mock to return a `PlaceResult`:
+
+```typescript
+const mockPlaceInNextSlot = vi.fn().mockReturnValue({
+  placed: true,
+  zoneIndex: 0,
+  rejected: false,
+});
+```
+
+Add these imports at the top of the file:
+
+```typescript
+import { playSound } from '@/lib/audio/AudioFeedback';
+```
+
+Add mock for audio (after existing mocks):
+
+```typescript
+vi.mock('@/lib/audio/AudioFeedback', () => ({
+  playSound: vi.fn(),
+}));
+```
+
+Add mock for slot-animations:
+
+```typescript
+const mockTriggerShake = vi.fn();
+vi.mock('./Slot/slot-animations', () => ({
+  triggerShake: (...args: unknown[]) => mockTriggerShake(...args),
+}));
+```
+
+Add mock for skin:
+
+```typescript
+vi.mock('@/lib/skin', () => ({
+  resolveSkin: () => ({ suppressDefaultSounds: false }),
+}));
+```
+
+Update the mock for `getGameEventBus` to capture emits:
+
+```typescript
+const mockEmit = vi.fn();
+vi.mock('@/lib/game-event-bus', () => ({
+  getGameEventBus: () => ({ emit: mockEmit, subscribe: vi.fn() }),
+}));
+```
+
+Add `beforeEach` to clear mocks:
+
+```typescript
+beforeEach(() => {
+  mockPlaceInNextSlot.mockClear().mockReturnValue({
+    placed: true,
+    zoneIndex: 0,
+    rejected: false,
+  });
+  mockSpeakTile.mockClear();
+  mockDispatch.mockClear();
+  mockEmit.mockClear();
+  mockTriggerShake.mockClear();
+  vi.mocked(playSound).mockClear();
+});
+```
+
+Update `useAnswerGameContext` mock to include `allTiles` and zone data for pre-validation testing:
+
+```typescript
+vi.mock('./useAnswerGameContext', () => ({
+  useAnswerGameContext: () => ({
+    config: {
+      inputMethod: 'drag',
+      ttsEnabled: true,
+      totalRounds: 1,
+      gameId: 'test',
+      wrongTileBehavior: 'lock-auto-eject',
+      tileBankMode: 'exact',
+    },
+    zones: [
+      {
+        id: 'z0',
+        index: 0,
+        expectedValue: 'C',
+        placedTileId: null,
+        isWrong: false,
+        isLocked: false,
+      },
+    ],
+    allTiles: [
+      { id: 't1', label: 'C', value: 'C' },
+      { id: 't2', label: 'X', value: 'X' },
+    ],
+    bankTileIds: ['t1', 't2'],
+    activeSlotIndex: 0,
+    roundIndex: 0,
+    retryCount: 0,
+    phase: 'playing',
+    dragActiveTileId: null,
+  }),
+}));
+```
+
+Add these tests:
+
+```typescript
+describe('handleClick reject path', () => {
+  it('does not speak or place when tile is already shaking', () => {
+    const tile = { id: 't1', label: 'C', value: 'C' };
+    const { result } = renderHook(() => useDraggableTile(tile));
+
+    // Simulate shake in progress
+    const button = document.createElement('button');
+    button.classList.add('animate-shake');
+    Object.defineProperty(result.current.ref, 'current', {
+      value: button,
+      writable: true,
+    });
+
+    act(() => result.current.handleClick());
+
+    expect(mockSpeakTile).not.toHaveBeenCalled();
+    expect(mockPlaceInNextSlot).not.toHaveBeenCalled();
+  });
+
+  it('dispatches REJECT_TAP and plays wrong sound on rejection', () => {
+    mockPlaceInNextSlot.mockReturnValue({
+      placed: false,
+      zoneIndex: 0,
+      rejected: true,
+    });
+
+    const tile = { id: 't2', label: 'X', value: 'X' };
+    const { result } = renderHook(() => useDraggableTile(tile));
+
+    const button = document.createElement('button');
+    Object.defineProperty(result.current.ref, 'current', {
+      value: button,
+      writable: true,
+    });
+
+    act(() => result.current.handleClick());
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'REJECT_TAP',
+      tileId: 't2',
+      zoneIndex: 0,
+    });
+    expect(playSound).toHaveBeenCalledWith('wrong', 0.8);
+  });
+
+  it('emits game:evaluate with expected field on rejection', () => {
+    mockPlaceInNextSlot.mockReturnValue({
+      placed: false,
+      zoneIndex: 0,
+      rejected: true,
+    });
+
+    const tile = { id: 't2', label: 'X', value: 'X' };
+    const { result } = renderHook(() => useDraggableTile(tile));
+
+    const button = document.createElement('button');
+    Object.defineProperty(result.current.ref, 'current', {
+      value: button,
+      writable: true,
+    });
+
+    act(() => result.current.handleClick());
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'game:evaluate',
+        answer: 't2',
+        correct: false,
+        expected: 'C',
+        zoneIndex: 0,
+      }),
+    );
+  });
+
+  it('does not dispatch REJECT_TAP on successful placement', () => {
+    const tile = { id: 't1', label: 'C', value: 'C' };
+    const { result } = renderHook(() => useDraggableTile(tile));
+
+    act(() => result.current.handleClick());
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'REJECT_TAP' }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/answer-game/useDraggableTile.test.tsx`
+
+Expected: FAIL — handleClick doesn't check `PlaceResult`, no shake, no `REJECT_TAP` dispatch.
+
+- [ ] **Step 3: Implement handleClick changes**
+
+In `useDraggableTile.ts`, add imports:
+
+```typescript
+import { playSound } from '@/lib/audio/AudioFeedback';
+import { triggerShake } from './Slot/slot-animations';
+import { resolveSkin } from '@/lib/skin';
+```
+
+Inside the hook body, add skin resolution (after the existing `const { placeTile } = useTileEvaluation();` line):
+
+```typescript
+const skin = resolveSkin(state.config.gameId, state.config.skin);
+```
+
+Replace the `handleClick` function (lines 129-132):
+
+```typescript
+const handleClick = () => {
+  if (ref.current?.classList.contains('animate-shake')) return;
+
+  speakTile(tile.label);
+  const result = placeInNextSlot(tile.id);
+
+  if (result.rejected && ref.current) {
+    triggerShake(ref.current);
+    const el = ref.current;
+    el.style.background = 'var(--skin-wrong-bg)';
+    el.style.borderColor = 'var(--skin-wrong-border)';
+    el.addEventListener(
+      'animationend',
+      () => {
+        el.style.background = '';
+        el.style.borderColor = '';
+      },
+      { once: true },
+    );
+
+    if (!skin.suppressDefaultSounds) {
+      playSound('wrong', 0.8);
+    }
+
+    dispatch({
+      type: 'REJECT_TAP',
+      tileId: tile.id,
+      zoneIndex: result.zoneIndex,
+    });
+
+    getGameEventBus().emit({
+      type: 'game:evaluate',
+      gameId: state.config.gameId,
+      sessionId: '',
+      profileId: '',
+      timestamp: Date.now(),
+      roundIndex: state.roundIndex,
+      answer: tile.id,
+      correct: false,
+      nearMiss: false,
+      zoneIndex: result.zoneIndex,
+      expected: state.zones[result.zoneIndex]?.expectedValue ?? '',
+    });
+  }
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/answer-game/useDraggableTile.test.tsx`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/answer-game/useDraggableTile.ts src/components/answer-game/useDraggableTile.test.tsx
+git commit -m "feat(answer-game): wire bank tile pre-validation with shake and reject feedback (#276)"
+```
+
+---
+
+## Task 6: Add touch-drag reject feedback
+
+**Files:**
+
+- Modify: `src/components/answer-game/useDraggableTile.ts:105-108`
+- Test: `src/components/answer-game/useDraggableTile.test.tsx`
+
+When a tile is dropped onto a slot via touch drag and rejected (reject mode + wrong), shake the bank tile after it reappears.
+
+- [ ] **Step 1: Write failing test**
+
+First, add a mock for `useTouchDrag` at module scope (alongside the other mocks
+at the top of `useDraggableTile.test.tsx`). This captures the `onDrop` callback
+so we can invoke it directly:
+
+```typescript
+let capturedTouchDragOptions: Record<string, unknown> = {};
+vi.mock('./useTouchDrag', () => ({
+  useTouchDrag: (options: Record<string, unknown>) => {
+    capturedTouchDragOptions = options;
+    return {
+      onPointerDown: vi.fn(),
+      onPointerMove: vi.fn(),
+      onPointerUp: vi.fn(),
+      onPointerCancel: vi.fn(),
+    };
+  },
+}));
+```
+
+Then update the `useAnswerGameContext` mock to accept a config override for
+`wrongTileBehavior`. The simplest way: change the existing mock to use a
+module-scope variable:
+
+```typescript
+let mockWrongTileBehavior = 'lock-auto-eject';
+
+vi.mock('./useAnswerGameContext', () => ({
+  useAnswerGameContext: () => ({
+    config: {
+      inputMethod: 'drag',
+      ttsEnabled: true,
+      totalRounds: 1,
+      gameId: 'test',
+      wrongTileBehavior: mockWrongTileBehavior,
+      tileBankMode: 'exact',
+    },
+    zones: [
+      {
+        id: 'z0',
+        index: 0,
+        expectedValue: 'C',
+        placedTileId: null,
+        isWrong: false,
+        isLocked: false,
+      },
+    ],
+    allTiles: [
+      { id: 't1', label: 'C', value: 'C' },
+      { id: 't2', label: 'X', value: 'X' },
+    ],
+    bankTileIds: ['t1', 't2'],
+    activeSlotIndex: 0,
+    roundIndex: 0,
+    retryCount: 0,
+    phase: 'playing',
+    dragActiveTileId: null,
+  }),
+}));
+```
+
+Add the drag-reject test:
+
+```typescript
+describe('touch drag reject path', () => {
+  it('calls triggerShake on bank tile when drag-drop is rejected in reject mode', () => {
+    mockWrongTileBehavior = 'reject';
+    mockPlaceTile.mockReturnValue({ correct: false });
+
+    const tile = { id: 't2', label: 'X', value: 'X' };
+    const { result } = renderHook(() => useDraggableTile(tile));
+
+    const button = document.createElement('button');
+    Object.defineProperty(result.current.ref, 'current', {
+      value: button,
+      writable: true,
+    });
+
+    const onDrop = capturedTouchDragOptions.onDrop as (
+      tileId: string,
+      zoneIndex: number,
+    ) => void;
+    act(() => onDrop('t2', 0));
+
+    expect(mockTriggerShake).toHaveBeenCalledWith(button);
+
+    mockWrongTileBehavior = 'lock-auto-eject';
+  });
+
+  it('does not shake when wrong tile is dropped in lock-auto-eject mode', () => {
+    mockPlaceTile.mockReturnValue({ correct: false });
+
+    const tile = { id: 't2', label: 'X', value: 'X' };
+    renderHook(() => useDraggableTile(tile));
+
+    const onDrop = capturedTouchDragOptions.onDrop as (
+      tileId: string,
+      zoneIndex: number,
+    ) => void;
+    act(() => onDrop('t2', 0));
+
+    expect(mockTriggerShake).not.toHaveBeenCalled();
+  });
+});
+```
+
+> **Note:** The `capturedTouchDragOptions` approach captures the callbacks
+> `useDraggableTile` passes to `useTouchDrag`. The `stateRef` used in
+> `onDrop` (line 29 of useDraggableTile.ts: `const stateRef = useRef(state)`)
+> ensures `wrongTileBehavior` reads the current value even inside a stale
+> closure. The `requestAnimationFrame` wrapper in the implementation defers
+> the shake until after React re-renders the tile at full opacity.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/answer-game/useDraggableTile.test.tsx`
+
+Expected: FAIL — onDrop doesn't check placeTile result.
+
+- [ ] **Step 3: Implement drag-reject feedback**
+
+In `useDraggableTile.ts`, update the touch drag `onDrop` handler (lines 105-108):
+
+```typescript
+      onDrop: (droppedTileId, zoneIndex) => {
+        dispatch({ type: 'SET_DRAG_ACTIVE', tileId: null });
+        const { correct } = placeTile(droppedTileId, zoneIndex);
+        if (
+          !correct &&
+          stateRef.current.config.wrongTileBehavior === 'reject' &&
+          ref.current
+        ) {
+          requestAnimationFrame(() => {
+            if (ref.current) {
+              triggerShake(ref.current);
+              ref.current.style.background = 'var(--skin-wrong-bg)';
+              ref.current.style.borderColor = 'var(--skin-wrong-border)';
+              ref.current.addEventListener(
+                'animationend',
+                () => {
+                  if (ref.current) {
+                    ref.current.style.background = '';
+                    ref.current.style.borderColor = '';
+                  }
+                },
+                { once: true },
+              );
+            }
+          });
+        }
+      },
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/answer-game/useDraggableTile.test.tsx`
+
+Expected: PASS
+
+- [ ] **Step 5: Run full answer-game test suite**
+
+Run: `npx vitest run src/components/answer-game/`
+
+Expected: PASS
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `yarn typecheck`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/answer-game/useDraggableTile.ts src/components/answer-game/useDraggableTile.test.tsx
+git commit -m "feat(answer-game): add touch-drag reject feedback with bank tile shake (#276)"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npx vitest run`
+
+Expected: PASS — no regressions.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `yarn typecheck`
+
+Expected: PASS
+
+- [ ] **Step 3: Run linters**
+
+Run: `yarn fix:md && yarn lint:md`
+
+Expected: PASS
+
+- [ ] **Step 4: Manual verification checklist**
+
+Verify against the spec's behavior matrix:
+
+| Mode              | Input                      | Expected behavior                                   |
+| ----------------- | -------------------------- | --------------------------------------------------- |
+| `lock-auto-eject` | Tap wrong tile             | Tile shakes in bank, wrong sound, no slot placement |
+| `lock-auto-eject` | Tap correct tile           | Tile placed in slot, correct sound                  |
+| `lock-auto-eject` | Rapid correct taps (C-A-T) | All three placed correctly, no false bounces        |
+| `lock-manual`     | Tap wrong tile             | Tile goes to slot (unchanged behavior)              |
+| `reject`          | Tap wrong tile             | Tile shakes in bank, wrong sound                    |
+| `reject`          | Drag wrong tile            | Tile returns to bank, wrong sound, shake            |
+| `lock-auto-eject` | Drag wrong tile            | Tile lands in slot, auto-ejects (unchanged)         |
+
+- [ ] **Step 5: Push and verify CI**
+
+Run: `git push`
+
+Expected: CI passes all required checks.

--- a/docs/superpowers/plans/2026-05-01-fast-tap-queue.md
+++ b/docs/superpowers/plans/2026-05-01-fast-tap-queue.md
@@ -76,7 +76,7 @@ export interface GameEvaluateEvent extends BaseGameEvent {
   /** Index of the slot the tile was placed into. */
   zoneIndex: number;
   /** Expected value for the target slot — provides confusion pair for SRS. */
-  expected: string;
+  expected?: string;
 }
 ```
 
@@ -84,7 +84,7 @@ export interface GameEvaluateEvent extends BaseGameEvent {
 
 Run: `yarn typecheck`
 
-Expected: Type errors in files that emit `game:evaluate` without `expected` (useTileEvaluation.ts, possibly useDraggableTile.ts). This is expected — we fix those emits in Tasks 3 and 5.
+Expected: PASS — `expected` is optional, so existing emit sites compile without changes. Tasks 3 and 5 add the field at all emit sites for completeness.
 
 - [ ] **Step 4: Commit**
 
@@ -372,6 +372,8 @@ const placeTile = useCallback(
       playSound(correct ? 'correct' : 'wrong', 0.8);
     }
 
+    // Drag path only — tap/click rejects are handled in useDraggableTile.handleClick
+    // (placeInNextSlot pre-validates and never calls placeTile on rejection)
     if (!correct && state.config.wrongTileBehavior === 'reject') {
       dispatch({ type: 'REJECT_TAP', tileId, zoneIndex });
     } else {
@@ -452,6 +454,13 @@ This is the core fix. Changes:
 4. Drain logic removes entries the reducer has applied
 5. Clear on round transitions via `useEffect`
 6. Remove `isWrong` early-return guard (superseded by pre-validation)
+
+**UX change note:** For `lock-auto-eject` tap, wrong tiles now shake in the bank
+instead of traveling to the slot and bouncing back. This is a deliberate change:
+bank-side rejection gives faster feedback (~0ms vs ~600ms round-trip animation),
+avoids the stale-closure race entirely for wrong tiles, and reduces visual noise.
+The slot-bounce UX is preserved for drag (user chose the slot explicitly) and
+for `lock-manual` (wrong tiles still land).
 
 - [ ] **Step 1: Write failing tests**
 
@@ -593,6 +602,10 @@ describe('useAutoNextSlot', () => {
   });
 
   describe('pre-validation', () => {
+    // Both lock-auto-eject and reject return rejected:true identically here.
+    // The behavioral difference (auto-eject vs reject-dispatch) occurs only
+    // when pre-validation passes and placeTile is called — which never happens
+    // on rejection since placeInNextSlot returns early.
     it('rejects wrong tile in lock-auto-eject mode', () => {
       const Wrapper = createWrapper(gameConfig);
       const { result } = renderHook(() => useHarness(), {
@@ -749,6 +762,60 @@ describe('useAutoNextSlot', () => {
       expect(res).toEqual({ placed: true, zoneIndex: 1, rejected: false });
       expect(result.current.state.zones[1]?.placedTileId).toBe('t2');
     });
+
+    it('treats isWrong slot with no placedTileId as available (pre-validation supersedes guard)', () => {
+      const wrongZones: AnswerZone[] = [
+        {
+          ...answerZones[0],
+          placedTileId: null,
+          isWrong: true,
+          isLocked: false,
+        },
+        answerZones[1],
+        answerZones[2],
+      ];
+
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(
+        () => useHarness(tileItems, wrongZones),
+        { wrapper: Wrapper },
+      );
+
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t1');
+      });
+
+      expect(res).toEqual({ placed: true, zoneIndex: 0, rejected: false });
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+    });
+  });
+
+  describe('no slot available', () => {
+    it('returns placed: false, zoneIndex: -1, rejected: false when all slots full', () => {
+      const fullZones: AnswerZone[] = answerZones.map((z) => ({
+        ...z,
+        placedTileId: 'tX',
+        isLocked: true,
+      }));
+
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(
+        () => useHarness(tileItems, fullZones),
+        { wrapper: Wrapper },
+      );
+
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t1');
+      });
+
+      expect(res).toEqual({
+        placed: false,
+        zoneIndex: -1,
+        rejected: false,
+      });
+    });
   });
 });
 ```
@@ -778,6 +845,8 @@ export interface AutoNextSlot {
   placeInNextSlot: (tileId: string) => PlaceResult;
 }
 
+// Module-scoped: shared across all hook instances on the page (single AnswerGame
+// instance assumed). For multi-instance support, lift to AnswerGameProvider context.
 let pendingPlacements: Array<{ tileId: string; zoneIndex: number }> =
   [];
 
@@ -793,7 +862,7 @@ export const useAutoNextSlot = (): AutoNextSlot => {
 
   useEffect(() => {
     clearPendingPlacements();
-  }, [roundIndex]);
+  }, [roundIndex, zones.length]);
 
   const placeInNextSlot = useCallback(
     (tileId: string): PlaceResult => {
@@ -844,7 +913,7 @@ export const useAutoNextSlot = (): AutoNextSlot => {
       }
 
       pendingPlacements.push({ tileId, zoneIndex: targetIndex });
-      placeTile(tileId, targetIndex);
+      void placeTile(tileId, targetIndex);
       return { placed: true, zoneIndex: targetIndex, rejected: false };
     },
     [
@@ -870,7 +939,17 @@ Expected: PASS
 
 Run: `npx vitest run src/components/answer-game/`
 
-Expected: PASS (some `useDraggableTile` tests may need updates due to changed `placeInNextSlot` return type — address in Task 5).
+Expected: PASS. If `useDraggableTile` tests fail because `placeInNextSlot` now returns `PlaceResult` instead of `void`, update the mock in `useDraggableTile.test.tsx` to return a default `PlaceResult`:
+
+```typescript
+const mockPlaceInNextSlot = vi.fn().mockReturnValue({
+  placed: true,
+  zoneIndex: 0,
+  rejected: false,
+});
+```
+
+Re-run and confirm PASS before proceeding.
 
 - [ ] **Step 6: Commit**
 
@@ -959,13 +1038,18 @@ beforeEach(() => {
   mockDispatch.mockClear();
   mockEmit.mockClear();
   mockTriggerShake.mockClear();
+  mockPlaceTile.mockReset();
   vi.mocked(playSound).mockClear();
+  mockWrongTileBehavior = 'lock-auto-eject';
 });
 ```
 
-Update `useAnswerGameContext` mock to include `allTiles` and zone data for pre-validation testing:
+Update `useAnswerGameContext` mock to include `allTiles`, zone data, and a
+module-scope `mockWrongTileBehavior` variable (forward-compatible with Task 6):
 
 ```typescript
+let mockWrongTileBehavior = 'lock-auto-eject';
+
 vi.mock('./useAnswerGameContext', () => ({
   useAnswerGameContext: () => ({
     config: {
@@ -973,7 +1057,7 @@ vi.mock('./useAnswerGameContext', () => ({
       ttsEnabled: true,
       totalRounds: 1,
       gameId: 'test',
-      wrongTileBehavior: 'lock-auto-eject',
+      wrongTileBehavior: mockWrongTileBehavior,
       tileBankMode: 'exact',
     },
     zones: [
@@ -1010,7 +1094,7 @@ describe('handleClick reject path', () => {
 
     // Simulate shake in progress
     const button = document.createElement('button');
-    button.classList.add('animate-shake');
+    button.dataset.shaking = 'true';
     Object.defineProperty(result.current.ref, 'current', {
       value: button,
       writable: true,
@@ -1116,21 +1200,23 @@ Replace the `handleClick` function (lines 129-132):
 
 ```typescript
 const handleClick = () => {
-  if (ref.current?.classList.contains('animate-shake')) return;
+  if (ref.current?.dataset.shaking) return;
 
   speakTile(tile.label);
   const result = placeInNextSlot(tile.id);
 
   if (result.rejected && ref.current) {
+    ref.current.dataset.shaking = 'true';
     triggerShake(ref.current);
     const el = ref.current;
-    el.style.background = 'var(--skin-wrong-bg)';
-    el.style.borderColor = 'var(--skin-wrong-border)';
+    el.style.background = 'var(--skin-wrong-bg, #f87171)';
+    el.style.borderColor = 'var(--skin-wrong-border, #ef4444)';
     el.addEventListener(
       'animationend',
       () => {
         el.style.background = '';
         el.style.borderColor = '';
+        delete el.dataset.shaking;
       },
       { once: true },
     );
@@ -1139,6 +1225,7 @@ const handleClick = () => {
       playSound('wrong', 0.8);
     }
 
+    // Tap/click path only — drag rejects are handled in useTileEvaluation.placeTile
     dispatch({
       type: 'REJECT_TAP',
       tileId: tile.id,
@@ -1207,46 +1294,9 @@ vi.mock('./useTouchDrag', () => ({
 }));
 ```
 
-Then update the `useAnswerGameContext` mock to accept a config override for
-`wrongTileBehavior`. The simplest way: change the existing mock to use a
-module-scope variable:
-
-```typescript
-let mockWrongTileBehavior = 'lock-auto-eject';
-
-vi.mock('./useAnswerGameContext', () => ({
-  useAnswerGameContext: () => ({
-    config: {
-      inputMethod: 'drag',
-      ttsEnabled: true,
-      totalRounds: 1,
-      gameId: 'test',
-      wrongTileBehavior: mockWrongTileBehavior,
-      tileBankMode: 'exact',
-    },
-    zones: [
-      {
-        id: 'z0',
-        index: 0,
-        expectedValue: 'C',
-        placedTileId: null,
-        isWrong: false,
-        isLocked: false,
-      },
-    ],
-    allTiles: [
-      { id: 't1', label: 'C', value: 'C' },
-      { id: 't2', label: 'X', value: 'X' },
-    ],
-    bankTileIds: ['t1', 't2'],
-    activeSlotIndex: 0,
-    roundIndex: 0,
-    retryCount: 0,
-    phase: 'playing',
-    dragActiveTileId: null,
-  }),
-}));
-```
+The `useAnswerGameContext` mock with `mockWrongTileBehavior` variable was already
+set up in Task 5 — no changes needed here. The `beforeEach` resets it to
+`'lock-auto-eject'`, so tests can override per-describe.
 
 Add the drag-reject test:
 
@@ -1322,8 +1372,8 @@ In `useDraggableTile.ts`, update the touch drag `onDrop` handler (lines 105-108)
           requestAnimationFrame(() => {
             if (ref.current) {
               triggerShake(ref.current);
-              ref.current.style.background = 'var(--skin-wrong-bg)';
-              ref.current.style.borderColor = 'var(--skin-wrong-border)';
+              ref.current.style.background = 'var(--skin-wrong-bg, #f87171)';
+              ref.current.style.borderColor = 'var(--skin-wrong-border, #ef4444)';
               ref.current.addEventListener(
                 'animationend',
                 () => {
@@ -1406,3 +1456,32 @@ Verify against the spec's behavior matrix:
 Run: `git push`
 
 Expected: CI passes all required checks.
+
+---
+
+## Task 8: Update architecture docs
+
+**Files:**
+
+- Modify: `src/components/answer-game/AnswerGame/AnswerGame.flows.mdx`
+
+Per CLAUDE.md: "When modifying game state logic — any file in
+`src/components/answer-game/` — update the co-located `.mdx` docs in the
+same PR."
+
+- [ ] **Step 1: Run the architecture docs skill**
+
+Run: `/update-architecture-docs`
+
+Update `AnswerGame.flows.mdx` to reflect:
+
+1. The new `REJECT_TAP` branch in the tile placement flow
+2. The pre-validation path (bank-side reject for tap/click)
+3. The `pendingPlacements` write-ahead log in the slot-targeting sequence
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/answer-game/AnswerGame/AnswerGame.flows.mdx
+git commit -m "docs(answer-game): update architecture docs for pre-validation and REJECT_TAP (#276)"
+```

--- a/docs/superpowers/specs/2026-05-01-fast-tap-queue-design.md
+++ b/docs/superpowers/specs/2026-05-01-fast-tap-queue-design.md
@@ -1,0 +1,126 @@
+# Fast-Tap Queue & Pre-Validation Design
+
+**Issue:** [#276](https://github.com/leocaseiro/base-skill/issues/276)
+**Date:** 2026-05-01
+
+## Problem
+
+On Android touch devices, tapping letter tiles quickly in the correct order
+(e.g. C-A-T within ~100ms) causes false error bounces. React's click handlers
+fire synchronously, but reducer dispatches are batched — the second tap reads
+stale `activeSlotIndex` and `zones` from its closure before the first
+`PLACE_TILE` has flushed.
+
+Mouse clicks cannot reproduce the bug (insufficient speed). Drag-and-drop is
+unaffected (user targets a specific slot).
+
+## Solution: Pre-Validation at the Bank + Input Buffer
+
+### Pre-validation on tap/click
+
+When a bank tile is tapped (not dragged), check the tile's value against the
+target slot's `expectedValue` **before** dispatching `PLACE_TILE`. Behavior
+varies by `wrongTileBehavior`:
+
+| `wrongTileBehavior` | Tap/click (new)                                          | Drag (unchanged)                                    |
+| ------------------- | -------------------------------------------------------- | --------------------------------------------------- |
+| `lock-auto-eject`   | Pre-validate at bank — wrong tile shakes in bank         | Lands in slot, auto-ejects after delay              |
+| `lock-manual`       | **No change** — wrong tile goes to slot, stays locked    | Same — no change                                    |
+| `reject`            | Shake + wrong sound + red flash on bank tile (all input) | Same shake + wrong sound + red flash (new feedback) |
+
+For `reject` mode, the feedback applies to **all input methods** (tap, click,
+and drag). The reducer already silently discards wrong tiles in this mode
+(lines 119-125 of `answer-game-reducer.ts`); we add visual+audio feedback
+where there was none.
+
+### Input buffer for rapid correct taps
+
+A ref-based pending-placements queue in `useAutoNextSlot` prevents the
+stale-closure race:
+
+- Maintain a `pendingPlacements` ref (`Array<{ tileId: string; zoneIndex: number }>`)
+- When `placeInNextSlot` is called, compute the target slot accounting for
+  both current `zones` state AND pending placements in the ref
+- Push the placement into the ref, then dispatch `PLACE_TILE`
+- On re-render (when `zones` updates), drain entries the reducer has applied
+
+The ref is synchronous (no React batching delay) — a write-ahead log that
+lets the second tap see slot 0 is claimed and correctly target slot 1. No
+`flushSync`, no debounce timers.
+
+### Bank tile shake animation
+
+`triggerShake` from `slot-animations.ts` is called on the bank tile's
+`<button>` ref when pre-validation rejects a tap. Same `animate-shake` CSS
+class (300ms oscillate-X) — no new keyframes.
+
+Flow in `useDraggableTile.handleClick`:
+
+1. `speakTile(tile.label)` (unchanged)
+2. Call pre-validation: check tile value against target slot's `expectedValue`
+3. Wrong + not `lock-manual`: `triggerShake(ref.current)`, play wrong sound,
+   dispatch `REJECT_TAP`
+4. Correct: push to pending ref, dispatch `PLACE_TILE`
+
+### New `REJECT_TAP` reducer action
+
+```typescript
+{
+  type: 'REJECT_TAP';
+  tileId: string;
+  zoneIndex: number;
+}
+```
+
+Increments `retryCount` only. No zone mutations, no bank changes, no
+`activeSlotIndex` movement.
+
+### Add `expected` field to `game:evaluate` events
+
+Add `expected: string` to the `GameEvaluateEvent` type, populated from
+`zone.expectedValue` at all emit sites:
+
+- `useTileEvaluation.placeTile`
+- `useTileEvaluation.typeTile`
+- Pre-validation reject path in `useDraggableTile.handleClick`
+
+Non-breaking additive change. No IndexedDB migration needed — `game:evaluate`
+events are in-memory only, and session history payloads use
+`additionalProperties: true`.
+
+Provides the confusion pair (`answer` vs `expected`) for future SRS (Anki
+algorithm) implementation.
+
+## Files to modify
+
+| File                                                 | Change                                                                                     |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `src/components/answer-game/types.ts`                | Add `REJECT_TAP` action                                                                    |
+| `src/types/game-events.ts`                           | Add `expected` field to `GameEvaluateEvent`                                                |
+| `src/components/answer-game/answer-game-reducer.ts`  | Handle `REJECT_TAP` (increment retryCount)                                                 |
+| `src/components/answer-game/useAutoNextSlot.ts`      | Add pending-placements ref, pre-validation logic                                           |
+| `src/components/answer-game/useDraggableTile.ts`     | Pre-validate on click, shake on reject, emit event                                         |
+| `src/components/answer-game/useTileEvaluation.ts`    | Add `expected` to all `game:evaluate` emits, add reject feedback for `reject` mode on drag |
+| `src/components/answer-game/Slot/useSlotBehavior.ts` | No changes expected                                                                        |
+
+## Scope
+
+### In scope
+
+- Pre-validate tile on tap/click path (`lock-auto-eject` and `reject` modes)
+- Full reject feedback (shake, sound, red flash) for `reject` mode on all
+  input methods
+- Ref-based pending queue to prevent stale-closure races on rapid correct taps
+- Shake animation on bank tile for wrong tap
+- `REJECT_TAP` reducer action
+- `expected` field on `GameEvaluateEvent` at all emit sites
+- Unit tests for new paths (pre-validation, queue, reducer action)
+
+### Not in scope
+
+- `lock-manual` tap behavior (unchanged — wrong tiles go to slot)
+- `lock-manual` sequential wrong tile blocking (separate bug, tracked in
+  [#280](https://github.com/leocaseiro/base-skill/issues/280))
+- Keyboard/type input path (`typeTile`)
+- SRS consumer implementation (future — this ensures the data shape is ready)
+- iOS-specific investigation (fix is platform-agnostic)

--- a/docs/superpowers/specs/2026-05-01-fast-tap-queue-design.md
+++ b/docs/superpowers/specs/2026-05-01-fast-tap-queue-design.md
@@ -19,7 +19,10 @@ unaffected (user targets a specific slot).
 ### Pre-validation on tap/click
 
 When a bank tile is tapped (not dragged), check the tile's value against the
-target slot's `expectedValue` **before** dispatching `PLACE_TILE`. Behavior
+target slot's `expectedValue` **before** dispatching `PLACE_TILE`.
+Pre-validation reads `expectedValue` from `zones[computedTargetIndex]`, where
+`computedTargetIndex` is the next empty slot accounting for pending placements
+in the ref (not the stale `activeSlotIndex` from the closure). Behavior
 varies by `wrongTileBehavior`:
 
 | `wrongTileBehavior` | Tap/click (new)                                          | Drag (unchanged)                                    |
@@ -35,14 +38,20 @@ where there was none.
 
 ### Input buffer for rapid correct taps
 
-A ref-based pending-placements queue in `useAutoNextSlot` prevents the
-stale-closure race:
+A shared ref-based pending-placements queue prevents the stale-closure race.
+The ref must be shared across all hook instances — either lifted to
+`AnswerGameProvider` context or stored at module scope — so that concurrent
+taps from different tile components see each other's pending claims.
 
 - Maintain a `pendingPlacements` ref (`Array<{ tileId: string; zoneIndex: number }>`)
 - When `placeInNextSlot` is called, compute the target slot accounting for
   both current `zones` state AND pending placements in the ref
 - Push the placement into the ref, then dispatch `PLACE_TILE`
-- On re-render (when `zones` updates), drain entries the reducer has applied
+- Drain condition: on re-render, remove entries where
+  `zones[entry.zoneIndex].placedTileId === entry.tileId` (the reducer has
+  applied them)
+- Clear the ref entirely on `INIT_ROUND`, `ADVANCE_ROUND`, and
+  `ADVANCE_LEVEL` to prevent stale entries across rounds
 
 The ref is synchronous (no React batching delay) — a write-ahead log that
 lets the second tap see slot 0 is claimed and correctly target slot 1. No
@@ -54,18 +63,36 @@ lets the second tap see slot 0 is claimed and correctly target slot 1. No
 `<button>` ref when pre-validation rejects a tap. Same `animate-shake` CSS
 class (300ms oscillate-X) — no new keyframes.
 
-For the red flash: briefly apply a CSS class (e.g. `is-wrong`) to the bank
-tile button for the duration of the shake animation (~300ms), using the
-existing `--skin-wrong-bg` or `--skin-wrong-border` CSS variables so it
-matches the slot wrong-tile styling. Remove the class on `animationend`.
+For the red flash: briefly apply a CSS class (`is-wrong`) to the bank tile
+button for the duration of the shake animation (~300ms), using the existing
+`--skin-wrong-bg` and `--skin-wrong-border` CSS variables so it matches the
+slot wrong-tile styling. Remove the class on `animationend`. Add the
+`.is-wrong` styles to the existing DraggableTile CSS module (co-located with
+the component) — no new stylesheet needed.
+
+**Throttle on rapid re-tap:** If the bank tile already has `animate-shake`
+(a shake is in progress), ignore subsequent taps. This prevents restarting
+the animation mid-cycle, which would orphan the `animationend` listener and
+leave the `is-wrong` class permanently applied.
+
+`useAutoNextSlot.placeInNextSlot` returns
+`{ placed: boolean; zoneIndex: number; rejected: boolean }` instead of
+`void`, so callers can branch on the outcome.
 
 Flow in `useDraggableTile.handleClick`:
 
 1. `speakTile(tile.label)` (unchanged)
-2. Call pre-validation: check tile value against target slot's `expectedValue`
-3. Wrong + not `lock-manual`: `triggerShake(ref.current)`, play wrong sound,
-   dispatch `REJECT_TAP`
-4. Correct: push to pending ref, dispatch `PLACE_TILE`
+2. Call `placeInNextSlot(tile.id)` — pre-validates tile value against
+   `zones[computedTargetIndex].expectedValue`
+3. If `rejected` and not `lock-manual`: `triggerShake(ref.current)`, play
+   wrong sound, dispatch `REJECT_TAP` with `zoneIndex` from the result
+4. If `placed`: tile is pushed to pending ref and `PLACE_TILE` dispatched
+
+Pre-validation supersedes the existing `isWrong` early-return guard
+(`if (zones[activeSlotIndex]?.isWrong) return`) for tap/click paths — the
+tile is checked at the bank before reaching the reducer. The `isWrong` guard
+remains active for drag and `lock-manual` paths where tiles still land in
+slots.
 
 ### New `REJECT_TAP` reducer action
 
@@ -98,15 +125,14 @@ algorithm) implementation.
 
 ## Files to modify
 
-| File                                                 | Change                                                                                     |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `src/components/answer-game/types.ts`                | Add `REJECT_TAP` action                                                                    |
-| `src/types/game-events.ts`                           | Add `expected` field to `GameEvaluateEvent`                                                |
-| `src/components/answer-game/answer-game-reducer.ts`  | Handle `REJECT_TAP` (increment retryCount)                                                 |
-| `src/components/answer-game/useAutoNextSlot.ts`      | Add pending-placements ref, pre-validation logic                                           |
-| `src/components/answer-game/useDraggableTile.ts`     | Pre-validate on click, shake on reject, emit event                                         |
-| `src/components/answer-game/useTileEvaluation.ts`    | Add `expected` to all `game:evaluate` emits, add reject feedback for `reject` mode on drag |
-| `src/components/answer-game/Slot/useSlotBehavior.ts` | No changes expected                                                                        |
+| File                                                | Change                                                                                     |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `src/components/answer-game/types.ts`               | Add `REJECT_TAP` action                                                                    |
+| `src/types/game-events.ts`                          | Add `expected` field to `GameEvaluateEvent`                                                |
+| `src/components/answer-game/answer-game-reducer.ts` | Handle `REJECT_TAP` (increment retryCount)                                                 |
+| `src/components/answer-game/useAutoNextSlot.ts`     | Add pending-placements ref, pre-validation logic                                           |
+| `src/components/answer-game/useDraggableTile.ts`    | Pre-validate on click, shake on reject, emit event                                         |
+| `src/components/answer-game/useTileEvaluation.ts`   | Add `expected` to all `game:evaluate` emits, add reject feedback for `reject` mode on drag |
 
 ## Scope
 
@@ -129,3 +155,10 @@ algorithm) implementation.
 - Keyboard/type input path (`typeTile`)
 - SRS consumer implementation (future — this ensures the data shape is ready)
 - iOS-specific investigation (fix is platform-agnostic)
+
+## Open Questions
+
+- **Screen reader announcements for rejected taps:** Should the shake +
+  red flash be accompanied by an `aria-live` announcement (e.g. "Wrong
+  tile") so screen reader users get equivalent feedback? Deferred from
+  doc review — not blocking for initial implementation.

--- a/docs/superpowers/specs/2026-05-01-fast-tap-queue-design.md
+++ b/docs/superpowers/specs/2026-05-01-fast-tap-queue-design.md
@@ -54,6 +54,11 @@ lets the second tap see slot 0 is claimed and correctly target slot 1. No
 `<button>` ref when pre-validation rejects a tap. Same `animate-shake` CSS
 class (300ms oscillate-X) — no new keyframes.
 
+For the red flash: briefly apply a CSS class (e.g. `is-wrong`) to the bank
+tile button for the duration of the shake animation (~300ms), using the
+existing `--skin-wrong-bg` or `--skin-wrong-border` CSS variables so it
+matches the slot wrong-tile styling. Remove the class on `animationend`.
+
 Flow in `useDraggableTile.handleClick`:
 
 1. `speakTile(tile.label)` (unchanged)


### PR DESCRIPTION
## Summary

- Design spec for fixing false error bounces on rapid Android taps (#276)
- 8-task TDD implementation plan with full code blocks
- Both documents doc-reviewed by 4 personas (coherence, feasibility, scope-guardian, adversarial)

### Spec review: 6 findings applied, 1 deferred (screen reader a11y)
### Plan review: 15 findings applied — key fixes:
- Made `expected` field optional on `GameEvaluateEvent` (P0: was breaking 4+ emit sites)
- Added `data-shaking` throttle attribute (TOCTOU fix for `triggerShake` remove-reflow-add)
- Added CSS variable fallback values for red flash visibility
- Added Task 8 for architecture docs update per CLAUDE.md
- Merged Task 5/6 test mocks into forward-compatible definition
- Added dispatch-ownership comments for REJECT_TAP invariant
- Added missing test cases (isWrong+null, no-slot-available)

## Test plan

- [ ] Execute the 8-task implementation plan via `superpowers:subagent-driven-development`
- [ ] Run full test suite (`npx vitest run`)
- [ ] Verify on Android device that rapid correct taps (C-A-T) no longer produce false bounces
- [ ] Verify behavior matrix in Task 7 Step 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)