### PR TITLE
fix(touch-drag): tap forgiveness with duration + distance gates (closes #298)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ worktrees/
 .specstory/statistics.json
 .superpowers/
 .local-debug/
+debug/
 .claude/settings.local.json
 *.code-workspace

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,9 @@ yarn.lock
 .husky/
 .vscode/
 
+# Local debug harness (gitignored, scratch HTML/JS/Python)
+debug/
+
 # Git worktrees — run `yarn fix` inside the worktree, not from root
 worktrees/
 

--- a/docs/brainstorms/2026-05-01-tap-forgiveness-requirements.md
+++ b/docs/brainstorms/2026-05-01-tap-forgiveness-requirements.md
@@ -1,0 +1,85 @@
+# Tap Forgiveness: Treat Micro-Drags as Taps
+
+**Date:** 2026-05-01
+**Issue:** [#298](https://github.com/leocaseiro/base-skill/issues/298)
+**Status:** Ready for planning
+
+## Problem
+
+Young users (and some adults unfamiliar with touch devices) accidentally move
+their finger slightly when tapping bank tiles. Once movement exceeds the 8px
+`DRAG_THRESHOLD_PX`, the system enters drag mode. When the finger lifts — still
+over the bank — the drag cancels as a no-op. The tile speaks its letter but
+never gets placed, frustrating the user.
+
+PR #287 solved a related but different problem (fast sequential taps arriving
+before state updates). This issue remains.
+
+## Solution
+
+Add a **tap forgiveness threshold**: on pointer-up, if the drag is active but
+total displacement from start is below a configurable pixel threshold AND the
+finger is still over the bank area, treat the gesture as a tap (place the tile
+in the next available slot).
+
+## Requirements
+
+### Core behavior
+
+- On touch pointer-up in `useTouchDrag`, calculate Euclidean distance from
+  `startPos` to current pointer position.
+- If `isDragging === true` AND distance < tap forgiveness threshold AND pointer
+  is over the bank area (not over a slot zone): treat as tap.
+- "Treat as tap" means: clean up drag state, then invoke the same tap handler
+  that `handleClick` uses (`speakTile` + `placeInNextSlot`). Since `onDragStart`
+  already called `speakTile`, the fallback should only call `placeInNextSlot`.
+- The existing `DRAG_THRESHOLD_PX = 8` (start-drag threshold) remains unchanged.
+- Applies to all games that use `useTouchDrag` (global behavior, not
+  game-specific).
+
+### Configurable threshold
+
+- Add an optional `tapForgivenessThreshold` field to `SettingsDoc` (per-profile
+  settings schema).
+- Default value: **20px** (hardcoded fallback when no setting is saved).
+- Expose in the settings UI as a slider or numeric input so testers/parents can
+  tune it per child.
+- `useTouchDrag` reads the threshold from settings context at pointer-up time.
+
+### Non-goals
+
+- Time-based detection (rejected during brainstorm — distance alone is
+  sufficient).
+- Recording/analytics of drag movements (mentioned in issue as alternative,
+  deferred).
+- Changes to desktop HTML5 DnD behavior (touch-only, gated by
+  `pointerType !== 'mouse'`).
+- Changes to the fast-tap queue from PR #287.
+
+## Key decisions
+
+| Decision           | Choice                            | Rationale                                                                   |
+| ------------------ | --------------------------------- | --------------------------------------------------------------------------- |
+| Detection method   | Distance from start on pointer-up | Simpler than time; directly measures "how far did the finger actually move" |
+| Threshold location | Per-profile `SettingsDoc`         | Persists per child, testable without code changes                           |
+| Default value      | 20px                              | ~2.5x the drag-start threshold; forgiving without catching real drags       |
+| Scope              | All games via `useTouchDrag`      | The hook is shared; the problem isn't game-specific                         |
+
+## Affected files
+
+- `src/components/answer-game/useTouchDrag.ts` — tap forgiveness check in
+  `onPointerUp`
+- `src/components/answer-game/useDraggableTile.ts` — pass `onTapFallback`
+  callback
+- `src/db/schemas/settings.ts` — add `tapForgivenessThreshold` field
+- `src/routes/$locale/_app/settings.tsx` — add slider/input for the threshold
+- `src/db/hooks/useSettings.ts` — expose the new field
+
+## Success criteria
+
+- A user who moves their finger ≤20px during a tap has the tile placed in the
+  next slot (same as a clean tap).
+- A user who intentionally drags >20px and returns to the bank still cancels
+  (no accidental placement).
+- The threshold is adjustable per profile from the settings page.
+- Existing tap and drag flows are unaffected (regression tests pass).

--- a/docs/brainstorms/2026-05-01-tap-forgiveness-requirements.md
+++ b/docs/brainstorms/2026-05-01-tap-forgiveness-requirements.md
@@ -2,7 +2,33 @@
 
 **Date:** 2026-05-01
 **Issue:** [#298](https://github.com/leocaseiro/base-skill/issues/298)
-**Status:** Ready for planning
+**Status:** Implemented (with revision — see Findings below)
+
+## Findings from device testing (2026-05-02)
+
+Distance-only forgiveness (the original spec below) failed in the field with
+**zero behavioural change** even at 40px threshold. Captures from a debug
+harness on real Chrome Android and Brave iOS devices revealed why:
+
+- A typical thumb tap registers **75–100px** of contact movement in
+  **50–65ms** due to **thumb-release drift** — the contact point pivots
+  toward the base of the thumb as pressure releases. Distance alone cannot
+  separate this from a deliberate drag without unacceptable false positives.
+- `pointercancel` never fires for these gestures (contradicting an early
+  hypothesis about iOS Safari). `lostpointercapture` fires correctly **after**
+  `pointerup`. The existing onPointerUp check IS reached — the displacement
+  check just always fails by a wide margin.
+- Duration is a much cleaner discriminator. Every captured failing tap
+  completed in <80ms; the shortest deliberate drag took 287ms — clean gap.
+
+Revised rule: treat as tap if **either** displacement is below
+`tapForgivenessThreshold` (default 17px) **OR** duration is below
+`tapForgivenessTimeMs` (default 150ms — below human reaction time, so any
+gesture this short is ballistic motion, not deliberate drag).
+
+Both thresholds are configurable per-profile; setting either to 0 disables
+that signal. Captured device logs are preserved in
+`debug/logs/` (gitignored) for future regression checks.
 
 ## Problem
 

--- a/docs/plans/2026-05-01-001-fix-tap-forgiveness-plan.md
+++ b/docs/plans/2026-05-01-001-fix-tap-forgiveness-plan.md
@@ -1,10 +1,24 @@
 ---
 title: 'fix: Tap forgiveness — treat micro-drags as taps'
 type: fix
-status: active
+status: shipped
 date: 2026-05-01
 origin: docs/brainstorms/2026-05-01-tap-forgiveness-requirements.md
 ---
+
+## Spec Delta — distance-only was insufficient
+
+Implementation initially followed this plan (distance check only). Real-device
+testing on Chrome Android and Brave iOS showed distance-only forgiveness has
+**zero behavioural impact** because a typical thumb tap registers 75–100px in
+50–65ms (thumb-release drift). See the Findings section in the origin
+brainstorm for the captured device data.
+
+The shipped implementation adds a duration-based gate alongside the distance
+gate: tap if `duration < tapForgivenessTimeMs` (default 150ms) OR
+`distance < tapForgivenessThreshold` (default 17px). Same `onTapFallback`
+hook contract; same priority order; same per-profile configurability with two
+sliders instead of one.
 
 ## Summary
 

--- a/docs/plans/2026-05-01-001-fix-tap-forgiveness-plan.md
+++ b/docs/plans/2026-05-01-001-fix-tap-forgiveness-plan.md
@@ -1,0 +1,304 @@
+---
+title: 'fix: Tap forgiveness — treat micro-drags as taps'
+type: fix
+status: active
+date: 2026-05-01
+origin: docs/brainstorms/2026-05-01-tap-forgiveness-requirements.md
+---
+
+## Summary
+
+Adds a configurable "tap forgiveness" threshold so that touch micro-drags
+(accidental finger movement < N pixels during a tap) are treated as taps
+rather than cancelled drags. The threshold is stored per-profile in settings
+and exposed via a slider in the settings UI. The check fires only for bank
+tile drags — slot tile drags are unaffected.
+
+## Problem Frame
+
+Young users accidentally move their finger slightly when tapping bank tiles.
+Once movement exceeds the 8px `DRAG_THRESHOLD_PX`, the system enters drag
+mode. When the finger lifts still over the bank, the drag cancels as a no-op.
+The tile speaks but never places. (see origin:
+`docs/brainstorms/2026-05-01-tap-forgiveness-requirements.md`)
+
+## Requirements
+
+- R1. On touch pointer-up, if total displacement < threshold AND pointer is
+  over the bank (not a slot zone), treat as tap (place in next slot).
+- R2. Existing `DRAG_THRESHOLD_PX = 8` remains unchanged.
+- R3. Per-profile `tapForgivenessThreshold` field in `SettingsDoc` with
+  default 20px.
+- R4. Settings UI slider to tune the threshold.
+- R5. Applies globally to all games via `useTouchDrag` (bank tiles only).
+- R6. Intentional drags (> threshold) that return to bank still cancel.
+
+## Scope Boundaries
+
+- Time-based detection (rejected)
+- Drag recording/analytics (deferred)
+- Desktop HTML5 DnD behavior (unaffected — touch-only)
+- Fast-tap queue from PR #287 (unaffected)
+- Slot tile drag behavior (unaffected — only bank tiles get tap forgiveness)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/components/answer-game/useTouchDrag.ts` — `DRAG_THRESHOLD_PX = 8`,
+  `onPointerUp` handler with priority-ordered drop detection
+- `src/components/answer-game/useDraggableTile.ts` — consumes `useTouchDrag`,
+  defines `handleClick` which calls `speakTile` + `placeInNextSlot`
+- `src/components/answer-game/useSlotTileDrag.ts` — also consumes
+  `useTouchDrag` but for slot-to-slot drags (no tap fallback needed)
+- `src/db/schemas/settings.ts` — `SettingsDoc` with existing optional numeric
+  fields (volume, speechRate)
+- `src/db/hooks/useSettings.ts` — `useSettings()` hook with `settings` object
+  and `update` function; merges defaults
+- `src/routes/$locale/_app/settings.tsx` — `<Slider>` pattern for
+  volume/speechRate already exists
+
+## Key Technical Decisions
+
+- **`onTapFallback` callback pattern**: `useTouchDrag` receives an optional
+  callback. When provided + conditions met, it fires instead of the normal
+  drop/cancel path. `useDraggableTile` passes it; `useSlotTileDrag` doesn't.
+  This avoids adding game-specific awareness into the shared hook.
+- **Read settings inside `useDraggableTile`**: The hook already calls
+  `useAutoNextSlot`, `useGameTTS`, etc. Adding `useSettings()` follows the
+  same pattern and keeps `useTouchDrag` free of database concerns.
+- **Euclidean distance, not axis-independent**: A single
+  `Math.hypot(dx, dy)` call is simple and matches how users perceive
+  movement regardless of direction.
+- **Default 20px**: ~2.5x the drag-start threshold. Forgiving enough for
+  sloppy taps without catching intentional drags. Tunable per-child via
+  settings.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should slot tile drags get tap forgiveness?** No — slot tiles are already
+  placed; a micro-drag returning to the same slot is correctly a no-op.
+- **Should `useTouchDrag` own the settings read?** No — it's a generic
+  pointer-events hook. Keeping it settings-unaware improves testability.
+
+### Deferred to Implementation
+
+- Exact i18n key name for the settings label (follow existing pattern in
+  translation files).
+
+## Implementation Units
+
+- U1. **Settings schema field**
+
+**Goal:** Add `tapForgivenessThreshold` to the settings schema so it persists
+per profile.
+
+**Requirements:** R3
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `src/db/schemas/settings.ts`
+- Modify: `src/db/hooks/useSettings.ts` (add default to `DEFAULT_SETTINGS`)
+
+**Approach:**
+
+- Add optional `tapForgivenessThreshold?: number` to `SettingsDoc` interface.
+- Add to schema properties with `type: 'number'`, `minimum: 8`, `maximum: 60`,
+  `default: 20`.
+- Add `tapForgivenessThreshold: 20` to `DEFAULT_SETTINGS` in `useSettings.ts`.
+
+**Patterns to follow:**
+
+- Existing `volume` and `speechRate` fields in the same schema.
+
+**Test expectation:** none — pure schema/type addition with no behavioral
+change. TypeScript compilation verifies the type is correct.
+
+**Verification:**
+
+- `yarn typecheck` passes with the new field.
+
+- U2. **Tap forgiveness logic in `useTouchDrag`**
+
+**Goal:** Add the distance-check logic to `onPointerUp` that fires
+`onTapFallback` when conditions are met.
+
+**Requirements:** R1, R2, R5, R6
+
+**Dependencies:** None (uses threshold as a param, not from settings directly)
+
+**Files:**
+
+- Modify: `src/components/answer-game/useTouchDrag.ts`
+- Create: `src/components/answer-game/useTouchDrag.test.ts`
+
+**Approach:**
+
+- Add two optional fields to `UseTouchDragOptions`: `tapForgivenessThreshold`
+  (number) and `onTapFallback` (callback `() => void`).
+- In `onPointerUp`, after confirming `isDragging.current === true`, before
+  existing drop detection logic: calculate Euclidean distance from
+  `startPos.current` to `(e.clientX, e.clientY)`. If distance <
+  `tapForgivenessThreshold` AND no zone is detected at center point AND
+  `onTapFallback` is defined → call `onTapFallback`, `cleanup()`, return
+  early.
+- Store `onTapFallback` in a ref (same pattern as `onDragCancelRef`).
+
+**Execution note:** Write failing tests first (micro-drag scenario should
+call `onTapFallback`; normal drag should NOT).
+
+**Patterns to follow:**
+
+- `onDragCancelRef` pattern for storing callback refs.
+- Existing `findZoneAt` helper for zone detection.
+
+**Test scenarios:**
+
+- Happy path: pointer moves 12px (< 20px threshold), no zone under pointer →
+  `onTapFallback` is called, `onDrop` is NOT called.
+- Happy path: pointer moves 12px but IS over a zone → normal drop fires (zone
+  takes priority over tap forgiveness).
+- Edge case: pointer moves exactly at threshold boundary (19.9px vs 20.1px) →
+  below fires fallback, above does not.
+- Edge case: `onTapFallback` is undefined (slot tile drag case) → normal
+  cancel path fires even for micro-drags.
+- Error path: `startPos.current` is null → no crash, early return.
+
+**Verification:**
+
+- All new tests pass.
+- Existing `useDraggableTile.test.tsx` and `useSlotTileDrag.test.tsx` still
+  pass (no regression).
+
+- U3. **Wire tap forgiveness in `useDraggableTile`**
+
+**Goal:** Connect the settings threshold and `placeInNextSlot` as the tap
+fallback for bank tile drags.
+
+**Requirements:** R1, R3, R5
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- Modify: `src/components/answer-game/useDraggableTile.ts`
+- Modify: `src/components/answer-game/useDraggableTile.test.tsx`
+
+**Approach:**
+
+- Import `useSettings` in `useDraggableTile`.
+- Read `settings.tapForgivenessThreshold` (falls back to default 20).
+- Pass `tapForgivenessThreshold` and `onTapFallback: () => placeInNextSlot(tile.id)` to `useTouchDrag`.
+- Note: `onDragStart` already speaks the tile, so `onTapFallback` only needs
+  to place — no double-speak.
+
+**Execution note:** Add a test that simulates a micro-drag through the full
+`useDraggableTile` hook and asserts `placeInNextSlot` is called.
+
+**Patterns to follow:**
+
+- Existing `handleClick` in same file (speaks + places).
+- Existing `useGameTTS` / `useAutoNextSlot` import pattern.
+
+**Test scenarios:**
+
+- Happy path: micro-drag (< threshold) on a bank tile → `placeInNextSlot`
+  called with tile.id.
+- Happy path: normal drag (> threshold) → existing drop/cancel path (no
+  placement).
+- Integration: `onDragStart` speaks tile, then micro-drag fallback places
+  tile → tile is spoken once and placed once.
+
+**Verification:**
+
+- `yarn typecheck` passes.
+- `npx vitest run src/components/answer-game/useDraggableTile.test.tsx` passes.
+
+- U4. **Settings UI slider**
+
+**Goal:** Expose the tap forgiveness threshold in the settings page for
+tuning.
+
+**Requirements:** R4
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `src/routes/$locale/_app/settings.tsx`
+
+**Approach:**
+
+- Add a `<Slider>` block following the volume/speechRate pattern.
+- `min={8}` (same as drag-start threshold — below this nothing changes),
+  `max={60}`, `step={1}`.
+- Label shows current value in pixels.
+- `onValueChange` calls `update({ tapForgivenessThreshold: v })`.
+
+**Patterns to follow:**
+
+- Volume slider in same file (exact same structure).
+
+**Test scenarios:**
+
+- Happy path: slider renders with current setting value (or default 20).
+- Happy path: sliding to 30 calls `update({ tapForgivenessThreshold: 30 })`.
+- Edge case: no settings doc yet → slider shows default 20.
+
+**Verification:**
+
+- Settings page renders without error.
+- Slider is visible and interactive.
+
+- U5. **Architecture docs update**
+
+**Goal:** Document the tap forgiveness path in the flows docs (required per
+CLAUDE.md when modifying `src/components/answer-game/` drag-related files).
+
+**Requirements:** R1 (documentation of new behavior)
+
+**Dependencies:** U2, U3
+
+**Files:**
+
+- Modify: `src/components/answer-game/AnswerGame/AnswerGame.flows.mdx`
+
+**Approach:**
+
+- Add a "Tap forgiveness" subsection near the existing bank tile tap/drag
+  flow documentation.
+- Describe the pointer-up distance check and when `onTapFallback` fires.
+
+**Test expectation:** none — documentation only.
+
+**Verification:**
+
+- `yarn fix:md` passes on the modified file.
+
+## System-Wide Impact
+
+- **Interaction graph:** `useTouchDrag` → `onTapFallback` → `placeInNextSlot`
+  → same path as `handleClick` (speak already happened at drag-start).
+- **State lifecycle risks:** None — tap forgiveness fires before any zone
+  mutation occurs. The existing `cleanup()` path clears ghost/pointer state.
+- **Unchanged invariants:** Slot tile drag behavior via `useSlotTileDrag` is
+  completely unaffected. Desktop HTML5 DnD is unaffected (gated by
+  `pointerType !== 'mouse'`). The fast-tap queue from PR #287 operates
+  independently inside `useAutoNextSlot`.
+
+## Risks & Dependencies
+
+| Risk                                                                  | Mitigation                                                                            |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| 20px too generous — catches some intentional drags                    | Threshold is configurable per-profile; start conservative and tune with real users    |
+| Settings schema migration if field added after production data exists | Field is optional with a hardcoded default; existing docs without the field work fine |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-01-tap-forgiveness-requirements.md](docs/brainstorms/2026-05-01-tap-forgiveness-requirements.md)
+- Related code: `src/components/answer-game/useTouchDrag.ts`
+- Related PRs/issues: #298, #276, PR #287

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "yarn dev",
     "dev": "vite dev --port 3000",
+    "devhost": "VITE_HTTPS=1 vite dev --host --port 3000",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
@@ -96,6 +97,7 @@
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-basic-ssl": "^2.3.0",
     "@vitejs/plugin-react": "^5.1.4",
     "@vitest/coverage-v8": "3.2.4",
     "eslint": "^9.18.0",

--- a/src/components/SettingsPanel/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel/SettingsPanel.test.tsx
@@ -74,4 +74,18 @@ describe('SettingsPanel', () => {
     renderSettingsPanel(db);
     expect(screen.getByText(/system default/i)).toBeInTheDocument();
   });
+
+  it('renders tap forgiveness distance slider with default 17px', () => {
+    renderSettingsPanel(db);
+    expect(
+      screen.getByText(/tap forgiveness — distance \(17px\)/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders tap forgiveness duration slider with default 150ms', () => {
+    renderSettingsPanel(db);
+    expect(
+      screen.getByText(/tap forgiveness — duration \(150ms\)/i),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/SettingsPanel/SettingsPanel.tsx
+++ b/src/components/SettingsPanel/SettingsPanel.tsx
@@ -41,6 +41,8 @@ export const SettingsPanel = ({
   const preferredVoice = settings.preferredVoiceURI ?? '';
   const voiceSelectValue =
     preferredVoice === '' ? '__default__' : preferredVoice;
+  const tapForgiveness = settings.tapForgivenessThreshold ?? 17;
+  const tapForgivenessTime = settings.tapForgivenessTimeMs ?? 150;
 
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
   const [voicesLoaded, setVoicesLoaded] = useState(() => {
@@ -173,6 +175,38 @@ export const SettingsPanel = ({
           </Select>
         </div>
       )}
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="settings-tapForgiveness">
+          {t('tapForgiveness', { px: tapForgiveness })}
+        </Label>
+        <Slider
+          id="settings-tapForgiveness"
+          min={0}
+          max={100}
+          step={1}
+          value={[tapForgiveness]}
+          onValueChange={([v]) =>
+            void update({ tapForgivenessThreshold: v })
+          }
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="settings-tapForgivenessTime">
+          {t('tapForgivenessTime', { ms: tapForgivenessTime })}
+        </Label>
+        <Slider
+          id="settings-tapForgivenessTime"
+          min={0}
+          max={500}
+          step={10}
+          value={[tapForgivenessTime]}
+          onValueChange={([v]) =>
+            void update({ tapForgivenessTimeMs: v })
+          }
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/answer-game/AnswerGame/AnswerGame.flows.mdx
+++ b/src/components/answer-game/AnswerGame/AnswerGame.flows.mdx
@@ -111,10 +111,23 @@ sequenceDiagram
 
 **Tap forgiveness (micro-drag → tap, touch only):**
 
-When a touch drag ends and total displacement from start is below
-`tapForgivenessThreshold` (configurable per-profile, default 20px)
-and no slot zone is under the pointer, the gesture is treated as a
-tap instead of a cancelled drag.
+When a touch drag ends, the gesture is treated as a tap (placing the
+tile in the next available slot) when **either** signal is below its
+threshold AND no slot zone is under the pointer:
+
+- **Distance:** Euclidean displacement from `pointerdown` to
+  `pointerup` < `tapForgivenessThreshold` (default 20px). Catches slow
+  careful taps where the finger barely moved.
+- **Duration:** elapsed time from `pointerdown` to `pointerup` <
+  `tapForgivenessTimeMs` (default 150ms). Catches thumb-release drift
+  — on touch devices a brief tap can register 75–100px of contact
+  movement in 50–65ms even when the user perceives no movement.
+
+Both thresholds are configurable per-profile in the settings page.
+Setting either to 0 disables that signal. The same check fires from
+`onPointerCancel` so platforms that fire `pointercancel` instead of
+`pointerup` for short gestures (documented iOS Safari behaviour) are
+also covered.
 
 ```mermaid
 sequenceDiagram

--- a/src/components/answer-game/AnswerGame/AnswerGame.flows.mdx
+++ b/src/components/answer-game/AnswerGame/AnswerGame.flows.mdx
@@ -109,6 +109,29 @@ sequenceDiagram
   Hook->>Reducer: SET_DRAG_ACTIVE { tileId: null }
 ```
 
+**Tap forgiveness (micro-drag → tap, touch only):**
+
+When a touch drag ends and total displacement from start is below
+`tapForgivenessThreshold` (configurable per-profile, default 20px)
+and no slot zone is under the pointer, the gesture is treated as a
+tap instead of a cancelled drag.
+
+```mermaid
+sequenceDiagram
+  actor User
+  participant Hook as useTouchDrag (onPointerUp)
+  participant Fallback as useDraggableTile (onTapFallback)
+  participant Reducer as answerGameReducer
+  participant Auto as useAutoNextSlot
+
+  User->>Hook: pointer up (displacement < threshold)
+  Hook->>Hook: check: no zone under pointer?
+  Hook->>Fallback: onTapFallback()
+  Fallback->>Reducer: SET_DRAG_ACTIVE { tileId: null }
+  Fallback->>Auto: placeInNextSlot(tile.id)
+  Auto->>Reducer: PLACE_TILE { tileId, zoneIndex: activeSlotIndex }
+```
+
 ---
 
 ## 4. Keyboard and Touch Input

--- a/src/components/answer-game/useDraggableTile.test.tsx
+++ b/src/components/answer-game/useDraggableTile.test.tsx
@@ -97,10 +97,24 @@ vi.mock('@/lib/game-event-bus', () => ({
   getGameEventBus: () => ({ emit: mockEmit, subscribe: vi.fn() }),
 }));
 
+vi.mock('@/db/hooks/useSettings', () => ({
+  useSettings: () => ({
+    settings: {
+      tapForgivenessThreshold: 17,
+      tapForgivenessTimeMs: 150,
+    },
+    update: vi.fn(),
+  }),
+}));
+
+// Capture the options passed to useTouchDrag so tests can invoke the touch
+// callbacks directly without simulating real pointer events.
 type CapturedTouchDragOptions = {
   onDrop?: (tileId: string, zoneIndex: number) => void;
   onDropOnBank?: () => void;
   onDropOnBankTile?: (bankTileId: string) => void;
+  onTapFallback?: () => void;
+  tapForgivenessThreshold?: number;
 };
 
 let capturedTouchDragOptions: CapturedTouchDragOptions | null = null;
@@ -372,6 +386,38 @@ describe('useDraggableTile', () => {
       act(() => onDrop?.('t2', 0));
 
       expect(mockTriggerShake).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('touch drag — tap forgiveness', () => {
+    it('passes tapForgivenessThreshold from settings to useTouchDrag', () => {
+      capturedTouchDragOptions = null;
+      renderHook(() => useDraggableTile(tile));
+
+      expect(capturedTouchDragOptions).not.toBeNull();
+      const opts =
+        capturedTouchDragOptions as unknown as CapturedTouchDragOptions;
+      expect(opts.tapForgivenessThreshold).toBe(17);
+    });
+
+    it('onTapFallback clears drag state and places tile in next slot', () => {
+      capturedTouchDragOptions = null;
+      mockDispatch.mockClear();
+      mockPlaceInNextSlot.mockClear();
+
+      renderHook(() => useDraggableTile(tile));
+
+      expect(capturedTouchDragOptions).not.toBeNull();
+      const opts =
+        capturedTouchDragOptions as unknown as CapturedTouchDragOptions;
+      expect(opts.onTapFallback).toBeDefined();
+      act(() => opts.onTapFallback?.());
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_DRAG_ACTIVE',
+        tileId: null,
+      });
+      expect(mockPlaceInNextSlot).toHaveBeenCalledWith(tile.id);
     });
   });
 });

--- a/src/components/answer-game/useDraggableTile.ts
+++ b/src/components/answer-game/useDraggableTile.ts
@@ -141,6 +141,7 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
         }
       },
       tapForgivenessThreshold: settings.tapForgivenessThreshold ?? 20,
+      tapForgivenessTimeMs: settings.tapForgivenessTimeMs ?? 150,
       onTapFallback: () => {
         dispatch({ type: 'SET_DRAG_ACTIVE', tileId: null });
         const result = placeInNextSlot(tile.id);

--- a/src/components/answer-game/useDraggableTile.ts
+++ b/src/components/answer-game/useDraggableTile.ts
@@ -140,10 +140,47 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
           });
         }
       },
-      tapForgivenessThreshold: settings.tapForgivenessThreshold,
+      tapForgivenessThreshold: settings.tapForgivenessThreshold ?? 20,
       onTapFallback: () => {
         dispatch({ type: 'SET_DRAG_ACTIVE', tileId: null });
-        placeInNextSlot(tile.id);
+        const result = placeInNextSlot(tile.id);
+
+        const bankEl = ref.current;
+        if (result.rejected && bankEl) {
+          bankEl.dataset.shaking = 'true';
+          flashBankTileRejectFeedback(tile.id, {
+            element: bankEl,
+            onAnimationEnd: () => {
+              delete bankEl.dataset.shaking;
+            },
+          });
+
+          if (!skin.suppressDefaultSounds) {
+            playSound('wrong', 0.8);
+          }
+
+          dispatch({
+            type: 'REJECT_TAP',
+            tileId: tile.id,
+            zoneIndex: result.zoneIndex,
+          });
+
+          getGameEventBus().emit({
+            type: 'game:evaluate',
+            gameId: stateRef.current.config.gameId,
+            sessionId: '',
+            profileId: '',
+            timestamp: Date.now(),
+            roundIndex: stateRef.current.roundIndex,
+            answer: tile.id,
+            correct: false,
+            nearMiss: false,
+            zoneIndex: result.zoneIndex,
+            expected:
+              stateRef.current.zones[result.zoneIndex]?.expectedValue ??
+              '',
+          });
+        }
       },
     });
 

--- a/src/components/answer-game/useDraggableTile.ts
+++ b/src/components/answer-game/useDraggableTile.ts
@@ -13,6 +13,7 @@ import { useTouchDrag } from './useTouchDrag';
 import type { TileItem } from './types';
 import type { TouchDragHandlers } from './useTouchDrag';
 import type { RefObject } from 'react';
+import { useSettings } from '@/db/hooks/useSettings';
 import { playSound } from '@/lib/audio/AudioFeedback';
 import { getGameEventBus } from '@/lib/game-event-bus';
 import { resolveSkin } from '@/lib/skin';
@@ -34,6 +35,7 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
   const { speakTile } = useGameTTS();
   const speakTileRef = useRef(speakTile);
   const { placeTile } = useTileEvaluation();
+  const { settings } = useSettings();
   const skin = resolveSkin(state.config.gameId, state.config.skin);
 
   useEffect(() => {
@@ -137,6 +139,11 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
             zoneIndex,
           });
         }
+      },
+      tapForgivenessThreshold: settings.tapForgivenessThreshold,
+      onTapFallback: () => {
+        dispatch({ type: 'SET_DRAG_ACTIVE', tileId: null });
+        placeInNextSlot(tile.id);
       },
     });
 

--- a/src/components/answer-game/useDraggableTile.ts
+++ b/src/components/answer-game/useDraggableTile.ts
@@ -140,7 +140,7 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
           });
         }
       },
-      tapForgivenessThreshold: settings.tapForgivenessThreshold ?? 20,
+      tapForgivenessThreshold: settings.tapForgivenessThreshold ?? 17,
       tapForgivenessTimeMs: settings.tapForgivenessTimeMs ?? 150,
       onTapFallback: () => {
         dispatch({ type: 'SET_DRAG_ACTIVE', tileId: null });

--- a/src/components/answer-game/useTouchDrag.test.ts
+++ b/src/components/answer-game/useTouchDrag.test.ts
@@ -1,0 +1,199 @@
+import { act, renderHook } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { useTouchDrag } from './useTouchDrag';
+import type { PointerEvent } from 'react';
+
+let target: HTMLButtonElement;
+
+beforeEach(() => {
+  document.elementsFromPoint = vi.fn().mockReturnValue([]);
+  target = document.createElement('button');
+  target.textContent = 'A';
+  target.style.width = '60px';
+  target.style.height = '60px';
+  document.body.append(target);
+  target.setPointerCapture = vi.fn();
+  target.releasePointerCapture = vi.fn();
+  target.getBoundingClientRect = () => ({
+    width: 60,
+    height: 60,
+    top: 0,
+    left: 0,
+    right: 60,
+    bottom: 60,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  });
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+const ev = (
+  overrides: Partial<PointerEvent<HTMLElement>> = {},
+): PointerEvent<HTMLElement> =>
+  ({
+    pointerType: 'touch',
+    clientX: 0,
+    clientY: 0,
+    pointerId: 1,
+    currentTarget: target,
+    ...overrides,
+  }) as unknown as PointerEvent<HTMLElement>;
+
+describe('useTouchDrag — tap forgiveness', () => {
+  it('calls onTapFallback when drag displacement is below threshold and no zone detected', () => {
+    const onTapFallback = vi.fn();
+    const onDrop = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTouchDrag({
+        tileId: 'tile-1',
+        label: 'A',
+        onDrop,
+        onTapFallback,
+        tapForgivenessThreshold: 20,
+      }),
+    );
+
+    act(() => {
+      result.current.onPointerDown(ev({ clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerMove(ev({ clientX: 110, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerUp(ev({ clientX: 112, clientY: 100 }));
+    });
+
+    expect(onTapFallback).toHaveBeenCalledOnce();
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onTapFallback when drag displacement exceeds threshold', () => {
+    const onTapFallback = vi.fn();
+    const onDrop = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTouchDrag({
+        tileId: 'tile-1',
+        label: 'A',
+        onDrop,
+        onTapFallback,
+        tapForgivenessThreshold: 20,
+      }),
+    );
+
+    act(() => {
+      result.current.onPointerDown(ev({ clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerMove(ev({ clientX: 125, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerUp(ev({ clientX: 130, clientY: 100 }));
+    });
+
+    expect(onTapFallback).not.toHaveBeenCalled();
+  });
+
+  it('drops on zone even when below tap forgiveness threshold', () => {
+    const onTapFallback = vi.fn();
+    const onDrop = vi.fn();
+
+    const zoneEl = document.createElement('div');
+    zoneEl.dataset['zoneIndex'] = '0';
+    (
+      document.elementsFromPoint as ReturnType<typeof vi.fn>
+    ).mockReturnValue([zoneEl]);
+
+    const { result } = renderHook(() =>
+      useTouchDrag({
+        tileId: 'tile-1',
+        label: 'A',
+        onDrop,
+        onTapFallback,
+        tapForgivenessThreshold: 20,
+      }),
+    );
+
+    act(() => {
+      result.current.onPointerDown(ev({ clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerMove(ev({ clientX: 110, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerUp(ev({ clientX: 112, clientY: 100 }));
+    });
+
+    expect(onDrop).toHaveBeenCalledWith('tile-1', 0);
+    expect(onTapFallback).not.toHaveBeenCalled();
+  });
+
+  it('does not call onTapFallback when it is undefined (slot tile case)', () => {
+    const onDrop = vi.fn();
+    const onDragCancel = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTouchDrag({
+        tileId: 'tile-1',
+        label: 'A',
+        onDrop,
+        onDragCancel,
+        tapForgivenessThreshold: 20,
+      }),
+    );
+
+    act(() => {
+      result.current.onPointerDown(ev({ clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerMove(ev({ clientX: 110, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerUp(ev({ clientX: 112, clientY: 100 }));
+    });
+
+    expect(onDragCancel).toHaveBeenCalled();
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it('handles threshold boundary correctly (exactly at threshold does NOT fire)', () => {
+    const onTapFallback = vi.fn();
+    const onDrop = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTouchDrag({
+        tileId: 'tile-1',
+        label: 'A',
+        onDrop,
+        onTapFallback,
+        tapForgivenessThreshold: 20,
+      }),
+    );
+
+    act(() => {
+      result.current.onPointerDown(ev({ clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerMove(ev({ clientX: 109, clientY: 100 }));
+    });
+    // Exactly 20px from start
+    act(() => {
+      result.current.onPointerUp(ev({ clientX: 120, clientY: 100 }));
+    });
+
+    expect(onTapFallback).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/answer-game/useTouchDrag.test.ts
+++ b/src/components/answer-game/useTouchDrag.test.ts
@@ -196,3 +196,99 @@ describe('useTouchDrag — tap forgiveness', () => {
     expect(onTapFallback).not.toHaveBeenCalled();
   });
 });
+
+describe('useTouchDrag — tap forgiveness on pointercancel', () => {
+  it('calls onTapFallback when pointercancel fires with small displacement', () => {
+    const onTapFallback = vi.fn();
+    const onDrop = vi.fn();
+    const onDragCancel = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTouchDrag({
+        tileId: 'tile-1',
+        label: 'A',
+        onDrop,
+        onDragCancel,
+        onTapFallback,
+        tapForgivenessThreshold: 20,
+      }),
+    );
+
+    act(() => {
+      result.current.onPointerDown(ev({ clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerMove(ev({ clientX: 110, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerCancel(
+        ev({ clientX: 112, clientY: 100 }),
+      );
+    });
+
+    expect(onTapFallback).toHaveBeenCalledOnce();
+    expect(onDragCancel).not.toHaveBeenCalled();
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it('calls onDragCancel when pointercancel displacement exceeds threshold', () => {
+    const onTapFallback = vi.fn();
+    const onDrop = vi.fn();
+    const onDragCancel = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTouchDrag({
+        tileId: 'tile-1',
+        label: 'A',
+        onDrop,
+        onDragCancel,
+        onTapFallback,
+        tapForgivenessThreshold: 20,
+      }),
+    );
+
+    act(() => {
+      result.current.onPointerDown(ev({ clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerMove(ev({ clientX: 130, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerCancel(
+        ev({ clientX: 135, clientY: 100 }),
+      );
+    });
+
+    expect(onTapFallback).not.toHaveBeenCalled();
+    expect(onDragCancel).toHaveBeenCalled();
+  });
+
+  it('calls onDragCancel (not onTapFallback) when tap forgiveness is not configured', () => {
+    const onDrop = vi.fn();
+    const onDragCancel = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTouchDrag({
+        tileId: 'tile-1',
+        label: 'A',
+        onDrop,
+        onDragCancel,
+      }),
+    );
+
+    act(() => {
+      result.current.onPointerDown(ev({ clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerMove(ev({ clientX: 110, clientY: 100 }));
+    });
+    act(() => {
+      result.current.onPointerCancel(
+        ev({ clientX: 112, clientY: 100 }),
+      );
+    });
+
+    expect(onDragCancel).toHaveBeenCalled();
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/answer-game/useTouchDrag.test.ts
+++ b/src/components/answer-game/useTouchDrag.test.ts
@@ -141,7 +141,7 @@ describe('useTouchDrag — tap forgiveness', () => {
     expect(onTapFallback).not.toHaveBeenCalled();
   });
 
-  it('does not call onTapFallback when it is undefined (slot tile case)', () => {
+  it('cancels drag normally when tap forgiveness is not configured (slot tile case)', () => {
     const onDrop = vi.fn();
     const onDragCancel = vi.fn();
 
@@ -151,7 +151,6 @@ describe('useTouchDrag — tap forgiveness', () => {
         label: 'A',
         onDrop,
         onDragCancel,
-        tapForgivenessThreshold: 20,
       }),
     );
 

--- a/src/components/answer-game/useTouchDrag.test.ts
+++ b/src/components/answer-game/useTouchDrag.test.ts
@@ -292,3 +292,147 @@ describe('useTouchDrag — tap forgiveness on pointercancel', () => {
     expect(onDrop).not.toHaveBeenCalled();
   });
 });
+
+describe('useTouchDrag — tap forgiveness time threshold', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls onTapFallback when duration is short even if distance exceeds threshold (thumb-drift case)', () => {
+    // Reproduces android-quick-drag.log: 50ms, 96px displacement.
+    // Distance fails (96 > 20) but duration passes (50 < 150).
+    const onTapFallback = vi.fn();
+    const onDrop = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTouchDrag({
+        tileId: 'tile-1',
+        label: 'A',
+        onDrop,
+        onTapFallback,
+        tapForgivenessThreshold: 20,
+        tapForgivenessTimeMs: 150,
+      }),
+    );
+
+    vi.setSystemTime(new Date(0));
+    act(() => {
+      result.current.onPointerDown(ev({ clientX: 100, clientY: 100 }));
+    });
+    vi.advanceTimersByTime(15);
+    act(() => {
+      result.current.onPointerMove(ev({ clientX: 110, clientY: 100 }));
+    });
+    vi.advanceTimersByTime(35); // total ~50ms, like the captured failing tap
+    act(() => {
+      result.current.onPointerUp(ev({ clientX: 192, clientY: 196 })); // 96px from start
+    });
+
+    expect(onTapFallback).toHaveBeenCalledOnce();
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onTapFallback when duration AND distance both exceed thresholds', () => {
+    // Reproduces android-quick-but-not-short: 288ms, 448px. Both checks fail.
+    const onTapFallback = vi.fn();
+    const onDrop = vi.fn();
+    const onDragCancel = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTouchDrag({
+        tileId: 'tile-1',
+        label: 'A',
+        onDrop,
+        onDragCancel,
+        onTapFallback,
+        tapForgivenessThreshold: 20,
+        tapForgivenessTimeMs: 150,
+      }),
+    );
+
+    vi.setSystemTime(new Date(0));
+    act(() => {
+      result.current.onPointerDown(ev({ clientX: 100, clientY: 100 }));
+    });
+    vi.advanceTimersByTime(20);
+    act(() => {
+      result.current.onPointerMove(ev({ clientX: 110, clientY: 100 }));
+    });
+    vi.advanceTimersByTime(270); // total ~290ms — past 150ms time threshold
+    act(() => {
+      result.current.onPointerUp(ev({ clientX: 410, clientY: 400 })); // ~424px from start
+    });
+
+    expect(onTapFallback).not.toHaveBeenCalled();
+    expect(onDragCancel).toHaveBeenCalled();
+  });
+
+  it('falls back to distance-only check when tapForgivenessTimeMs is undefined', () => {
+    // Backwards compatibility: existing behaviour (distance < 20) still works
+    // when caller does not opt into the time threshold.
+    const onTapFallback = vi.fn();
+    const onDrop = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTouchDrag({
+        tileId: 'tile-1',
+        label: 'A',
+        onDrop,
+        onTapFallback,
+        tapForgivenessThreshold: 20,
+      }),
+    );
+
+    vi.setSystemTime(new Date(0));
+    act(() => {
+      result.current.onPointerDown(ev({ clientX: 100, clientY: 100 }));
+    });
+    vi.advanceTimersByTime(20);
+    act(() => {
+      result.current.onPointerMove(ev({ clientX: 110, clientY: 100 }));
+    });
+    vi.advanceTimersByTime(30); // 50ms total — short, but no time threshold opted in
+    act(() => {
+      result.current.onPointerUp(ev({ clientX: 200, clientY: 100 })); // 100px — fails distance
+    });
+
+    // No time threshold → only distance check → 100 > 20 → no tap fallback
+    expect(onTapFallback).not.toHaveBeenCalled();
+  });
+
+  it('time threshold also applies to onPointerCancel path', () => {
+    const onTapFallback = vi.fn();
+    const onDrop = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTouchDrag({
+        tileId: 'tile-1',
+        label: 'A',
+        onDrop,
+        onTapFallback,
+        tapForgivenessThreshold: 20,
+        tapForgivenessTimeMs: 150,
+      }),
+    );
+
+    vi.setSystemTime(new Date(0));
+    act(() => {
+      result.current.onPointerDown(ev({ clientX: 100, clientY: 100 }));
+    });
+    vi.advanceTimersByTime(15);
+    act(() => {
+      result.current.onPointerMove(ev({ clientX: 110, clientY: 100 }));
+    });
+    vi.advanceTimersByTime(40);
+    act(() => {
+      result.current.onPointerCancel(
+        ev({ clientX: 192, clientY: 196 }), // 96px — fails distance, but 55ms total
+      );
+    });
+
+    expect(onTapFallback).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/answer-game/useTouchDrag.ts
+++ b/src/components/answer-game/useTouchDrag.ts
@@ -72,8 +72,23 @@ interface UseTouchDragBaseOptions {
 
 type UseTouchDragOptions = UseTouchDragBaseOptions &
   (
-    | { tapForgivenessThreshold?: undefined; onTapFallback?: undefined }
-    | { tapForgivenessThreshold: number; onTapFallback: () => void }
+    | {
+        tapForgivenessThreshold?: undefined;
+        tapForgivenessTimeMs?: undefined;
+        onTapFallback?: undefined;
+      }
+    | {
+        tapForgivenessThreshold: number;
+        /**
+         * Optional duration ceiling (milliseconds). If the gesture's
+         * total time from pointerdown to up/cancel is shorter, treat as
+         * a tap regardless of distance. Catches thumb-release drift
+         * where the contact point can travel 75–100px in 50–65ms even
+         * for what the user perceives as a tap.
+         */
+        tapForgivenessTimeMs?: number;
+        onTapFallback: () => void;
+      }
   );
 
 export const useTouchDrag = ({
@@ -87,6 +102,7 @@ export const useTouchDrag = ({
   onHoverZone,
   onHoverBankTile,
   tapForgivenessThreshold,
+  tapForgivenessTimeMs,
   onTapFallback,
 }: UseTouchDragOptions): TouchDragHandlers => {
   const onDragCancelRef = useRef(onDragCancel);
@@ -112,6 +128,7 @@ export const useTouchDrag = ({
   const ghostRef = useRef<GhostInfo | null>(null);
   const isDragging = useRef(false);
   const startPos = useRef<{ x: number; y: number } | null>(null);
+  const startTime = useRef<number | null>(null);
   const capturedElRef = useRef<HTMLElement | null>(null);
   const capturedPointerIdRef = useRef<number | null>(null);
   const safetyTimerRef = useRef<ReturnType<
@@ -155,6 +172,7 @@ export const useTouchDrag = ({
     lastHoverZoneRef.current = null;
     lastHoverBankTileRef.current = null;
     startPos.current = null;
+    startTime.current = null;
     cleanupInProgressRef.current = false;
   }, []);
 
@@ -169,6 +187,7 @@ export const useTouchDrag = ({
       capturedElRef.current = e.currentTarget;
       capturedPointerIdRef.current = e.pointerId;
       startPos.current = { x: e.clientX, y: e.clientY };
+      startTime.current = Date.now();
       isDragging.current = false;
 
       // When the captured element is removed from the DOM (e.g. a slot tile
@@ -296,8 +315,11 @@ export const useTouchDrag = ({
       if (e.pointerType === 'mouse' || !startPos.current) return;
 
       if (isDragging.current) {
-        // Tap forgiveness: if the total displacement is below the threshold
-        // and no slot zone is under the pointer, treat this as a tap.
+        // Tap forgiveness: treat as a tap if EITHER displacement is small
+        // (slow careful tap) OR duration is short (thumb-release drift —
+        // the contact point can travel 75–100px in 50–65ms during release
+        // even when the user perceives no movement). Both signals are
+        // configurable per-profile.
         if (
           tapForgivenessThreshold !== undefined &&
           onTapFallbackRef.current
@@ -305,7 +327,15 @@ export const useTouchDrag = ({
           const dx = e.clientX - startPos.current.x;
           const dy = e.clientY - startPos.current.y;
           const dist = Math.hypot(dx, dy);
-          if (dist < tapForgivenessThreshold) {
+          const duration =
+            startTime.current === null
+              ? Number.POSITIVE_INFINITY
+              : Date.now() - startTime.current;
+          const distancePassed = dist < tapForgivenessThreshold;
+          const timePassed =
+            tapForgivenessTimeMs !== undefined &&
+            duration < tapForgivenessTimeMs;
+          if (distancePassed || timePassed) {
             // Check there's no zone under the center point before treating as tap.
             ghostRef.current?.el.remove();
             ghostRef.current = null;
@@ -474,6 +504,7 @@ export const useTouchDrag = ({
       onDropOnBank,
       onDropOnBankTile,
       tapForgivenessThreshold,
+      tapForgivenessTimeMs,
       cleanup,
     ],
   );
@@ -482,9 +513,10 @@ export const useTouchDrag = ({
     (e: PointerEvent<HTMLElement>) => {
       if (e.pointerType === 'mouse') return;
       if (isDragging.current) {
-        // Tap forgiveness: iOS Safari (and some Android browsers) fire pointercancel
-        // instead of pointerup for short gestures, even with touch-action:none set.
-        // Apply the same micro-drag check here so the threshold actually takes effect.
+        // Mirror the same tap forgiveness rules here. Defends against any
+        // platform that fires pointercancel rather than pointerup for short
+        // gestures (documented but not observed on Chrome Android or Brave
+        // iOS in our captures — kept as defence in depth).
         if (
           startPos.current &&
           tapForgivenessThreshold !== undefined &&
@@ -492,7 +524,16 @@ export const useTouchDrag = ({
         ) {
           const dx = e.clientX - startPos.current.x;
           const dy = e.clientY - startPos.current.y;
-          if (Math.hypot(dx, dy) < tapForgivenessThreshold) {
+          const dist = Math.hypot(dx, dy);
+          const duration =
+            startTime.current === null
+              ? Number.POSITIVE_INFINITY
+              : Date.now() - startTime.current;
+          const distancePassed = dist < tapForgivenessThreshold;
+          const timePassed =
+            tapForgivenessTimeMs !== undefined &&
+            duration < tapForgivenessTimeMs;
+          if (distancePassed || timePassed) {
             onTapFallbackRef.current();
             cleanupGhost();
             return;
@@ -502,7 +543,7 @@ export const useTouchDrag = ({
       }
       cleanupGhost();
     },
-    [tapForgivenessThreshold, cleanupGhost],
+    [tapForgivenessThreshold, tapForgivenessTimeMs, cleanupGhost],
   );
 
   return { onPointerDown, onPointerMove, onPointerUp, onPointerCancel };

--- a/src/components/answer-game/useTouchDrag.ts
+++ b/src/components/answer-game/useTouchDrag.ts
@@ -68,6 +68,10 @@ interface UseTouchDragOptions {
   onHoverZone?: (zoneIndex: number | null) => void;
   /** Called when the ghost enters or leaves a bank tile hole during drag. */
   onHoverBankTile?: (bankTileId: string | null) => void;
+  /** If set, micro-drags below this px distance are treated as taps. */
+  tapForgivenessThreshold?: number;
+  /** Called instead of cancel when displacement < tapForgivenessThreshold. */
+  onTapFallback?: () => void;
 }
 
 export const useTouchDrag = ({
@@ -80,11 +84,18 @@ export const useTouchDrag = ({
   onDropOnBankTile,
   onHoverZone,
   onHoverBankTile,
+  tapForgivenessThreshold,
+  onTapFallback,
 }: UseTouchDragOptions): TouchDragHandlers => {
   const onDragCancelRef = useRef(onDragCancel);
   useEffect(() => {
     onDragCancelRef.current = onDragCancel;
   }, [onDragCancel]);
+
+  const onTapFallbackRef = useRef(onTapFallback);
+  useEffect(() => {
+    onTapFallbackRef.current = onTapFallback;
+  }, [onTapFallback]);
 
   const onHoverZoneRef = useRef(onHoverZone);
   useEffect(() => {
@@ -283,6 +294,40 @@ export const useTouchDrag = ({
       if (e.pointerType === 'mouse' || !startPos.current) return;
 
       if (isDragging.current) {
+        // Tap forgiveness: if the total displacement is below the threshold
+        // and no slot zone is under the pointer, treat this as a tap.
+        if (
+          tapForgivenessThreshold !== undefined &&
+          onTapFallbackRef.current
+        ) {
+          const dx = e.clientX - startPos.current.x;
+          const dy = e.clientY - startPos.current.y;
+          const dist = Math.hypot(dx, dy);
+          if (dist < tapForgivenessThreshold) {
+            // Check there's no zone under the center point before treating as tap.
+            ghostRef.current?.el.remove();
+            ghostRef.current = null;
+            let zoneUnderPointer = false;
+            for (const el of document.elementsFromPoint(
+              e.clientX,
+              e.clientY,
+            )) {
+              if (
+                el instanceof HTMLElement &&
+                el.dataset['zoneIndex'] !== undefined
+              ) {
+                zoneUnderPointer = true;
+                break;
+              }
+            }
+            if (!zoneUnderPointer) {
+              onTapFallbackRef.current();
+              cleanup();
+              return;
+            }
+          }
+        }
+
         // Capture ghost dimensions before removing.
         const ghostHalfW = ghostRef.current?.halfW ?? 0;
         const ghostHalfH = ghostRef.current?.halfH ?? 0;
@@ -421,7 +466,14 @@ export const useTouchDrag = ({
 
       cleanup();
     },
-    [tileId, onDrop, onDropOnBank, onDropOnBankTile, cleanup],
+    [
+      tileId,
+      onDrop,
+      onDropOnBank,
+      onDropOnBankTile,
+      tapForgivenessThreshold,
+      cleanup,
+    ],
   );
 
   const onPointerCancel = useCallback(

--- a/src/components/answer-game/useTouchDrag.ts
+++ b/src/components/answer-game/useTouchDrag.ts
@@ -53,7 +53,7 @@ export interface TouchDragHandlers {
   onPointerCancel: (e: PointerEvent<HTMLElement>) => void;
 }
 
-interface UseTouchDragOptions {
+interface UseTouchDragBaseOptions {
   /** Empty string disables the drag (no pointer capture, no ghost). */
   tileId: string;
   label: string;
@@ -68,11 +68,13 @@ interface UseTouchDragOptions {
   onHoverZone?: (zoneIndex: number | null) => void;
   /** Called when the ghost enters or leaves a bank tile hole during drag. */
   onHoverBankTile?: (bankTileId: string | null) => void;
-  /** If set, micro-drags below this px distance are treated as taps. */
-  tapForgivenessThreshold?: number;
-  /** Called instead of cancel when displacement < tapForgivenessThreshold. */
-  onTapFallback?: () => void;
 }
+
+type UseTouchDragOptions = UseTouchDragBaseOptions &
+  (
+    | { tapForgivenessThreshold?: undefined; onTapFallback?: undefined }
+    | { tapForgivenessThreshold: number; onTapFallback: () => void }
+  );
 
 export const useTouchDrag = ({
   tileId,

--- a/src/components/answer-game/useTouchDrag.ts
+++ b/src/components/answer-game/useTouchDrag.ts
@@ -482,11 +482,27 @@ export const useTouchDrag = ({
     (e: PointerEvent<HTMLElement>) => {
       if (e.pointerType === 'mouse') return;
       if (isDragging.current) {
+        // Tap forgiveness: iOS Safari (and some Android browsers) fire pointercancel
+        // instead of pointerup for short gestures, even with touch-action:none set.
+        // Apply the same micro-drag check here so the threshold actually takes effect.
+        if (
+          startPos.current &&
+          tapForgivenessThreshold !== undefined &&
+          onTapFallbackRef.current
+        ) {
+          const dx = e.clientX - startPos.current.x;
+          const dy = e.clientY - startPos.current.y;
+          if (Math.hypot(dx, dy) < tapForgivenessThreshold) {
+            onTapFallbackRef.current();
+            cleanupGhost();
+            return;
+          }
+        }
         onDragCancelRef.current?.();
       }
       cleanupGhost();
     },
-    [cleanupGhost],
+    [tapForgivenessThreshold, cleanupGhost],
   );
 
   return { onPointerDown, onPointerMove, onPointerUp, onPointerCancel };

--- a/src/db/create-database.ts
+++ b/src/db/create-database.ts
@@ -64,7 +64,12 @@ const COLLECTIONS = {
   },
   profiles: { schema: profilesSchema },
   progress: { schema: progressSchema },
-  settings: { schema: settingsSchema },
+  settings: {
+    schema: settingsSchema,
+    migrationStrategies: {
+      1: (oldDoc: Record<string, unknown>) => oldDoc,
+    },
+  },
   game_config_overrides: { schema: gameConfigOverridesSchema },
   saved_game_configs: {
     schema: savedGameConfigsSchema,

--- a/src/db/create-database.ts
+++ b/src/db/create-database.ts
@@ -68,6 +68,7 @@ const COLLECTIONS = {
     schema: settingsSchema,
     migrationStrategies: {
       1: (oldDoc: Record<string, unknown>) => oldDoc,
+      2: (oldDoc: Record<string, unknown>) => oldDoc,
     },
   },
   game_config_overrides: { schema: gameConfigOverridesSchema },

--- a/src/db/hooks/useSettings.ts
+++ b/src/db/hooks/useSettings.ts
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS: Omit<SettingsDoc, 'updatedAt'> = {
   speechRate: 1,
   ttsEnabled: true,
   showSubtitles: true,
+  tapForgivenessThreshold: 20,
 };
 
 function plainSettingsFromQuery(

--- a/src/db/hooks/useSettings.ts
+++ b/src/db/hooks/useSettings.ts
@@ -15,6 +15,7 @@ const DEFAULT_SETTINGS: Omit<SettingsDoc, 'updatedAt'> = {
   ttsEnabled: true,
   showSubtitles: true,
   tapForgivenessThreshold: 20,
+  tapForgivenessTimeMs: 150,
 };
 
 function plainSettingsFromQuery(

--- a/src/db/hooks/useSettings.ts
+++ b/src/db/hooks/useSettings.ts
@@ -14,7 +14,7 @@ const DEFAULT_SETTINGS: Omit<SettingsDoc, 'updatedAt'> = {
   speechRate: 1,
   ttsEnabled: true,
   showSubtitles: true,
-  tapForgivenessThreshold: 20,
+  tapForgivenessThreshold: 17,
   tapForgivenessTimeMs: 150,
 };
 

--- a/src/db/schemas/settings.ts
+++ b/src/db/schemas/settings.ts
@@ -11,6 +11,7 @@ export type SettingsDoc = {
   themeId?: string;
   preferredVoiceURI?: string;
   preferredVoiceDeviceId?: string;
+  tapForgivenessThreshold?: number;
   updatedAt: string;
 };
 
@@ -34,6 +35,12 @@ export const settingsSchema: RxJsonSchema<SettingsDoc> = {
     themeId: { type: 'string' },
     preferredVoiceURI: { type: 'string' },
     preferredVoiceDeviceId: { type: 'string' },
+    tapForgivenessThreshold: {
+      type: 'number',
+      minimum: 8,
+      maximum: 60,
+      default: 20,
+    },
     updatedAt: { type: 'string', format: 'date-time' },
   },
   required: ['id', 'profileId', 'updatedAt'],

--- a/src/db/schemas/settings.ts
+++ b/src/db/schemas/settings.ts
@@ -12,11 +12,12 @@ export type SettingsDoc = {
   preferredVoiceURI?: string;
   preferredVoiceDeviceId?: string;
   tapForgivenessThreshold?: number;
+  tapForgivenessTimeMs?: number;
   updatedAt: string;
 };
 
 export const settingsSchema: RxJsonSchema<SettingsDoc> = {
-  version: 1,
+  version: 2,
   primaryKey: 'id',
   type: 'object',
   properties: {
@@ -37,9 +38,15 @@ export const settingsSchema: RxJsonSchema<SettingsDoc> = {
     preferredVoiceDeviceId: { type: 'string' },
     tapForgivenessThreshold: {
       type: 'number',
-      minimum: 8,
-      maximum: 60,
+      minimum: 0,
+      maximum: 100,
       default: 20,
+    },
+    tapForgivenessTimeMs: {
+      type: 'number',
+      minimum: 0,
+      maximum: 500,
+      default: 150,
     },
     updatedAt: { type: 'string', format: 'date-time' },
   },

--- a/src/db/schemas/settings.ts
+++ b/src/db/schemas/settings.ts
@@ -16,7 +16,7 @@ export type SettingsDoc = {
 };
 
 export const settingsSchema: RxJsonSchema<SettingsDoc> = {
-  version: 0,
+  version: 1,
   primaryKey: 'id',
   type: 'object',
   properties: {

--- a/src/db/schemas/settings.ts
+++ b/src/db/schemas/settings.ts
@@ -40,7 +40,7 @@ export const settingsSchema: RxJsonSchema<SettingsDoc> = {
       type: 'number',
       minimum: 0,
       maximum: 100,
-      default: 20,
+      default: 17,
     },
     tapForgivenessTimeMs: {
       type: 'number',

--- a/src/lib/i18n/locales/en/settings.json
+++ b/src/lib/i18n/locales/en/settings.json
@@ -6,6 +6,7 @@
   "theme": "Theme",
   "voice": "Voice",
   "voiceDefault": "System default",
+  "tapForgiveness": "Tap forgiveness ({{px}}px)",
   "themes": {
     "theme_ocean_preset": "Ocean",
     "theme_forest_preset": "Forest"

--- a/src/lib/i18n/locales/en/settings.json
+++ b/src/lib/i18n/locales/en/settings.json
@@ -6,7 +6,8 @@
   "theme": "Theme",
   "voice": "Voice",
   "voiceDefault": "System default",
-  "tapForgiveness": "Tap forgiveness ({{px}}px)",
+  "tapForgiveness": "Tap forgiveness — distance ({{px}}px)",
+  "tapForgivenessTime": "Tap forgiveness — duration ({{ms}}ms)",
   "themes": {
     "theme_ocean_preset": "Ocean",
     "theme_forest_preset": "Forest"

--- a/src/lib/i18n/locales/pt-BR/settings.json
+++ b/src/lib/i18n/locales/pt-BR/settings.json
@@ -6,6 +6,7 @@
   "theme": "Tema",
   "voice": "Voz",
   "voiceDefault": "Padrão do sistema",
+  "tapForgiveness": "Tolerância ao toque ({{px}}px)",
   "themes": {
     "theme_ocean_preset": "Oceano",
     "theme_forest_preset": "Floresta"

--- a/src/lib/i18n/locales/pt-BR/settings.json
+++ b/src/lib/i18n/locales/pt-BR/settings.json
@@ -6,7 +6,8 @@
   "theme": "Tema",
   "voice": "Voz",
   "voiceDefault": "Padrão do sistema",
-  "tapForgiveness": "Tolerância ao toque ({{px}}px)",
+  "tapForgiveness": "Tolerância ao toque — distância ({{px}}px)",
+  "tapForgivenessTime": "Tolerância ao toque — duração ({{ms}}ms)",
   "themes": {
     "theme_ocean_preset": "Oceano",
     "theme_forest_preset": "Floresta"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,11 +7,17 @@ import { devtools } from '@tanstack/devtools-vite';
 
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 
+import basicSsl from '@vitejs/plugin-basic-ssl';
 import viteReact from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { version } from './package.json';
 import type { Plugin } from 'vite';
+
+// Enable HTTPS + LAN host binding when launched via `yarn devhost`. Required
+// because RxDB needs `crypto.subtle` which is only exposed in secure contexts
+// (HTTPS or localhost) — plain HTTP on a LAN IP throws RxDB error UT8.
+const enableHttps = process.env['VITE_HTTPS'] === '1';
 
 const base = process.env['APP_BASE_URL'] ?? '/base-skill/';
 
@@ -133,6 +139,7 @@ const config = defineConfig({
     }),
     viteReact(),
     workboxPlugin(),
+    ...(enableHttps ? [basicSsl()] : []),
   ],
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4726,6 +4726,11 @@
   resolved "https://registry.yarnpkg.com/@valibot/to-json-schema/-/to-json-schema-1.6.0.tgz#d61354fb50629868a2de7169c3093899abad923d"
   integrity sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==
 
+"@vitejs/plugin-basic-ssl@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.3.0.tgz#f505b1c197d8cb4fd6e213a78847574ecc51e2f9"
+  integrity sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==
+
 "@vitejs/plugin-react@^5.1.4":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz#108bd0f566f288ce3566982df4eff137ded7b15f"


### PR DESCRIPTION
## Summary

Fixes [#298](https://github.com/leocaseiro/base-skill/issues/298): on touch devices, what feels like a tap on a bank tile triggers drag mode and then cancels — the tile speaks but never gets placed.

The original distance-only proposal didn't work in the field. Real-device captures revealed why and led to a duration-based gate that complements distance, both per-profile configurable.

## Root cause (from real device captures)

Built a small HTML/JS harness (`debug/pointer-events.html` + `debug/serve.py`, gitignored) that mirrors the production setup — `touch-action: none`, `setPointerCapture`, and the `pointer-events: none` parent the production wrapper applies once a drag starts — and logs every pointer / capture / click event with full properties. Ran it on Chrome Android (Pixel) and Brave iOS (iPhone).

Two earlier hypotheses were **wrong**:

1. ❌ `pointercancel` fires instead of `pointerup` (iOS Safari quirk) — never observed on either platform
2. ❌ `lostpointercapture` fires prematurely from the parent's CSS change — fires after `pointerup`, correctly

What the captures **actually** show:

| Gesture | Platform | Duration | Final Δ | Intent |
| ------- | -------- | -------- | ------- | ------ |
| quick-drag | Android | 50ms | **96px** | TAP (failing) |
| quick-drag-verbose | Android | 65ms | **76px** | TAP (failing) |
| tap-once (no drag) | Android | 47ms | 0px | TAP (works via click) |
| quick-but-not-short | Android | **288ms** | 449px | DRAG (correct) |
| slow-long-drag | Android | 1854ms | 507px | DRAG (correct) |
| iPhone short tap | Brave iOS | 63ms | 58px | TAP (failing) |
| iPhone short tap (verbose) | Brave iOS | 79ms | 64px | TAP (failing) |
| iPhone long drag | Brave iOS | 287ms | 267px | DRAG (correct) |

The actual problem: **thumb-release drift**. A typical thumb tap registers 75–100px of contact movement in 50–65ms because the contact point pivots toward the base of the thumb as pressure releases. Distance alone cannot separate this from a deliberate drag without unacceptable false positives. Duration is a much cleaner discriminator — every captured failing tap completed in <80ms; the shortest deliberate drag took 287ms.

## Fix

Tap forgiveness fires when **either** signal is below its threshold AND no slot zone is under the pointer:

- **Distance** — Euclidean displacement from `pointerdown` to `pointerup` < `tapForgivenessThreshold` (default **17px**, range 0–100). Catches slow careful taps with tiny movement.
- **Duration** — elapsed time < `tapForgivenessTimeMs` (default **150ms**, range 0–500). Below human reaction time, so any gesture this short is ballistic motion, not deliberate drag.

Both thresholds live in the per-profile settings doc and surface as sliders inside `SettingsPanel`, so they appear in both the sidebar sheet and the `/settings` route automatically. Setting either to 0 disables that signal.

The same combined check runs in `onPointerCancel` as defence in depth (covers documented platforms that fire `pointercancel` instead of `pointerup` for short gestures, even though our captures didn't trigger it).

Verified rule against all 8 captured gestures — 5 Android + 3 iOS — with the 17px / 150ms defaults: every gesture classifies according to user intent (5 taps as taps, 3 drags as drags, no false positives).

## Files

| Area | File | Change |
| ---- | ---- | ------ |
| Touch drag hook | `src/components/answer-game/useTouchDrag.ts` | Time + distance gate in `onPointerUp` and `onPointerCancel`. New `tapForgivenessTimeMs` option, paired type with `tapForgivenessThreshold` and `onTapFallback`. |
| Wiring | `src/components/answer-game/useDraggableTile.ts` | Reads both thresholds from settings; passes to `useTouchDrag` along with `onTapFallback` (which now also fires the bank-shake / `wrong` sound / `REJECT_TAP` flow when the tap places into the wrong slot). |
| Settings schema | `src/db/schemas/settings.ts` | Adds `tapForgivenessThreshold` (range 0–100, default 17) and `tapForgivenessTimeMs` (range 0–500, default 150). Schema bumped to v2 with no-op migration. |
| Settings UI | `src/components/SettingsPanel/SettingsPanel.tsx` | Adds two sliders so both surfaces (sidebar sheet + `/settings`) get them. |
| i18n | `src/lib/i18n/locales/{en,pt-BR}/settings.json` | Two labels: distance / duration variants. |
| Architecture docs | `src/components/answer-game/AnswerGame/AnswerGame.flows.mdx` | Updated tap-forgiveness section to document both gates and per-profile config. |
| Plan / brainstorm | `docs/{brainstorms,plans}/2026-05-01-*.md` | Findings / Spec Delta sections explaining why distance-only proved insufficient and pointing to the captured device data. |

## Test plan

### Automated

- [x] `useTouchDrag.test.ts` — 12 unit tests
  - Distance under threshold → tap fallback
  - Distance over threshold → no tap fallback
  - Slot zone under pointer wins over tap forgiveness
  - Slot tile drag (no fallback configured) → cancels normally
  - Threshold boundary
  - `pointercancel` mirrors of all of the above
  - **Duration < 150ms with distance > threshold → tap fallback (the actual failing case)**
  - Duration AND distance both over → cancel
  - Time-undefined falls back to distance-only
  - Time check applies in `onPointerCancel` too
- [x] `useDraggableTile.test.tsx` — settings → `useTouchDrag` wiring; `onTapFallback` calls `placeInNextSlot`; reject-path sound + shake + `REJECT_TAP` dispatch on wrong placement (covers tap and drag variants)
- [x] `SettingsPanel.test.tsx` — both new sliders render with their default values (17px / 150ms)
- [x] `yarn typecheck` clean
- [x] Full vitest suite (368 tests in answer-game / SettingsPanel / db) passes
- [x] `yarn lint:md` + `npx prettier --check .` clean

### Manual on devices (already done — captures saved locally to `debug/logs/`)

- [x] Chrome Android (Pixel, Chrome 147) — 5 captures across tap and drag patterns
- [x] Brave iOS (iPhone, iOS 18.7, Brave 1) — 3 captures across tap and drag patterns

### Reproduction harness for future regressions

Anyone can re-capture by running:

```bash
cd debug && python3 serve.py        # serves the test page on port 8000
yarn devhost                         # serves the app on https://<lan-ip>:3000
```

Then on the device, reproduce the gesture and tap **Save log** — entries land in `debug/logs/` on the dev machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/299/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/299/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/299#issuecomment-)
<!-- /preview-urls -->
