### PR TITLE
feat(answer-game): fast-tap queue and bank pre-validation (#276)

### DIFF
--- a/src/components/answer-game/AnswerGame/AnswerGame.flows.mdx
+++ b/src/components/answer-game/AnswerGame/AnswerGame.flows.mdx
@@ -38,6 +38,18 @@ sequenceDiagram
   end
 ```
 
+### Tap / click via `useAutoNextSlot` (ordered slots)
+
+Bank **tap** (not drag) goes through `useDraggableTile.handleClick` → `useAutoNextSlot.placeInNextSlot`:
+
+1. **`pendingPlacements`** (module-scoped write-ahead log) records `{ tileId, zoneIndex }` before React applies `PLACE_TILE`, so rapid taps see prior claims synchronously.
+2. Entries are **drained** when `zones[entry.zoneIndex].placedTileId === entry.tileId`. The queue is **cleared** on round transitions (`roundIndex` / `zones.length` changes in `useEffect`).
+3. **Pre-validation**: for `reject` and `lock-auto-eject`, wrong tiles never call `placeTile`; `handleClick` applies bank shake + wrong sound + **`REJECT_TAP`** + `game:evaluate` (with `expected`). For **`lock-manual`**, there is no bank pre-validation — wrong tiles still flow through `PLACE_TILE` into the slot.
+
+### `REJECT_TAP`
+
+Reducer increments **`retryCount`** only (no zone or bank mutation). Dispatched from **`handleClick`** on bank-side rejection, and from **`useTileEvaluation.placeTile`** for drag-drop wrong tiles when `wrongTileBehavior === 'reject'`.
+
 ---
 
 ## 2. Wrong Tile Auto-Eject

--- a/src/components/answer-game/AnswerGame/AnswerGame.flows.mdx
+++ b/src/components/answer-game/AnswerGame/AnswerGame.flows.mdx
@@ -50,6 +50,8 @@ Bank **tap** (not drag) goes through `useDraggableTile.handleClick` → `useAuto
 
 Reducer increments **`retryCount`** only (no zone or bank mutation). Dispatched from **`handleClick`** on bank-side rejection, and from **`useTileEvaluation.placeTile`** for drag-drop wrong tiles when `wrongTileBehavior === 'reject'`.
 
+Wrong bank feedback (**shake + wrong colors**) uses **`flashBankTileRejectFeedback`** so the tile matches **`Slot`** wrong styling (`border-2` equivalent and **`--skin-wrong-*`** tokens). **Touch** drops invoke it from **`useDraggableTile`** (after `requestAnimationFrame`). **Pragmatic drag-and-drop** bank→slot drops invoke it from **`useSlotBehavior.handleDrop`** when `placeTile` returns incorrect in **`reject`** mode (same helper, resolved via **`data-tile-bank-hole`**).
+
 ---
 
 ## 2. Wrong Tile Auto-Eject

--- a/src/components/answer-game/Slot/useSlotBehavior.ts
+++ b/src/components/answer-game/Slot/useSlotBehavior.ts
@@ -1,5 +1,6 @@
 import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { useCallback, useEffect, useRef } from 'react';
+import { flashBankTileRejectFeedback } from '../bank-tile-reject-feedback';
 import { useAnswerGameContext } from '../useAnswerGameContext';
 import { useAnswerGameDispatch } from '../useAnswerGameDispatch';
 import { useSlotTileDrag } from '../useSlotTileDrag';
@@ -172,7 +173,15 @@ export const useSlotBehavior = (
         });
         return;
       }
-      placeTile(droppedTileId, targetZoneIndex);
+      const { correct } = placeTile(droppedTileId, targetZoneIndex);
+      if (
+        !correct &&
+        stateRef.current.config.wrongTileBehavior === 'reject'
+      ) {
+        requestAnimationFrame(() => {
+          flashBankTileRejectFeedback(droppedTileId);
+        });
+      }
     },
     [placeTile, zones, dispatch, allTiles],
   );

--- a/src/components/answer-game/answer-game-reducer.test.ts
+++ b/src/components/answer-game/answer-game-reducer.test.ts
@@ -851,4 +851,46 @@ describe('answerGameReducer', () => {
       expect(next.dragHoverBankTileId).toBeNull();
     });
   });
+
+  describe('REJECT_TAP', () => {
+    it('increments retryCount without mutating zones or bank', () => {
+      const state = answerGameReducer(makeInitialState(config), {
+        type: 'INIT_ROUND',
+        tiles,
+        zones,
+      });
+
+      const next = answerGameReducer(state, {
+        type: 'REJECT_TAP',
+        tileId: 't2',
+        zoneIndex: 0,
+      });
+
+      expect(next.retryCount).toBe(state.retryCount + 1);
+      expect(next.zones).toEqual(state.zones);
+      expect(next.bankTileIds).toEqual(state.bankTileIds);
+      expect(next.activeSlotIndex).toBe(state.activeSlotIndex);
+      expect(next.phase).toBe('playing');
+    });
+
+    it('preserves existing retryCount accumulation', () => {
+      let state = answerGameReducer(makeInitialState(config), {
+        type: 'INIT_ROUND',
+        tiles,
+        zones,
+      });
+      state = answerGameReducer(state, {
+        type: 'REJECT_TAP',
+        tileId: 't2',
+        zoneIndex: 0,
+      });
+      state = answerGameReducer(state, {
+        type: 'REJECT_TAP',
+        tileId: 't2',
+        zoneIndex: 0,
+      });
+
+      expect(state.retryCount).toBe(2);
+    });
+  });
 });

--- a/src/components/answer-game/answer-game-reducer.ts
+++ b/src/components/answer-game/answer-game-reducer.ts
@@ -103,6 +103,13 @@ export function answerGameReducer(
       };
     }
 
+    case 'REJECT_TAP': {
+      return {
+        ...state,
+        retryCount: state.retryCount + 1,
+      };
+    }
+
     case 'PLACE_TILE': {
       const tile = state.allTiles.find((t) => t.id === action.tileId);
       const zone = state.zones[action.zoneIndex];

--- a/src/components/answer-game/bank-tile-reject-feedback.test.ts
+++ b/src/components/answer-game/bank-tile-reject-feedback.test.ts
@@ -39,4 +39,28 @@ describe('flashBankTileRejectFeedback', () => {
     expect(mockTriggerShake).toHaveBeenCalledWith(standalone);
     expect(standalone.style.borderWidth).toBe('2px');
   });
+
+  it('restores React tile inline styles after animationend', () => {
+    document.body.innerHTML = `
+      <div class="relative">
+        <div data-tile-bank-hole="t1"></div>
+        <div class="absolute"><button type="button">A</button></div>
+      </div>
+    `;
+    const btn = document.querySelector('button')!;
+    const gradient =
+      'linear-gradient(180deg, transparent 70%, red 100%), blue';
+    const shadow =
+      'rgba(0,0,0,0.08) 0 0 0 1px, inset 0 -2px 1px rgba(0,0,0,0.08)';
+    btn.style.background = gradient;
+    btn.style.boxShadow = shadow;
+
+    flashBankTileRejectFeedback('t1');
+
+    btn.dispatchEvent(new Event('animationend'));
+
+    expect(btn.style.background).toBe(gradient);
+    expect(btn.style.boxShadow).toBe(shadow);
+    expect(btn.style.borderWidth).toBe('');
+  });
 });

