### PR TITLE
feat(home): sort bookmarked game cards to the top

### DIFF
--- a/src/routes/$locale/_app/home-screen-card-order.test.ts
+++ b/src/routes/$locale/_app/home-screen-card-order.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { compareHomeScreenCardRows } from './home-screen-card-order';
+import type { HomeScreenCardSortRow } from './home-screen-card-order';
+
+const sortRows = (
+  rows: HomeScreenCardSortRow[],
+): HomeScreenCardSortRow[] => rows.toSorted(compareHomeScreenCardRows);
+
+describe('compareHomeScreenCardRows', () => {
+  it('places bookmarked defaults before non-bookmarked defaults (stable by catalog index)', () => {
+    const rows: HomeScreenCardSortRow[] = [
+      { kind: 'default', index: 0, bookmarked: false },
+      { kind: 'default', index: 1, bookmarked: true },
+      { kind: 'default', index: 2, bookmarked: false },
+    ];
+    expect(sortRows(rows)).toEqual([
+      { kind: 'default', index: 1, bookmarked: true },
+      { kind: 'default', index: 0, bookmarked: false },
+      { kind: 'default', index: 2, bookmarked: false },
+    ]);
+  });
+
+  it('places bookmarked customs before non-bookmarked customs', () => {
+    const rows: HomeScreenCardSortRow[] = [
+      { kind: 'custom', index: 1, bookmarked: false },
+      { kind: 'custom', index: 0, bookmarked: true },
+    ];
+    expect(sortRows(rows)).toEqual([
+      { kind: 'custom', index: 0, bookmarked: true },
+      { kind: 'custom', index: 1, bookmarked: false },
+    ]);
+  });
+
+  it('places all bookmarked cards before any non-bookmarked, keeping defaults before customs within each tier', () => {
+    const rows: HomeScreenCardSortRow[] = [
+      { kind: 'default', index: 0, bookmarked: false },
+      { kind: 'custom', index: 0, bookmarked: true },
+      { kind: 'default', index: 1, bookmarked: true },
+      { kind: 'custom', index: 1, bookmarked: false },
+    ];
+    expect(sortRows(rows)).toEqual([
+      { kind: 'default', index: 1, bookmarked: true },
+      { kind: 'custom', index: 0, bookmarked: true },
+      { kind: 'default', index: 0, bookmarked: false },
+      { kind: 'custom', index: 1, bookmarked: false },
+    ]);
+  });
+});

--- a/src/routes/$locale/_app/home-screen-card-order.ts
+++ b/src/routes/$locale/_app/home-screen-card-order.ts
@@ -1,0 +1,13 @@
+export type HomeScreenCardSortRow =
+  | { kind: 'default'; index: number; bookmarked: boolean }
+  | { kind: 'custom'; index: number; bookmarked: boolean };
+
+export const compareHomeScreenCardRows = (
+  a: HomeScreenCardSortRow,
+  b: HomeScreenCardSortRow,
+): number => {
+  const byBookmark = Number(b.bookmarked) - Number(a.bookmarked);
+  if (byBookmark !== 0) return byBookmark;
+  if (a.kind !== b.kind) return a.kind === 'default' ? -1 : 1;
+  return a.index - b.index;
+};

--- a/src/routes/$locale/_app/index.tsx
+++ b/src/routes/$locale/_app/index.tsx
@@ -5,6 +5,7 @@ import {
 } from '@tanstack/react-router';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { compareHomeScreenCardRows } from './home-screen-card-order';
 import type { Draft } from '@/components/answer-game/InstructionsOverlay/useConfigDraft';
 import type { CustomGameDoc } from '@/db/schemas/custom_games';
 import type { GameColorKey } from '@/lib/game-colors';
@@ -87,31 +88,67 @@ const HomeScreen = (): JSX.Element => {
     });
   };
 
