### PR TITLE
feat(settings): shared SettingsPanel + fix voice dropdown (#303)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,21 +5,12 @@ import {
   useParams,
 } from '@tanstack/react-router';
 import { MenuIcon, SearchIcon } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { EMPTY } from 'rxjs';
-import type { ThemeDoc } from '@/db/schemas/themes';
+import { SettingsPanel } from '@/components/SettingsPanel';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import {
   Sheet,
   SheetContent,
@@ -27,20 +18,10 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
-import { Slider } from '@/components/ui/slider';
-import { useRxDB } from '@/db/hooks/useRxDB';
-import { useRxQuery } from '@/db/hooks/useRxQuery';
-import { useSettings } from '@/db/hooks/useSettings';
 import { isAppGameSessionPath } from '@/lib/app-paths';
-import { safeGetVoices } from '@/lib/speech/safe-get-voices';
 import { APP_VERSION, IS_BETA } from '@/lib/version';
 
-const LOCALES = [
-  { code: 'en', label: '🇬🇧 English' },
-  { code: 'pt-BR', label: '🇧🇷 Português' },
-] as const;
-
-type HeaderLocale = (typeof LOCALES)[number]['code'];
+type HeaderLocale = 'en' | 'pt-BR';
 
 const HeaderMenuPanel = ({
   appName,
@@ -50,155 +31,27 @@ const HeaderMenuPanel = ({
   appName: string;
   locale: string;
   onLocaleChange: (locale: HeaderLocale) => void;
-}) => {
-  const { t } = useTranslation('settings');
-  const { settings, update } = useSettings();
-  const { db } = useRxDB();
-  const volume = settings.volume ?? 0.8;
-  const speechRate = settings.speechRate ?? 1;
-  const activeThemeId = settings.themeId ?? 'theme_ocean_preset';
-  const preferredVoice = settings.preferredVoiceURI ?? '';
-  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
-
-  useEffect(() => {
-    const synth = (
-      globalThis as unknown as { speechSynthesis?: SpeechSynthesis }
-    ).speechSynthesis;
-    if (!synth) return;
-    const load = () => setVoices(safeGetVoices(synth));
-    load();
-    synth.addEventListener('voiceschanged', load);
-    return () => synth.removeEventListener('voiceschanged', load);
-  }, []);
-
-  const themes$ = useMemo(
-    () => (db ? db.themes.find().$ : EMPTY),
-    [db],
-  );
-  const themeDocs = useRxQuery<{ toJSON: () => ThemeDoc }[]>(
-    themes$,
-    [],
-  );
-  const themes = themeDocs.map((d) => d.toJSON());
-
-  return (
-    <SheetContent side="right">
-      <SheetHeader>
-        <SheetTitle>{appName}</SheetTitle>
-      </SheetHeader>
-      <div className="flex flex-col gap-6 p-4">
-        <div className="flex items-center justify-between">
-          <a
-            href="/base-skill/docs/"
-            className="rounded-full border border-[var(--chip-line)] bg-[var(--chip-bg)] px-3 py-1.5 text-sm font-semibold text-[var(--sea-ink)] no-underline"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Docs
-          </a>
-          <ThemeToggle />
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="drawer-volume">
-            {t('volume', { percent: Math.round(volume * 100) })}
-          </Label>
-          <Slider
-            id="drawer-volume"
-            min={0}
-            max={1}
-            step={0.05}
-            value={[volume]}
-            onValueChange={([v]) => {
-              void update({ volume: v });
-            }}
-          />
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="drawer-speechRate">
-            {t('speechRate', { rate: speechRate })}
-          </Label>
-          <Slider
-            id="drawer-speechRate"
-            min={0.5}
-            max={2}
-            step={0.1}
-            value={[speechRate]}
-            onValueChange={([v]) => {
-              void update({ speechRate: v });
-            }}
-          />
-        </div>
-
-        {voices.length > 0 && (
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="drawer-voice">{t('voice')}</Label>
-            <Select
-              value={preferredVoice}
-              onValueChange={(v) =>
-                void update({ preferredVoiceURI: v })
-              }
-            >
-              <SelectTrigger id="drawer-voice">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {voices.map((v) => (
-                  <SelectItem key={v.name} value={v.name}>
-                    {v.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        )}
-
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="drawer-language">{t('language')}</Label>
-          <Select
-            value={locale}
-            onValueChange={(v) => onLocaleChange(v as HeaderLocale)}
-          >
-            <SelectTrigger id="drawer-language">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {LOCALES.map(({ code, label }) => (
-                <SelectItem key={code} value={code}>
-                  {label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        {themes.length > 0 && (
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="drawer-theme">{t('theme')}</Label>
-            <Select
-              value={activeThemeId}
-              onValueChange={(v) => void update({ themeId: v })}
-            >
-              <SelectTrigger id="drawer-theme">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {themes.map(({ id, name, isPreset }) => (
-                  <SelectItem key={id} value={id}>
-                    {isPreset
-                      ? t(`themes.${id}`, { defaultValue: name })
-                      : name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        )}
+}) => (
+  <SheetContent side="right">
+    <SheetHeader>
+      <SheetTitle>{appName}</SheetTitle>
+    </SheetHeader>
+    <div className="flex flex-col gap-6 p-4">
+      <div className="flex items-center justify-between">
+        <a
+          href="/base-skill/docs/"
+          className="rounded-full border border-[var(--chip-line)] bg-[var(--chip-bg)] px-3 py-1.5 text-sm font-semibold text-[var(--sea-ink)] no-underline"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Docs
+        </a>
+        <ThemeToggle />
       </div>
-    </SheetContent>
-  );
-};
+      <SettingsPanel locale={locale} onLocaleChange={onLocaleChange} />
+    </div>
+  </SheetContent>
+);
 
 const MenuSheetTrigger = () => (
   <SheetTrigger asChild>
@@ -217,8 +70,6 @@ export const Header = () => {
     null,
   );
 
-  // The search input is uncontrolled — it navigates to the home route on change.
-  // It does not read the current search param (avoiding router hook complexity in a layout component).
   const handleSearchChange = (value: string) => {
     if (searchTimeout.current) clearTimeout(searchTimeout.current);
     searchTimeout.current = setTimeout(() => {

--- a/src/components/SettingsPanel/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel/SettingsPanel.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { SettingsPanel } from './SettingsPanel';
+import type { BaseSkillDatabase } from '@/db/types';
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+} from '@/db/create-database';
+import { i18n } from '@/lib/i18n/i18n';
+import { DbProvider } from '@/providers/DbProvider';
+
+const renderSettingsPanel = (db: BaseSkillDatabase) =>
+  render(
+    <I18nextProvider i18n={i18n}>
+      <DbProvider openDatabase={() => Promise.resolve(db)}>
+        <SettingsPanel locale="en" onLocaleChange={vi.fn()} />
+      </DbProvider>
+    </I18nextProvider>,
+  );
+
+let db: BaseSkillDatabase;
+
+beforeEach(async () => {
+  db = await createTestDatabase();
+  Object.defineProperty(globalThis, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((q: string) => ({
+      matches: false,
+      media: q,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+afterEach(async () => {
+  await destroyTestDatabase(db);
+});
+
+describe('SettingsPanel', () => {
+  it('renders volume slider', () => {
+    renderSettingsPanel(db);
+    expect(screen.getByText(/volume/i)).toBeInTheDocument();
+  });
+
+  it('renders speech rate slider', () => {
+    renderSettingsPanel(db);
+    expect(screen.getByText(/speech rate/i)).toBeInTheDocument();
+  });
+
+  it('renders language select with current locale selected', () => {
+    renderSettingsPanel(db);
+    expect(screen.getByText(/language/i)).toBeInTheDocument();
+  });
+
+  it('renders voice select', () => {
+    renderSettingsPanel(db);
+    expect(screen.getByText(/^voice$/i)).toBeInTheDocument();
+  });
+
+  it('shows system default placeholder in voice select when no voice is saved', () => {
+    renderSettingsPanel(db);
+    expect(screen.getByText(/system default/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/SettingsPanel/SettingsPanel.tsx
+++ b/src/components/SettingsPanel/SettingsPanel.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { EMPTY } from 'rxjs';
+import type { ThemeDoc } from '@/db/schemas/themes';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Slider } from '@/components/ui/slider';
+import { useRxDB } from '@/db/hooks/useRxDB';
+import { useRxQuery } from '@/db/hooks/useRxQuery';
+import { useSettings } from '@/db/hooks/useSettings';
+import { safeGetVoices } from '@/lib/speech/safe-get-voices';
+
+const LOCALES = [
+  { code: 'en', label: '🇬🇧 English' },
+  { code: 'pt-BR', label: '🇧🇷 Português' },
+] as const;
+
+type Locale = (typeof LOCALES)[number]['code'];
+
+type SettingsPanelProps = {
+  locale: string;
+  onLocaleChange: (locale: Locale) => void;
+};
+
+export const SettingsPanel = ({
+  locale,
+  onLocaleChange,
+}: SettingsPanelProps) => {
+  const { t } = useTranslation('settings');
+  const { settings, update } = useSettings();
+  const { db } = useRxDB();
+
+  const volume = settings.volume ?? 0.8;
+  const speechRate = settings.speechRate ?? 1;
+  const preferredVoice = settings.preferredVoiceURI ?? '';
+  const voiceSelectValue =
+    preferredVoice === '' ? '__default__' : preferredVoice;
+
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [voicesLoaded, setVoicesLoaded] = useState(() => {
+    const synth = (
+      globalThis as unknown as { speechSynthesis?: SpeechSynthesis }
+    ).speechSynthesis;
+    return !synth;
+  });
+
+  useEffect(() => {
+    const synth = (
+      globalThis as unknown as { speechSynthesis?: SpeechSynthesis }
+    ).speechSynthesis;
+    if (!synth) return;
+    const load = () => {
+      setVoices(safeGetVoices(synth));
+      setVoicesLoaded(true);
+    };
+    load();
+    synth.addEventListener('voiceschanged', load);
+    return () => synth.removeEventListener('voiceschanged', load);
+  }, []);
+
+  const themes$ = useMemo(
+    () => (db ? db.themes.find().$ : EMPTY),
+    [db],
+  );
+  const themeDocs = useRxQuery<{ toJSON: () => ThemeDoc }[]>(
+    themes$,
+    [],
+  );
+  const themes = themeDocs.map((d) => d.toJSON());
+  const activeThemeId = settings.themeId ?? 'theme_ocean_preset';
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="settings-volume">
+          {t('volume', { percent: Math.round(volume * 100) })}
+        </Label>
+        <Slider
+          id="settings-volume"
+          min={0}
+          max={1}
+          step={0.05}
+          value={[volume]}
+          onValueChange={([v]) => void update({ volume: v })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="settings-speechRate">
+          {t('speechRate', { rate: speechRate })}
+        </Label>
+        <Slider
+          id="settings-speechRate"
+          min={0.5}
+          max={2}
+          step={0.1}
+          value={[speechRate]}
+          onValueChange={([v]) => void update({ speechRate: v })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="settings-voice">{t('voice')}</Label>
+        <Select
+          value={voiceSelectValue}
+          onValueChange={(v) =>
+            void update({
+              preferredVoiceURI: v === '__default__' ? '' : v,
+            })
+          }
+          disabled={!voicesLoaded}
+        >
+          <SelectTrigger id="settings-voice">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__default__">
+              {t('voiceDefault')}
+            </SelectItem>
+            {voices.map((v) => (
+              <SelectItem key={v.name} value={v.name}>
+                {v.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="settings-language">{t('language')}</Label>
+        <Select
+          value={locale}
+          onValueChange={(v) => onLocaleChange(v as Locale)}
+        >
+          <SelectTrigger id="settings-language">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {LOCALES.map(({ code, label }) => (
+              <SelectItem key={code} value={code}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {themes.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="settings-theme">{t('theme')}</Label>
+          <Select
+            value={activeThemeId}
+            onValueChange={(v) => void update({ themeId: v })}
+          >
+            <SelectTrigger id="settings-theme">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {themes.map(({ id, name, isPreset }) => (
+                <SelectItem key={id} value={id}>
+                  {isPreset
+                    ? t(`themes.${id}`, { defaultValue: name })
+                    : name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/SettingsPanel/index.ts
+++ b/src/components/SettingsPanel/index.ts
@@ -1,0 +1,1 @@
+export { SettingsPanel } from './SettingsPanel';

--- a/src/lib/i18n/locales/en/settings.json
+++ b/src/lib/i18n/locales/en/settings.json
@@ -5,6 +5,7 @@
   "language": "Language",
   "theme": "Theme",
   "voice": "Voice",
+  "voiceDefault": "System default",
   "themes": {
     "theme_ocean_preset": "Ocean",
     "theme_forest_preset": "Forest"

--- a/src/lib/i18n/locales/pt-BR/settings.json
+++ b/src/lib/i18n/locales/pt-BR/settings.json
@@ -5,6 +5,7 @@
   "language": "Idioma",
   "theme": "Tema",
   "voice": "Voz",
+  "voiceDefault": "Padrão do sistema",
   "themes": {
     "theme_ocean_preset": "Oceano",
     "theme_forest_preset": "Floresta"

--- a/src/routes/$locale/_app/settings.tsx
+++ b/src/routes/$locale/_app/settings.tsx
@@ -4,31 +4,14 @@ import {
   useNavigate,
   useParams,
 } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Slider } from '@/components/ui/slider';
-import { useSettings } from '@/db/hooks/useSettings';
-import { safeGetVoices } from '@/lib/speech/safe-get-voices';
-
-const LOCALES = [
-  { code: 'en', label: '🇬🇧 English' },
-  { code: 'pt-BR', label: '🇧🇷 Português' },
-] as const;
+import { SettingsPanel } from '@/components/SettingsPanel';
 
 const SettingsScreen = () => {
   const { t } = useTranslation('settings');
   const { locale } = useParams({ from: '/$locale' });
   const navigate = useNavigate();
   const location = useLocation();
-  const { settings, update } = useSettings();
 
   const handleLocaleChange = (newLocale: string) => {
     const newPath = location.pathname.replace(
@@ -38,96 +21,13 @@ const SettingsScreen = () => {
     void navigate({ to: newPath });
   };
 
-  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
-
-  useEffect(() => {
-    const synth = (
-      globalThis as unknown as { speechSynthesis?: SpeechSynthesis }
-    ).speechSynthesis;
-    if (!synth) return;
-    const load = () => setVoices(safeGetVoices(synth));
-    load();
-    synth.addEventListener('voiceschanged', load);
-    return () => synth.removeEventListener('voiceschanged', load);
-  }, []);
-
-  const volume = settings.volume ?? 0.8;
-  const speechRate = settings.speechRate ?? 1;
-  const preferredVoice = settings.preferredVoiceURI ?? '';
-
   return (
     <div className="mx-auto max-w-md px-4 py-8">
       <h1 className="mb-6 text-2xl font-bold">{t('title')}</h1>
-
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="volume">
-            {t('volume', { percent: Math.round(volume * 100) })}
-          </Label>
-          <Slider
-            id="volume"
-            min={0}
-            max={1}
-            step={0.05}
-            value={[volume]}
-            onValueChange={([v]) => {
-              void update({ volume: v });
-            }}
-          />
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="speechRate">
-            {t('speechRate', { rate: speechRate })}
-          </Label>
-          <Slider
-            id="speechRate"
-            min={0.5}
-            max={2}
-            step={0.1}
-            value={[speechRate]}
-            onValueChange={([v]) => {
-              void update({ speechRate: v });
-            }}
-          />
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="language">{t('language')}</Label>
-          <Select value={locale} onValueChange={handleLocaleChange}>
-            <SelectTrigger id="language">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {LOCALES.map(({ code, label }) => (
-                <SelectItem key={code} value={code}>
-                  {label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="voice">{t('voice')}</Label>
-          <Select
-            value={preferredVoice}
-            onValueChange={(v) => void update({ preferredVoiceURI: v })}
-            disabled={voices.length === 0}
-          >
-            <SelectTrigger id="voice">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {voices.map((v) => (
-                <SelectItem key={v.name} value={v.name}>
-                  {v.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
+      <SettingsPanel
+        locale={locale}
+        onLocaleChange={handleLocaleChange}
+      />
     </div>
   );
 };

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,2 +1,8 @@
 import 'fake-indexeddb/auto';
 import '@testing-library/jest-dom';
+
+globalThis.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};


### PR DESCRIPTION
## Summary

- Extracts a shared `SettingsPanel` component (`src/components/SettingsPanel/`) used by both the Header sidebar sheet and the settings page route — any new setting added to `SettingsPanel` appears in both places automatically
- Settings page gains the **theme selector** it was previously missing (present in sidebar only)
- Fixes voice dropdown showing empty on first load: the select now always renders (disabled until voices load) and shows **"System default"** when no voice is saved, making the Daniel fallback in `SpeechOutput` explicit
- Uses sentinel value `__default__` for the "System default" SelectItem (Radix disallows empty-string SelectItem values); saves `''` to `preferredVoiceURI` when selected
- Adds `ResizeObserver` stub to `test-setup.ts` so Radix Select can be rendered in unit tests

## Test plan

- [x] `SettingsPanel` unit tests (5 tests) — renders all fields, shows "System default" voice placeholder
- [x] `Header` tests still pass (2 tests)
- [x] Full suite: 1593 tests, 0 failures
- [x] TypeScript clean
- [x] ESLint + Prettier + pre-push hooks all pass
- [ ] Manual: open sidebar menu → confirm same fields as `/settings` page
- [ ] Manual: open `/settings` → voice dropdown shows "System default" on first load; theme selector now present

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/304/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/304/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/304#issuecomment-)
<!-- /preview-urls -->