--- a/src/components/answer-game/bank-tile-reject-feedback.test.ts
+++ b/src/components/answer-game/bank-tile-reject-feedback.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { flashBankTileRejectFeedback } from './bank-tile-reject-feedback';
+
+const mockTriggerShake = vi.fn();
+
+vi.mock('./Slot/slot-animations', () => ({
+  triggerShake: (...args: unknown[]) => mockTriggerShake(...args),
+}));
+
+describe('flashBankTileRejectFeedback', () => {
+  it('resolves bank button from data-tile-bank-hole and matches slot-style wrong treatment', () => {
+    document.body.innerHTML = `
+      <div class="relative">
+        <div data-tile-bank-hole="t1"></div>
+        <div class="absolute"><button type="button">A</button></div>
+      </div>
+    `;
+    const btn = document.querySelector('button');
+    expect(btn).not.toBeNull();
+
+    flashBankTileRejectFeedback('t1');
+
+    expect(mockTriggerShake).toHaveBeenCalledWith(btn);
+    expect(btn!.style.borderWidth).toBe('2px');
+    expect(btn!.style.borderStyle).toBe('solid');
+    expect(btn!.style.boxShadow).toBe('none');
+    expect(btn!.style.background).toBe('var(--skin-wrong-bg)');
+    expect(btn!.style.borderColor).toBe('var(--skin-wrong-border)');
+    expect(btn!.style.color).toBe('var(--skin-wrong-color)');
+  });
+
+  it('uses explicit element when provided', () => {
+    document.body.innerHTML = '';
+    const standalone = document.createElement('button');
+    document.body.append(standalone);
+
+    flashBankTileRejectFeedback('missing-id', { element: standalone });
+
+    expect(mockTriggerShake).toHaveBeenCalledWith(standalone);
+    expect(standalone.style.borderWidth).toBe('2px');
+  });
+});

--- a/src/components/answer-game/bank-tile-reject-feedback.ts
+++ b/src/components/answer-game/bank-tile-reject-feedback.ts
@@ -1,5 +1,45 @@
 import { triggerShake } from './Slot/slot-animations';
 