-  const defaults = GAME_CATALOG.map((entry) => (
-    <GameCard
-      key={`default-${entry.id}`}
-      variant="default"
-      gameId={entry.id}
-      title={t(entry.titleKey)}
-      chips={configToChips(
-        entry.id,
-        lastSessionConfigs[entry.id] ?? {},
-      )}
-      onPlay={() => handlePlayDefault(entry.id)}
-      onOpenCog={() => void openDefaultCog(entry.id)}
-      isBookmarked={isBookmarked({
-        targetType: 'game',
-        targetId: entry.id,
-      })}
-      onToggleBookmark={() =>
-        void toggle({ targetType: 'game', targetId: entry.id })
-      }
-    />
-  ));
-  const customCards = customGames.flatMap((doc) => {
-    const entry = GAME_CATALOG.find((g) => g.id === doc.gameId);
-    if (!entry) return [];
-    return [
+  const unsortedCards = [
+    ...GAME_CATALOG.map((entry, index) => ({
+      row: {
+        kind: 'default' as const,
+        index,
+        bookmarked: isBookmarked({
+          targetType: 'game',
+          targetId: entry.id,
+        }),
+      },
+      kind: 'default' as const,
+      entry,
+    })),
+    ...customGames.flatMap((doc, listIndex) => {
+      const entry = GAME_CATALOG.find((g) => g.id === doc.gameId);
+      if (!entry) return [];
+      return [
+        {
+          row: {
+            kind: 'custom' as const,
+            index: listIndex,
+            bookmarked: isBookmarked({
+              targetType: 'customGame',
+              targetId: doc.id,
+            }),
+          },
+          kind: 'custom' as const,
+          doc,
+          entry,
+        },
+      ];
+    }),
+  ].toSorted((a, b) => compareHomeScreenCardRows(a.row, b.row));
+
+  const cards = unsortedCards.map((item) => {
+    if (item.kind === 'default') {
+      const { entry } = item;
+      return (
+        <GameCard
+          key={`default-${entry.id}`}
+          variant="default"
+          gameId={entry.id}
+          title={t(entry.titleKey)}
+          chips={configToChips(
+            entry.id,
+            lastSessionConfigs[entry.id] ?? {},
+          )}
+          onPlay={() => handlePlayDefault(entry.id)}
+          onOpenCog={() => void openDefaultCog(entry.id)}
+          isBookmarked={isBookmarked({
+            targetType: 'game',
+            targetId: entry.id,
+          })}
+          onToggleBookmark={() =>
+            void toggle({ targetType: 'game', targetId: entry.id })
+          }
+        />
+      );
+    }
+    const { doc, entry } = item;
+    return (
       <GameCard
         key={`custom-${doc.id}`}
         variant="customGame"
@@ -130,10 +167,9 @@ const HomeScreen = (): JSX.Element => {
         onToggleBookmark={() =>
           void toggle({ targetType: 'customGame', targetId: doc.id })
         }
-      />,
-    ];
+      />
+    );
   });
-  const cards = [...defaults, ...customCards];
 
   return (
     <div className="px-4 py-4">


### PR DESCRIPTION
## Summary

On the home screen, **bookmarked** games and custom saved configs now appear **before** non-bookmarked items. Within the same bookmark tier, **catalog defaults** still come before **custom games**, and order within each group stays stable (catalog index / custom list index).

## Implementation

- `compareHomeScreenCardRows` in `home-screen-card-order.ts`: sort by bookmarked first, then `default` before `custom`, then by index.
- `HomeScreen` builds a merged list of default + custom card descriptors, `toSorted`s with that comparator, then maps to `GameCard`s.
- Unit tests cover default-only, custom-only, and mixed bookmark/custom ordering.

## Verification

- Pre-push (related unit tests, typecheck, eslint, etc.) passed on push.
- Existing E2E bookmark flows should still behave; order in DOM changes for bookmarked items only.

Made with [Cursor](https://cursor.com)

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/283/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/283/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/283#issuecomment-)
<!-- /preview-urls -->