+/** Inline props games may set on bank tiles via React `style={tileStyle()}` / skin overrides. */
+const INLINE_TILE_SNAPSHOT_KEYS = [
+  'background',
+  'boxShadow',
+  'textShadow',
+  'border',
+  'borderWidth',
+  'borderStyle',
+  'borderColor',
+  'borderRadius',
+  'color',
+  'opacity',
+  'filter',
+  'fontWeight',
+] as const;
+
+type InlineTileSnapshot = Record<
+  (typeof INLINE_TILE_SNAPSHOT_KEYS)[number],
+  string
+>;
+
+function snapshotInlineTileStyles(el: HTMLElement): InlineTileSnapshot {
+  const s = el.style;
+  const snap = {} as InlineTileSnapshot;
+  for (const key of INLINE_TILE_SNAPSHOT_KEYS) {
+    snap[key] = String(s[key as keyof CSSStyleDeclaration] ?? '');
+  }
+  return snap;
+}
+
+function restoreInlineTileStyles(
+  el: HTMLElement,
+  snap: InlineTileSnapshot,
+): void {
+  const styleObj = el.style as unknown as Record<string, string>;
+  for (const key of INLINE_TILE_SNAPSHOT_KEYS) {
+    styleObj[key] = snap[key];
+  }
+}
+
 function resolveBankTileButton(tileId: string): HTMLElement | null {
   const escaped =
     typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
@@ -16,18 +56,23 @@ function resolveBankTileButton(tileId: string): HTMLElement | null {
  * Wrong-tile feedback on a bank tile: matches {@link Slot} wrong styling
  * (`border-2` weight + skin wrong tokens). Clears `tileStyle()` box-shadow for
  * the flash so the red border reads like the slot.
+ *
+ * Snapshots inline styles before mutating and restores them on `animationend`
+ * so React's `style={tileStyle()}` is not left blank until the next render.
  */
 export const flashBankTileRejectFeedback = (
   tileId: string,
   options?: {
     /** Prefer passing the dragged tile's button when available (touch path). */
     element?: HTMLElement | null;
-    /** Runs after inline styles are cleared (e.g. drop `data-shaking`). */
+    /** Runs after inline tile styles are restored (e.g. drop `data-shaking`). */
     onAnimationEnd?: () => void;
   },
 ): void => {
   const el = options?.element ?? resolveBankTileButton(tileId);
   if (!el) return;
+
+  const priorInline = snapshotInlineTileStyles(el);
 
   triggerShake(el);
 
@@ -41,12 +86,7 @@ export const flashBankTileRejectFeedback = (
   el.addEventListener(
     'animationend',
     () => {
-      el.style.borderWidth = '';
-      el.style.borderStyle = '';
-      el.style.borderColor = '';
-      el.style.background = '';
-      el.style.color = '';
-      el.style.boxShadow = '';
+      restoreInlineTileStyles(el, priorInline);
       options?.onAnimationEnd?.();
     },
     { once: true },

--- a/src/components/answer-game/bank-tile-reject-feedback.ts
+++ b/src/components/answer-game/bank-tile-reject-feedback.ts
@@ -1,0 +1,54 @@
+import { triggerShake } from './Slot/slot-animations';
+
+function resolveBankTileButton(tileId: string): HTMLElement | null {
+  const escaped =
+    typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+      ? CSS.escape(tileId)
+      : tileId.replaceAll('\\', '\\\\').replaceAll('"', String.raw`\"`);
+  const hole = document.querySelector(
+    `[data-tile-bank-hole="${escaped}"]`,
+  );
+  const btn = hole?.parentElement?.querySelector('button');
+  return btn ?? null;
+}
+
+/**
+ * Wrong-tile feedback on a bank tile: matches {@link Slot} wrong styling
+ * (`border-2` weight + skin wrong tokens). Clears `tileStyle()` box-shadow for
+ * the flash so the red border reads like the slot.
+ */
+export const flashBankTileRejectFeedback = (
+  tileId: string,
+  options?: {
+    /** Prefer passing the dragged tile's button when available (touch path). */
+    element?: HTMLElement | null;
+    /** Runs after inline styles are cleared (e.g. drop `data-shaking`). */
+    onAnimationEnd?: () => void;
+  },
+): void => {
+  const el = options?.element ?? resolveBankTileButton(tileId);
+  if (!el) return;
+
+  triggerShake(el);
+
+  el.style.borderWidth = '2px';
+  el.style.borderStyle = 'solid';
+  el.style.borderColor = 'var(--skin-wrong-border)';
+  el.style.background = 'var(--skin-wrong-bg)';
+  el.style.color = 'var(--skin-wrong-color)';
+  el.style.boxShadow = 'none';
+
+  el.addEventListener(
+    'animationend',
+    () => {
+      el.style.borderWidth = '';
+      el.style.borderStyle = '';
+      el.style.borderColor = '';
+      el.style.background = '';
+      el.style.color = '';
+      el.style.boxShadow = '';
+      options?.onAnimationEnd?.();
+    },
+    { once: true },
+  );
+};

--- a/src/components/answer-game/types.ts
+++ b/src/components/answer-game/types.ts
@@ -118,7 +118,8 @@ export type AnswerGameAction =
   | { type: 'SET_DRAG_HOVER'; zoneIndex: number | null }
   | { type: 'SET_DRAG_HOVER_BANK'; tileId: string | null }
   | { type: 'SWAP_SLOT_BANK'; zoneIndex: number; bankTileId: string }
-  | { type: 'SET_ACTIVE_SLOT'; zoneIndex: number };
+  | { type: 'SET_ACTIVE_SLOT'; zoneIndex: number }
+  | { type: 'REJECT_TAP'; tileId: string; zoneIndex: number };
 
 /**
  * Snapshot of AnswerGameState persisted to session_history_index.draftState.

--- a/src/components/answer-game/useAutoNextSlot.test.tsx
+++ b/src/components/answer-game/useAutoNextSlot.test.tsx
@@ -1,10 +1,14 @@
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AnswerGameProvider } from './AnswerGameProvider';
 import { useAnswerGameContext } from './useAnswerGameContext';
 import { useAnswerGameDispatch } from './useAnswerGameDispatch';
-import { useAutoNextSlot } from './useAutoNextSlot';
+import {
+  clearPendingPlacements,
+  useAutoNextSlot,
+} from './useAutoNextSlot';
 import type { AnswerGameConfig, AnswerZone, TileItem } from './types';
+import type { PlaceResult } from './useAutoNextSlot';
 import type { ReactNode } from 'react';
 
 vi.mock('@/lib/game-event-bus', () => ({
@@ -27,6 +31,7 @@ const gameConfig: AnswerGameConfig = {
 const tileItems: TileItem[] = [
   { id: 't1', label: 'C', value: 'C' },
   { id: 't2', label: 'A', value: 'A' },
+  { id: 't3', label: 'T', value: 'T' },
 ];
 
 const answerZones: AnswerZone[] = [
@@ -46,215 +51,321 @@ const answerZones: AnswerZone[] = [
     isWrong: false,
     isLocked: false,
   },
+  {
+    id: 'z2',
+    index: 2,
+    expectedValue: 'T',
+    placedTileId: null,
+    isWrong: false,
+    isLocked: false,
+  },
 ];
 
-function useHarness() {
+beforeEach(() => {
+  clearPendingPlacements();
+});
+
+function createWrapper(config: AnswerGameConfig) {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <AnswerGameProvider config={config}>{children}</AnswerGameProvider>
+  );
+  Wrapper.displayName = 'AutoNextSlotTestWrapper';
+  return Wrapper;
+}
+
+function useHarness(
+  tiles: TileItem[] = tileItems,
+  zones: AnswerZone[] = answerZones,
+) {
   const dispatch = useAnswerGameDispatch();
   const state = useAnswerGameContext();
   if (state.zones.length === 0)
-    dispatch({
-      type: 'INIT_ROUND',
-      tiles: tileItems,
-      zones: answerZones,
-    });
+    dispatch({ type: 'INIT_ROUND', tiles, zones });
   const { placeInNextSlot } = useAutoNextSlot();
   return { state, placeInNextSlot };
 }
 
-const Wrapper = ({ children }: { children: ReactNode }) => (
-  <AnswerGameProvider config={gameConfig}>
-    {children}
-  </AnswerGameProvider>
-);
-
 describe('useAutoNextSlot', () => {
-  it('places tile in activeSlotIndex zone', () => {
-    const { result } = renderHook(() => useHarness(), {
-      wrapper: Wrapper,
-    });
-    act(() => result.current.placeInNextSlot('t1'));
-    expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
-  });
+  describe('basic placement', () => {
+    it('places correct tile in activeSlotIndex zone', () => {
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
 
-  it('advances activeSlotIndex after correct placement', () => {
-    const { result } = renderHook(() => useHarness(), {
-      wrapper: Wrapper,
-    });
-    expect(result.current.state.activeSlotIndex).toBe(0);
-    act(() => result.current.placeInNextSlot('t1'));
-    expect(result.current.state.activeSlotIndex).toBe(1);
-  });
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t1');
+      });
 
-  it('skips locked zones when finding the next available slot', () => {
-    const lockedZoneConfig: AnswerGameConfig = {
-      ...gameConfig,
-    };
-    const lockedZones: AnswerZone[] = [
-      {
-        id: 'z0',
-        index: 0,
-        expectedValue: 'C',
-        placedTileId: null,
-        isWrong: false,
-        isLocked: true,
-      },
-      {
-        id: 'z1',
-        index: 1,
-        expectedValue: 'A',
-        placedTileId: null,
-        isWrong: false,
-        isLocked: false,
-      },
-    ];
-
-    function useHarnessWithLockedZone() {
-      const dispatch = useAnswerGameDispatch();
-      const state = useAnswerGameContext();
-      if (state.zones.length === 0)
-        dispatch({
-          type: 'INIT_ROUND',
-          tiles: tileItems,
-          zones: lockedZones,
-        });
-      const { placeInNextSlot } = useAutoNextSlot();
-      return { state, placeInNextSlot };
-    }
-
-    const LockedWrapper = ({ children }: { children: ReactNode }) => (
-      <AnswerGameProvider config={lockedZoneConfig}>
-        {children}
-      </AnswerGameProvider>
-    );
-
-    const { result } = renderHook(() => useHarnessWithLockedZone(), {
-      wrapper: LockedWrapper,
+      expect(res).toEqual({
+        placed: true,
+        zoneIndex: 0,
+        rejected: false,
+      });
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
     });
 
-    // Zone 0 is locked, so tile should go to zone 1
-    // t2 has value 'A' which matches zone 1's expectedValue 'A'
-    act(() => result.current.placeInNextSlot('t2'));
-    expect(result.current.state.zones[0]?.placedTileId).toBeNull();
-    expect(result.current.state.zones[1]?.placedTileId).toBe('t2');
-  });
+    it('advances activeSlotIndex after correct placement', () => {
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
 
-  it('blocks placement when active slot is in wrong state (double-tap guard)', () => {
-    // Scenario: wrong tile was just placed in zone 0 (lock-auto-eject) —
-    // isWrong=true, placedTileId=null. A second tap should NOT advance to zone 1.
-    const wrongZones: AnswerZone[] = [
-      {
-        id: 'z0',
-        index: 0,
-        expectedValue: 'C',
-        placedTileId: null,
-        isWrong: true,
-        isLocked: true,
-      },
-      {
-        id: 'z1',
-        index: 1,
-        expectedValue: 'A',
-        placedTileId: null,
-        isWrong: false,
-        isLocked: false,
-      },
-    ];
-
-    function useHarnessWithWrongZone() {
-      const dispatch = useAnswerGameDispatch();
-      const state = useAnswerGameContext();
-      if (state.zones.length === 0)
-        dispatch({
-          type: 'INIT_ROUND',
-          tiles: tileItems,
-          zones: wrongZones,
-        });
-      const { placeInNextSlot } = useAutoNextSlot();
-      return { state, placeInNextSlot };
-    }
-
-    const WrongWrapper = ({ children }: { children: ReactNode }) => (
-      <AnswerGameProvider config={gameConfig}>
-        {children}
-      </AnswerGameProvider>
-    );
-
-    const { result } = renderHook(() => useHarnessWithWrongZone(), {
-      wrapper: WrongWrapper,
+      expect(result.current.state.activeSlotIndex).toBe(0);
+      act(() => result.current.placeInNextSlot('t1'));
+      expect(result.current.state.activeSlotIndex).toBe(1);
     });
 
-    act(() => result.current.placeInNextSlot('t2'));
-    // Zone 1 must stay empty — the guard blocked the placement
-    expect(result.current.state.zones[1]?.placedTileId).toBeNull();
+    it('skips locked zones when finding the next available slot', () => {
+      const lockedZones: AnswerZone[] = [
+        { ...answerZones[0]!, isLocked: true },
+        answerZones[1]!,
+        answerZones[2]!,
+      ];
+
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(
+        () => useHarness(tileItems, lockedZones),
+        { wrapper: Wrapper },
+      );
+
+      act(() => result.current.placeInNextSlot('t2'));
+      expect(result.current.state.zones[0]?.placedTileId).toBeNull();
+      expect(result.current.state.zones[1]?.placedTileId).toBe('t2');
+    });
   });
 
-  it('wraps around to fill earlier empty slots after out-of-order drag placement', () => {
-    // Replicates "cat" scenario: user drags 'a' to slot 1, taps 't' into slot 2,
-    // then taps 'c' — activeSlotIndex is 2 (or beyond) but slot 0 is still empty.
-    // placeInNextSlot must wrap around and place 'c' in zone 0.
-    const threeZones: AnswerZone[] = [
-      {
-        id: 'z0',
-        index: 0,
-        expectedValue: 'C',
-        placedTileId: null, // still empty
-        isWrong: false,
-        isLocked: false,
-      },
-      {
-        id: 'z1',
-        index: 1,
-        expectedValue: 'A',
-        placedTileId: 't2', // already filled out-of-order
-        isWrong: false,
-        isLocked: false,
-      },
-      {
-        id: 'z2',
-        index: 2,
-        expectedValue: 'X',
-        placedTileId: null,
-        isWrong: false,
-        isLocked: false,
-      },
-    ];
+  describe('pre-validation', () => {
+    it('rejects wrong tile in lock-auto-eject mode', () => {
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
 
-    const threeItems: TileItem[] = [
-      { id: 't1', label: 'C', value: 'C' },
-      { id: 't2', label: 'A', value: 'A' },
-      { id: 't3', label: 'X', value: 'X' },
-    ];
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t2');
+      });
 
-    function useHarnessThreeZones() {
-      const dispatch = useAnswerGameDispatch();
-      const state = useAnswerGameContext();
-      if (state.zones.length === 0) {
-        dispatch({
-          type: 'INIT_ROUND',
-          tiles: threeItems,
-          zones: threeZones,
-        });
-        // Simulate activeSlotIndex already at 2 (as if zone 1 was filled via drag)
-        dispatch({ type: 'PLACE_TILE', tileId: 't2', zoneIndex: 1 });
+      expect(res).toEqual({
+        placed: false,
+        zoneIndex: 0,
+        rejected: true,
+      });
+      expect(result.current.state.zones[0]?.placedTileId).toBeNull();
+    });
+
+    it('rejects wrong tile in reject mode', () => {
+      const rejectConfig: AnswerGameConfig = {
+        ...gameConfig,
+        wrongTileBehavior: 'reject',
+      };
+      const Wrapper = createWrapper(rejectConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
+
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t2');
+      });
+
+      expect(res).toEqual({
+        placed: false,
+        zoneIndex: 0,
+        rejected: true,
+      });
+      expect(result.current.state.zones[0]?.placedTileId).toBeNull();
+    });
+
+    it('allows wrong tile through in lock-manual mode (no pre-validation)', () => {
+      const manualConfig: AnswerGameConfig = {
+        ...gameConfig,
+        wrongTileBehavior: 'lock-manual',
+      };
+      const Wrapper = createWrapper(manualConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
+
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t2');
+      });
+
+      expect(res).toEqual({
+        placed: true,
+        zoneIndex: 0,
+        rejected: false,
+      });
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t2');
+    });
+  });
+
+  describe('pending placements queue', () => {
+    it('prevents double-placement on rapid taps (stale closure fix)', () => {
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
+
+      act(() => {
+        result.current.placeInNextSlot('t1');
+        result.current.placeInNextSlot('t2');
+      });
+
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+      expect(result.current.state.zones[1]?.placedTileId).toBe('t2');
+    });
+
+    it('handles three rapid correct taps', () => {
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(() => useHarness(), {
+        wrapper: Wrapper,
+      });
+
+      act(() => {
+        result.current.placeInNextSlot('t1');
+        result.current.placeInNextSlot('t2');
+        result.current.placeInNextSlot('t3');
+      });
+
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+      expect(result.current.state.zones[1]?.placedTileId).toBe('t2');
+      expect(result.current.state.zones[2]?.placedTileId).toBe('t3');
+    });
+  });
+
+  describe('wrap-around', () => {
+    it('wraps around to fill earlier empty slots', () => {
+      const threeZones: AnswerZone[] = [
+        { ...answerZones[0]!, placedTileId: null },
+        { ...answerZones[1]!, placedTileId: 't2' },
+        { ...answerZones[2]!, placedTileId: null },
+      ];
+
+      const Wrapper = createWrapper(gameConfig);
+
+      function useHarnessWrap() {
+        const dispatch = useAnswerGameDispatch();
+        const state = useAnswerGameContext();
+        if (state.zones.length === 0) {
+          dispatch({
+            type: 'INIT_ROUND',
+            tiles: tileItems,
+            zones: threeZones,
+          });
+          dispatch({ type: 'PLACE_TILE', tileId: 't2', zoneIndex: 1 });
+        }
+        const { placeInNextSlot } = useAutoNextSlot();
+        return { state, placeInNextSlot };
       }
-      const { placeInNextSlot } = useAutoNextSlot();
-      return { state, placeInNextSlot };
-    }
 
-    const ThreeWrapper = ({ children }: { children: ReactNode }) => (
-      <AnswerGameProvider config={gameConfig}>
-        {children}
-      </AnswerGameProvider>
-    );
+      const { result } = renderHook(() => useHarnessWrap(), {
+        wrapper: Wrapper,
+      });
 
-    const { result } = renderHook(() => useHarnessThreeZones(), {
-      wrapper: ThreeWrapper,
+      act(() => result.current.placeInNextSlot('t3'));
+      act(() => result.current.placeInNextSlot('t1'));
+
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+    });
+  });
+
+  describe('isWrong guard removal', () => {
+    it('places correct tile in next slot even when active slot is wrong (lock-auto-eject drag)', () => {
+      const wrongZones: AnswerZone[] = [
+        {
+          ...answerZones[0]!,
+          placedTileId: 'tX',
+          isWrong: true,
+          isLocked: true,
+        },
+        answerZones[1]!,
+        answerZones[2]!,
+      ];
+
+      const tilesWithX: TileItem[] = [
+        ...tileItems,
+        { id: 'tX', label: 'X', value: 'X' },
+      ];
+
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(
+        () => useHarness(tilesWithX, wrongZones),
+        { wrapper: Wrapper },
+      );
+
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t2');
+      });
+
+      expect(res).toEqual({
+        placed: true,
+        zoneIndex: 1,
+        rejected: false,
+      });
+      expect(result.current.state.zones[1]?.placedTileId).toBe('t2');
     });
 
-    // activeSlotIndex is 2; zones[2] is empty so first call fills zone 2
-    act(() => result.current.placeInNextSlot('t3'));
-    // Now zones[0] is still empty and activeSlotIndex should wrap around
-    act(() => result.current.placeInNextSlot('t1'));
-    expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+    it('treats isWrong slot with no placedTileId as available (pre-validation supersedes guard)', () => {
+      const wrongZones: AnswerZone[] = [
+        {
+          ...answerZones[0]!,
+          placedTileId: null,
+          isWrong: true,
+          isLocked: false,
+        },
+        answerZones[1]!,
+        answerZones[2]!,
+      ];
+
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(
+        () => useHarness(tileItems, wrongZones),
+        { wrapper: Wrapper },
+      );
+
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t1');
+      });
+
+      expect(res).toEqual({
+        placed: true,
+        zoneIndex: 0,
+        rejected: false,
+      });
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t1');
+    });
+  });
+
+  describe('no slot available', () => {
+    it('returns placed: false, zoneIndex: -1, rejected: false when all slots full', () => {
+      const fullZones: AnswerZone[] = answerZones.map((z) => ({
+        ...z,
+        placedTileId: 'tX',
+        isLocked: true,
+      }));
+
+      const Wrapper = createWrapper(gameConfig);
+      const { result } = renderHook(
+        () => useHarness(tileItems, fullZones),
+        { wrapper: Wrapper },
+      );
+
+      let res: PlaceResult | undefined;
+      act(() => {
+        res = result.current.placeInNextSlot('t1');
+      });
+
+      expect(res).toEqual({
+        placed: false,
+        zoneIndex: -1,
+        rejected: false,
+      });
+    });
   });
 });

--- a/src/components/answer-game/useAutoNextSlot.ts
+++ b/src/components/answer-game/useAutoNextSlot.ts
@@ -1,43 +1,100 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useAnswerGameContext } from './useAnswerGameContext';
 import { useTileEvaluation } from './useTileEvaluation';
 
-export interface AutoNextSlot {
-  placeInNextSlot: (tileId: string) => void;
+export interface PlaceResult {
+  placed: boolean;
+  zoneIndex: number;
+  rejected: boolean;
 }
 
+export interface AutoNextSlot {
+  placeInNextSlot: (tileId: string) => PlaceResult;
+}
+
+// Module-scoped: shared across all hook instances on the page (single AnswerGame
+// instance assumed). For multi-instance support, lift to AnswerGameProvider context.
+let pendingPlacements: Array<{ tileId: string; zoneIndex: number }> =
+  [];
+
+export const clearPendingPlacements = (): void => {
+  pendingPlacements = [];
+};
+
 export const useAutoNextSlot = (): AutoNextSlot => {
-  const { activeSlotIndex, zones } = useAnswerGameContext();
+  const state = useAnswerGameContext();
+  const { zones, activeSlotIndex, config, allTiles, roundIndex } =
+    state;
   const { placeTile } = useTileEvaluation();
 
-  const placeInNextSlot = useCallback(
-    (tileId: string) => {
-      // Guard: if the active slot is in a wrong state (e.g. a wrong tile was
-      // just placed with lock-auto-eject), block further placements until it
-      // clears. This prevents double/triple taps from skipping past the slot.
-      if (zones[activeSlotIndex]?.isWrong) return;
+  useEffect(() => {
+    clearPendingPlacements();
+  }, [roundIndex, zones.length]);
 
-      // Look for the next available slot from activeSlotIndex forward...
-      let targetIndex = zones.findIndex(
-        (z, i) =>
-          i >= activeSlotIndex &&
-          z.placedTileId === null &&
-          !z.isLocked,
+  const placeInNextSlot = useCallback(
+    (tileId: string): PlaceResult => {
+      pendingPlacements = pendingPlacements.filter(
+        (entry) =>
+          zones[entry.zoneIndex]?.placedTileId !== entry.tileId,
       );
 
-      // ...and wrap around if needed. This handles out-of-order placements
-      // (e.g. via drag) where earlier slots were left empty and activeSlotIndex
-      // has already advanced past them.
+      const claimedZones = new Set(
+        pendingPlacements.map((e) => e.zoneIndex),
+      );
+
+      const isAvailable = (i: number) =>
+        zones[i] &&
+        !zones[i].placedTileId &&
+        !zones[i].isLocked &&
+        !claimedZones.has(i);
+
+      let targetIndex = -1;
+      for (let i = activeSlotIndex; i < zones.length; i++) {
+        if (isAvailable(i)) {
+          targetIndex = i;
+          break;
+        }
+      }
       if (targetIndex === -1) {
-        targetIndex = zones.findIndex(
-          (z) => z.placedTileId === null && !z.isLocked,
-        );
+        for (let i = 0; i < activeSlotIndex; i++) {
+          if (isAvailable(i)) {
+            targetIndex = i;
+            break;
+          }
+        }
       }
 
-      if (targetIndex === -1) return;
-      placeTile(tileId, targetIndex);
+      if (targetIndex === -1) {
+        return { placed: false, zoneIndex: -1, rejected: false };
+      }
+
+      if (config.wrongTileBehavior !== 'lock-manual') {
+        const tile = allTiles.find((t) => t.id === tileId);
+        const targetZone = zones[targetIndex];
+        if (
+          tile &&
+          targetZone &&
+          tile.value !== targetZone.expectedValue
+        ) {
+          return {
+            placed: false,
+            zoneIndex: targetIndex,
+            rejected: true,
+          };
+        }
+      }
+
+      pendingPlacements.push({ tileId, zoneIndex: targetIndex });
+      void placeTile(tileId, targetIndex);
+      return { placed: true, zoneIndex: targetIndex, rejected: false };
     },
-    [placeTile, activeSlotIndex, zones],
+    [
+      zones,
+      activeSlotIndex,
+      config.wrongTileBehavior,
+      allTiles,
+      placeTile,
+    ],
   );
 
   return { placeInNextSlot };

--- a/src/components/answer-game/useDraggableTile.test.tsx
+++ b/src/components/answer-game/useDraggableTile.test.tsx
@@ -1,8 +1,9 @@
 import { act, render, renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AnswerGameProvider } from './AnswerGameProvider';
 import { useDraggableTile } from './useDraggableTile';
 import type { AnswerGameConfig } from './types';
+import { playSound } from '@/lib/audio/AudioFeedback';
 
 const mockDraggable = vi.fn().mockReturnValue(() => {});
 const mockDropTargetForElements = vi.fn().mockReturnValue(() => {});
@@ -13,7 +14,11 @@ vi.mock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
     mockDropTargetForElements(...args),
 }));
 
-const mockPlaceInNextSlot = vi.fn();
+const mockPlaceInNextSlot = vi.fn().mockReturnValue({
+  placed: true,
+  zoneIndex: 0,
+  rejected: false,
+});
 const mockSpeakTile = vi.fn();
 
 vi.mock('./useAutoNextSlot', () => ({
@@ -27,6 +32,8 @@ vi.mock('./useGameTTS', () => ({
   }),
 }));
 
+let mockWrongTileBehavior = 'lock-auto-eject';
+
 vi.mock('./useAnswerGameContext', () => ({
   useAnswerGameContext: () => ({
     config: {
@@ -34,12 +41,24 @@ vi.mock('./useAnswerGameContext', () => ({
       ttsEnabled: true,
       totalRounds: 1,
       gameId: 'test',
-      wrongTileBehavior: 'lock-auto-eject',
+      wrongTileBehavior: mockWrongTileBehavior,
       tileBankMode: 'exact',
     },
-    zones: [],
-    allTiles: [],
-    bankTileIds: [],
+    zones: [
+      {
+        id: 'z0',
+        index: 0,
+        expectedValue: 'C',
+        placedTileId: null,
+        isWrong: false,
+        isLocked: false,
+      },
+    ],
+    allTiles: [
+      { id: 't1', label: 'C', value: 'C' },
+      { id: 't2', label: 'X', value: 'X' },
+    ],
+    bankTileIds: ['t1', 't2'],
     activeSlotIndex: 0,
     roundIndex: 0,
     retryCount: 0,
@@ -60,9 +79,26 @@ vi.mock('./useTileEvaluation', () => ({
   useTileEvaluation: () => ({ placeTile: mockPlaceTile }),
 }));
 
-// Capture the options passed to useTouchDrag so tests can invoke the touch
-// callbacks directly without simulating real pointer events.
+vi.mock('@/lib/audio/AudioFeedback', () => ({
+  playSound: vi.fn(),
+}));
+
+const mockTriggerShake = vi.fn();
+vi.mock('./Slot/slot-animations', () => ({
+  triggerShake: (...args: unknown[]) => mockTriggerShake(...args),
+}));
+
+vi.mock('@/lib/skin', () => ({
+  resolveSkin: () => ({ suppressDefaultSounds: false }),
+}));
+
+const mockEmit = vi.fn();
+vi.mock('@/lib/game-event-bus', () => ({
+  getGameEventBus: () => ({ emit: mockEmit, subscribe: vi.fn() }),
+}));
+
 type CapturedTouchDragOptions = {
+  onDrop?: (tileId: string, zoneIndex: number) => void;
   onDropOnBank?: () => void;
   onDropOnBankTile?: (bankTileId: string) => void;
 };
@@ -105,6 +141,22 @@ const DraggableHost = () => {
 
 describe('useDraggableTile', () => {
   const tile = { id: 't1', label: 'C', value: 'c' };
+
+  beforeEach(() => {
+    capturedTouchDragOptions = null;
+    mockPlaceInNextSlot.mockClear().mockReturnValue({
+      placed: true,
+      zoneIndex: 0,
+      rejected: false,
+    });
+    mockSpeakTile.mockClear();
+    mockDispatch.mockClear();
+    mockEmit.mockClear();
+    mockTriggerShake.mockClear();
+    mockPlaceTile.mockReset();
+    vi.mocked(playSound).mockClear();
+    mockWrongTileBehavior = 'lock-auto-eject';
+  });
 
   it('returns a ref, handleClick, and touch handlers', () => {
     const { result } = renderHook(() => useDraggableTile(tile));
@@ -153,9 +205,6 @@ describe('useDraggableTile', () => {
 
   describe('touch drag — onDropOnBank', () => {
     it('clears drag state when bank tile is released back onto the bank', () => {
-      // Regression: dragging a bank tile a few pixels then releasing within the
-      // bank left dragActiveTileId set, making the tile permanently faded and
-      // uninteractable. onDropOnBank must reset the active drag state.
       capturedTouchDragOptions = null;
       mockDispatch.mockClear();
 
@@ -176,8 +225,6 @@ describe('useDraggableTile', () => {
 
   describe('touch drag — onDropOnBankTile', () => {
     it('clears drag state when bank tile is dropped onto another bank tile hole', () => {
-      // Same regression path — dropping on a bank tile hole also left
-      // dragActiveTileId set when onDropOnBankTile was not provided.
       capturedTouchDragOptions = null;
       mockDispatch.mockClear();
 
@@ -193,6 +240,138 @@ describe('useDraggableTile', () => {
         type: 'SET_DRAG_ACTIVE',
         tileId: null,
       });
+    });
+  });
+
+  describe('handleClick reject path', () => {
+    it('does not speak or place when tile is already shaking', () => {
+      const shakeTile = { id: 't1', label: 'C', value: 'C' };
+      const { result } = renderHook(() => useDraggableTile(shakeTile));
+
+      const button = document.createElement('button');
+      button.dataset.shaking = 'true';
+      Object.defineProperty(result.current.ref, 'current', {
+        value: button,
+        writable: true,
+      });
+
+      act(() => result.current.handleClick());
+
+      expect(mockSpeakTile).not.toHaveBeenCalled();
+      expect(mockPlaceInNextSlot).not.toHaveBeenCalled();
+    });
+
+    it('dispatches REJECT_TAP and plays wrong sound on rejection', () => {
+      mockPlaceInNextSlot.mockReturnValue({
+        placed: false,
+        zoneIndex: 0,
+        rejected: true,
+      });
+
+      const rejectTile = { id: 't2', label: 'X', value: 'X' };
+      const { result } = renderHook(() => useDraggableTile(rejectTile));
+
+      const button = document.createElement('button');
+      Object.defineProperty(result.current.ref, 'current', {
+        value: button,
+        writable: true,
+      });
+
+      act(() => result.current.handleClick());
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'REJECT_TAP',
+        tileId: 't2',
+        zoneIndex: 0,
+      });
+      expect(playSound).toHaveBeenCalledWith('wrong', 0.8);
+    });
+
+    it('emits game:evaluate with expected field on rejection', () => {
+      mockPlaceInNextSlot.mockReturnValue({
+        placed: false,
+        zoneIndex: 0,
+        rejected: true,
+      });
+
+      const rejectTile = { id: 't2', label: 'X', value: 'X' };
+      const { result } = renderHook(() => useDraggableTile(rejectTile));
+
+      const button = document.createElement('button');
+      Object.defineProperty(result.current.ref, 'current', {
+        value: button,
+        writable: true,
+      });
+
+      act(() => result.current.handleClick());
+
+      expect(mockEmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'game:evaluate',
+          answer: 't2',
+          correct: false,
+          expected: 'C',
+          zoneIndex: 0,
+        }),
+      );
+    });
+
+    it('does not dispatch REJECT_TAP on successful placement', () => {
+      const okTile = { id: 't1', label: 'C', value: 'C' };
+      const { result } = renderHook(() => useDraggableTile(okTile));
+
+      act(() => result.current.handleClick());
+
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'REJECT_TAP' }),
+      );
+    });
+  });
+
+  describe('touch drag reject path', () => {
+    it('calls triggerShake on bank tile when drag-drop is rejected in reject mode', () => {
+      const rafSpy = vi
+        .spyOn(globalThis, 'requestAnimationFrame')
+        .mockImplementation((cb: FrameRequestCallback) => {
+          cb(0);
+          return 0;
+        });
+      try {
+        mockWrongTileBehavior = 'reject';
+        mockPlaceTile.mockReturnValue({ correct: false });
+
+        const rejectTile = { id: 't2', label: 'X', value: 'X' };
+        const { result } = renderHook(() =>
+          useDraggableTile(rejectTile),
+        );
+
+        const button = document.createElement('button');
+        Object.defineProperty(result.current.ref, 'current', {
+          value: button,
+          writable: true,
+        });
+
+        const onDrop = capturedTouchDragOptions?.onDrop;
+        expect(onDrop).toBeDefined();
+        act(() => onDrop?.('t2', 0));
+
+        expect(mockTriggerShake).toHaveBeenCalledWith(button);
+      } finally {
+        rafSpy.mockRestore();
+        mockWrongTileBehavior = 'lock-auto-eject';
+      }
+    });
+
+    it('does not shake when wrong tile is dropped in lock-auto-eject mode', () => {
+      mockPlaceTile.mockReturnValue({ correct: false });
+
+      const rejectTile = { id: 't2', label: 'X', value: 'X' };
+      renderHook(() => useDraggableTile(rejectTile));
+
+      const onDrop = capturedTouchDragOptions?.onDrop;
+      act(() => onDrop?.('t2', 0));
+
+      expect(mockTriggerShake).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/answer-game/useDraggableTile.ts
+++ b/src/components/answer-game/useDraggableTile.ts
@@ -3,7 +3,7 @@ import {
   dropTargetForElements,
 } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { useEffect, useRef } from 'react';
-import { triggerShake } from './Slot/slot-animations';
+import { flashBankTileRejectFeedback } from './bank-tile-reject-feedback';
 import { useAnswerGameContext } from './useAnswerGameContext';
 import { useAnswerGameDispatch } from './useAnswerGameDispatch';
 import { useAutoNextSlot } from './useAutoNextSlot';
@@ -111,27 +111,12 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
         const { correct } = placeTile(droppedTileId, zoneIndex);
         if (
           !correct &&
-          stateRef.current.config.wrongTileBehavior === 'reject' &&
-          ref.current
+          stateRef.current.config.wrongTileBehavior === 'reject'
         ) {
           requestAnimationFrame(() => {
-            if (ref.current) {
-              triggerShake(ref.current);
-              ref.current.style.background =
-                'var(--skin-wrong-bg, #f87171)';
-              ref.current.style.borderColor =
-                'var(--skin-wrong-border, #ef4444)';
-              ref.current.addEventListener(
-                'animationend',
-                () => {
-                  if (ref.current) {
-                    ref.current.style.background = '';
-                    ref.current.style.borderColor = '';
-                  }
-                },
-                { once: true },
-              );
-            }
+            flashBankTileRejectFeedback(droppedTileId, {
+              element: ref.current,
+            });
           });
         }
       },
@@ -161,21 +146,15 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
     speakTile(tile.label);
     const result = placeInNextSlot(tile.id);
 
-    if (result.rejected && ref.current) {
-      ref.current.dataset.shaking = 'true';
-      triggerShake(ref.current);
-      const el = ref.current;
-      el.style.background = 'var(--skin-wrong-bg, #f87171)';
-      el.style.borderColor = 'var(--skin-wrong-border, #ef4444)';
-      el.addEventListener(
-        'animationend',
-        () => {
-          el.style.background = '';
-          el.style.borderColor = '';
-          delete el.dataset.shaking;
+    const bankEl = ref.current;
+    if (result.rejected && bankEl) {
+      bankEl.dataset.shaking = 'true';
+      flashBankTileRejectFeedback(tile.id, {
+        element: bankEl,
+        onAnimationEnd: () => {
+          delete bankEl.dataset.shaking;
         },
-        { once: true },
-      );
+      });
 
       if (!skin.suppressDefaultSounds) {
         playSound('wrong', 0.8);

--- a/src/components/answer-game/useDraggableTile.ts
+++ b/src/components/answer-game/useDraggableTile.ts
@@ -3,6 +3,7 @@ import {
   dropTargetForElements,
 } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { useEffect, useRef } from 'react';
+import { triggerShake } from './Slot/slot-animations';
 import { useAnswerGameContext } from './useAnswerGameContext';
 import { useAnswerGameDispatch } from './useAnswerGameDispatch';
 import { useAutoNextSlot } from './useAutoNextSlot';
@@ -12,7 +13,9 @@ import { useTouchDrag } from './useTouchDrag';
 import type { TileItem } from './types';
 import type { TouchDragHandlers } from './useTouchDrag';
 import type { RefObject } from 'react';
+import { playSound } from '@/lib/audio/AudioFeedback';
 import { getGameEventBus } from '@/lib/game-event-bus';
+import { resolveSkin } from '@/lib/skin';
 
 export interface DraggableTile extends TouchDragHandlers {
   ref: RefObject<HTMLButtonElement | null>;
@@ -31,6 +34,7 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
   const { speakTile } = useGameTTS();
   const speakTileRef = useRef(speakTile);
   const { placeTile } = useTileEvaluation();
+  const skin = resolveSkin(state.config.gameId, state.config.skin);
 
   useEffect(() => {
     speakTileRef.current = speakTile;
@@ -104,7 +108,32 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
         dispatch({ type: 'SET_DRAG_ACTIVE', tileId: null }),
       onDrop: (droppedTileId, zoneIndex) => {
         dispatch({ type: 'SET_DRAG_ACTIVE', tileId: null });
-        placeTile(droppedTileId, zoneIndex);
+        const { correct } = placeTile(droppedTileId, zoneIndex);
+        if (
+          !correct &&
+          stateRef.current.config.wrongTileBehavior === 'reject' &&
+          ref.current
+        ) {
+          requestAnimationFrame(() => {
+            if (ref.current) {
+              triggerShake(ref.current);
+              ref.current.style.background =
+                'var(--skin-wrong-bg, #f87171)';
+              ref.current.style.borderColor =
+                'var(--skin-wrong-border, #ef4444)';
+              ref.current.addEventListener(
+                'animationend',
+                () => {
+                  if (ref.current) {
+                    ref.current.style.background = '';
+                    ref.current.style.borderColor = '';
+                  }
+                },
+                { once: true },
+              );
+            }
+          });
+        }
       },
       onDropOnBank: () =>
         dispatch({ type: 'SET_DRAG_ACTIVE', tileId: null }),
@@ -127,8 +156,52 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
     });
 
   const handleClick = () => {
+    if (ref.current?.dataset.shaking) return;
+
     speakTile(tile.label);
-    placeInNextSlot(tile.id);
+    const result = placeInNextSlot(tile.id);
+
+    if (result.rejected && ref.current) {
+      ref.current.dataset.shaking = 'true';
+      triggerShake(ref.current);
+      const el = ref.current;
+      el.style.background = 'var(--skin-wrong-bg, #f87171)';
+      el.style.borderColor = 'var(--skin-wrong-border, #ef4444)';
+      el.addEventListener(
+        'animationend',
+        () => {
+          el.style.background = '';
+          el.style.borderColor = '';
+          delete el.dataset.shaking;
+        },
+        { once: true },
+      );
+
+      if (!skin.suppressDefaultSounds) {
+        playSound('wrong', 0.8);
+      }
+
+      // Tap/click path only — drag rejects are handled in useTileEvaluation.placeTile
+      dispatch({
+        type: 'REJECT_TAP',
+        tileId: tile.id,
+        zoneIndex: result.zoneIndex,
+      });
+
+      getGameEventBus().emit({
+        type: 'game:evaluate',
+        gameId: state.config.gameId,
+        sessionId: '',
+        profileId: '',
+        timestamp: Date.now(),
+        roundIndex: state.roundIndex,
+        answer: tile.id,
+        correct: false,
+        nearMiss: false,
+        zoneIndex: result.zoneIndex,
+        expected: state.zones[result.zoneIndex]?.expectedValue ?? '',
+      });
+    }
   };
 
   return {

--- a/src/components/answer-game/useTileEvaluation.test.tsx
+++ b/src/components/answer-game/useTileEvaluation.test.tsx
@@ -16,8 +16,9 @@ import type { ReactNode } from 'react';
 import { playSound } from '@/lib/audio/AudioFeedback';
 import { __resetSkinRegistryForTests, registerSkin } from '@/lib/skin';
 
+const mockEmit = vi.fn();
 vi.mock('@/lib/game-event-bus', () => ({
-  getGameEventBus: () => ({ emit: vi.fn(), subscribe: vi.fn() }),
+  getGameEventBus: () => ({ emit: mockEmit, subscribe: vi.fn() }),
 }));
 
 vi.mock('@/lib/audio/AudioFeedback', () => ({
@@ -82,6 +83,7 @@ describe('useTileEvaluation', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    mockEmit.mockClear();
   });
   afterEach(() => vi.useRealTimers());
 
@@ -179,5 +181,74 @@ describe('useTileEvaluation', () => {
     });
 
     expect(playSound).not.toHaveBeenCalled();
+  });
+
+  describe('expected field on game:evaluate', () => {
+    it('includes expected value from zone in placeTile emit', () => {
+      const { result } = renderHook(() => useTileEvaluationHarness(), {
+        wrapper: createWrapper(baseConfig),
+      });
+      act(() => result.current.placeTile('t1', 0));
+
+      expect(mockEmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'game:evaluate',
+          expected: 'C',
+        }),
+      );
+    });
+  });
+
+  describe('placeTile return value', () => {
+    it('returns { correct: true } for correct placement', () => {
+      const { result } = renderHook(() => useTileEvaluationHarness(), {
+        wrapper: createWrapper(baseConfig),
+      });
+      let returnVal: { correct: boolean } | undefined;
+      act(() => {
+        returnVal = result.current.placeTile('t1', 0);
+      });
+
+      expect(returnVal).toEqual({ correct: true });
+    });
+
+    it('returns { correct: false } for wrong placement', () => {
+      const { result } = renderHook(() => useTileEvaluationHarness(), {
+        wrapper: createWrapper(baseConfig),
+      });
+      let returnVal: { correct: boolean } | undefined;
+      act(() => {
+        returnVal = result.current.placeTile('t2', 0);
+      });
+
+      expect(returnVal).toEqual({ correct: false });
+    });
+  });
+
+  describe('reject mode dispatches REJECT_TAP', () => {
+    it('dispatches REJECT_TAP instead of PLACE_TILE for wrong tile in reject mode', () => {
+      const rejectConfig: AnswerGameConfig = {
+        ...baseConfig,
+        wrongTileBehavior: 'reject',
+      };
+
+      const { result } = renderHook(() => useTileEvaluationHarness(), {
+        wrapper: createWrapper(rejectConfig),
+      });
+      act(() => result.current.placeTile('t2', 0));
+
+      expect(result.current.state.retryCount).toBe(1);
+      expect(result.current.state.zones[0]?.placedTileId).toBeNull();
+    });
+
+    it('dispatches PLACE_TILE for wrong tile in lock-auto-eject mode', () => {
+      const { result } = renderHook(() => useTileEvaluationHarness(), {
+        wrapper: createWrapper(baseConfig),
+      });
+      act(() => result.current.placeTile('t2', 0));
+
+      expect(result.current.state.zones[0]?.placedTileId).toBe('t2');
+      expect(result.current.state.zones[0]?.isWrong).toBe(true);
+    });
   });
 });

--- a/src/components/answer-game/useTileEvaluation.ts
+++ b/src/components/answer-game/useTileEvaluation.ts
@@ -7,7 +7,10 @@ import { getGameEventBus } from '@/lib/game-event-bus';
 import { resolveSkin } from '@/lib/skin';
 
 export interface TileEvaluation {
-  placeTile: (tileId: string, zoneIndex: number) => void;
+  placeTile: (
+    tileId: string,
+    zoneIndex: number,
+  ) => { correct: boolean };
   /**
    * Place a free-typed value into a slot. Creates a virtual tile when
    * no matching bank tile exists. Used with lock-manual / lock-auto-eject
@@ -22,16 +25,23 @@ export function useTileEvaluation(): TileEvaluation {
   const skin = resolveSkin(state.config.gameId, state.config.skin);
 
   const placeTile = useCallback(
-    (tileId: string, zoneIndex: number) => {
+    (tileId: string, zoneIndex: number): { correct: boolean } => {
       const tile = state.allTiles.find((t) => t.id === tileId);
       const zone = state.zones[zoneIndex];
-      if (!tile || !zone) return;
+      if (!tile || !zone) return { correct: false };
 
       const correct = tile.value === zone.expectedValue;
       if (!skin.suppressDefaultSounds) {
         playSound(correct ? 'correct' : 'wrong', 0.8);
       }
-      dispatch({ type: 'PLACE_TILE', tileId, zoneIndex });
+
+      // Drag path only — tap/click rejects are handled in useDraggableTile.handleClick
+      // (placeInNextSlot pre-validates and never calls placeTile on rejection)
+      if (!correct && state.config.wrongTileBehavior === 'reject') {
+        dispatch({ type: 'REJECT_TAP', tileId, zoneIndex });
+      } else {
+        dispatch({ type: 'PLACE_TILE', tileId, zoneIndex });
+      }
 
       getGameEventBus().emit({
         type: 'game:evaluate',
@@ -44,7 +54,10 @@ export function useTileEvaluation(): TileEvaluation {
         correct,
         nearMiss: false,
         zoneIndex,
+        expected: zone.expectedValue,
       });
+
+      return { correct };
     },
     [state, dispatch, skin],
   );
@@ -77,6 +90,7 @@ export function useTileEvaluation(): TileEvaluation {
         correct,
         nearMiss: false,
         zoneIndex,
+        expected: zone.expectedValue,
       });
     },
     [state, dispatch, skin],

--- a/src/types/game-events.ts
+++ b/src/types/game-events.ts
@@ -55,6 +55,8 @@ export interface GameEvaluateEvent extends BaseGameEvent {
   nearMiss: boolean;
   /** Index of the slot the tile was placed into. */
   zoneIndex: number;
+  /** Expected value for the target slot — provides confusion pair for SRS. */
+  expected?: string;
 }
 
 export interface GameScoreEvent extends BaseGameEvent {


### PR DESCRIPTION
## Summary

Implements the [fast-tap queue plan](docs/superpowers/plans/2026-05-01-fast-tap-queue.md): fixes false error bounces on rapid Android taps by combining **bank pre-validation** with a module-scoped **pending placements** write-ahead log, plus a **`REJECT_TAP`** reducer path for retries without zone mutation.

## Changes

- **Types:** `REJECT_TAP` on `AnswerGameAction`; optional `expected` on `GameEvaluateEvent`.
- **Reducer:** `REJECT_TAP` increments `retryCount` only.
- **useTileEvaluation:** `placeTile` returns `{ correct }`; reject-mode wrong drag dispatches `REJECT_TAP`; all `game:evaluate` emits include `expected` where applicable.
- **useAutoNextSlot:** `PlaceResult`, `clearPendingPlacements`, pending queue + pre-validation (skipped for `lock-manual`).
- **useDraggableTile:** tap reject uses `data-shaking` throttle, shake + wrong styling/sound, `REJECT_TAP` + evaluate emit; touch drag reject uses `requestAnimationFrame` + bank shake styling.
- **Docs:** `AnswerGame.flows.mdx` updated for tap path and `REJECT_TAP`.

## Verification

- `yarn typecheck`
- `npx vitest run` (full suite)
- Pre-push hooks (related unit + lint + typecheck) passed locally.

## Local run

From the worktree:

```bash
cd /Users/leocaseiro/Sites/base-skill/worktrees/276-fast-tap-queue
yarn install
yarn dev
```

Closes #276.


<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/287/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/287/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/287#issuecomment-)
<!-- /preview-urls -->




