### PR TITLE
feat(game): in-game menu, fullscreen toggle, and lean chrome

### DIFF
--- a/src/components/AppMenuPanel.tsx
+++ b/src/components/AppMenuPanel.tsx
@@ -1,0 +1,76 @@
+import { Link } from '@tanstack/react-router';
+import { Menu } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { SettingsPanel } from '@/components/SettingsPanel/SettingsPanel';
+import { ThemeToggle } from '@/components/ThemeToggle';
+import {
+  SheetClose,
+  SheetContent,
+  SheetTitle,
+} from '@/components/ui/sheet';
+
+export type AppLocale = 'en' | 'pt-BR';
+
+type AppMenuPanelProps = {
+  locale: string;
+  onLocaleChange: (locale: AppLocale) => void;
+};
+
+// Same size and position as the in-game chrome trigger so toggle = zero
+// cursor travel. Idles as just the icon — no chrome until hovered/focused
+// so it doesn't compete with menu content for attention.
+const TOGGLE_BUTTON_CLASS =
+  'flex size-10 shrink-0 items-center justify-center rounded-full bg-transparent text-foreground transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none';
+
+export const AppMenuPanel = ({
+  locale,
+  onLocaleChange,
+}: AppMenuPanelProps) => {
+  const { t } = useTranslation('common');
+
+  return (
+    <SheetContent side="left" showCloseButton={false}>
+      <SheetTitle className="sr-only">{t('appName')}</SheetTitle>
+
+      <div className="flex items-center gap-3 p-4">
+        <SheetClose asChild>
+          <button
+            type="button"
+            className={TOGGLE_BUTTON_CLASS}
+            aria-label={t('closeMenu')}
+          >
+            <Menu aria-hidden className="size-5" strokeWidth={2.25} />
+          </button>
+        </SheetClose>
+
+        <SheetClose asChild>
+          <Link
+            to="/$locale"
+            params={{ locale }}
+            className="rounded-full border border-[var(--chip-line)] bg-[var(--chip-bg)] px-3 py-1.5 text-sm font-semibold text-[var(--sea-ink)] no-underline"
+          >
+            {t('appName')}
+          </Link>
+        </SheetClose>
+      </div>
+
+      <div className="flex flex-col gap-6 px-4 pb-4">
+        <div className="flex items-center justify-between">
+          <a
+            href="/base-skill/docs/"
+            className="rounded-full border border-[var(--chip-line)] bg-[var(--chip-bg)] px-3 py-1.5 text-sm font-semibold text-[var(--sea-ink)] no-underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Docs
+          </a>
+          <ThemeToggle />
+        </div>
+        <SettingsPanel
+          locale={locale}
+          onLocaleChange={onLocaleChange}
+        />
+      </div>
+    </SheetContent>
+  );
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,51 +7,14 @@ import {
 import { MenuIcon, SearchIcon } from 'lucide-react';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { SettingsPanel } from '@/components/SettingsPanel';
+import type { AppLocale } from '@/components/AppMenuPanel';
+import { AppMenuPanel } from '@/components/AppMenuPanel';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet';
+import { Sheet, SheetTrigger } from '@/components/ui/sheet';
 import { isAppGameSessionPath } from '@/lib/app-paths';
 import { APP_VERSION, IS_BETA } from '@/lib/version';
-
-type HeaderLocale = 'en' | 'pt-BR';
-
-const HeaderMenuPanel = ({
-  appName,
-  locale,
-  onLocaleChange,
-}: {
-  appName: string;
-  locale: string;
-  onLocaleChange: (locale: HeaderLocale) => void;
-}) => (
-  <SheetContent side="right">
-    <SheetHeader>
-      <SheetTitle>{appName}</SheetTitle>
-    </SheetHeader>
-    <div className="flex flex-col gap-6 p-4">
-      <div className="flex items-center justify-between">
-        <a
-          href="/base-skill/docs/"
-          className="rounded-full border border-[var(--chip-line)] bg-[var(--chip-bg)] px-3 py-1.5 text-sm font-semibold text-[var(--sea-ink)] no-underline"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Docs
-        </a>
-        <ThemeToggle />
-      </div>
-      <SettingsPanel locale={locale} onLocaleChange={onLocaleChange} />
-    </div>
-  </SheetContent>
-);
 
 const MenuSheetTrigger = () => (
   <SheetTrigger asChild>
@@ -81,7 +44,7 @@ export const Header = () => {
     }, 300);
   };
 
-  const switchLocale = (newLocale: HeaderLocale) => {
+  const switchLocale = (newLocale: AppLocale) => {
     const newPath = location.pathname.replace(
       /^\/(en|pt-BR)/,
       `/${newLocale}`,
@@ -96,6 +59,11 @@ export const Header = () => {
   return (
     <header className="sticky top-0 z-50 border-b border-[var(--line)] bg-[var(--header-bg)] backdrop-blur-lg">
       <div className="flex items-center gap-3 px-4 py-3">
+        <Sheet>
+          <MenuSheetTrigger />
+          <AppMenuPanel locale={locale} onLocaleChange={switchLocale} />
+        </Sheet>
+
         <Link
           to="/$locale"
           params={{ locale }}
@@ -139,15 +107,6 @@ export const Header = () => {
         <span className="hidden sm:flex">
           <ThemeToggle />
         </span>
-
-        <Sheet>
-          <MenuSheetTrigger />
-          <HeaderMenuPanel
-            appName={t('appName')}
-            locale={locale}
-            onLocaleChange={switchLocale}
-          />
-        </Sheet>
       </div>
     </header>
   );

--- a/src/components/game/GameShell.test.tsx
+++ b/src/components/game/GameShell.test.tsx
@@ -32,7 +32,23 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
   return {
     ...actual,
     useNavigate: () => vi.fn(),
+    useLocation: () => ({
+      pathname: '/en/game/word-builder/sess-shell-001',
+    }),
     useParams: () => ({ locale: 'en', gameId: 'word-builder' }),
+    Link: ({
+      children,
+      className,
+      to: _to,
+    }: {
+      children?: ReactNode;
+      className?: string;
+      to: string;
+    }): ReactNode => (
+      <a className={className} href="http://test/">
+        {children}
+      </a>
+    ),
   };
 });
 
@@ -78,11 +94,43 @@ let db: BaseSkillDatabase;
 
 beforeEach(async () => {
   db = await createTestDatabase();
+  Object.defineProperty(globalThis, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((q: string) => ({
+      matches: false,
+      media: q,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
 });
 
 afterEach(async () => {
   await destroyTestDatabase(db);
 });
+
+const setFullscreenSupport = (
+  supported: boolean,
+  request?: () => Promise<void>,
+  exit?: () => Promise<void>,
+) => {
+  Object.defineProperty(document, 'fullscreenEnabled', {
+    configurable: true,
+    value: supported,
+  });
+  Object.defineProperty(document.documentElement, 'requestFullscreen', {
+    configurable: true,
+    value: request ?? (() => Promise.resolve()),
+  });
+  Object.defineProperty(document, 'exitFullscreen', {
+    configurable: true,
+    value: exit ?? (() => Promise.resolve()),
+  });
+};
 
 function renderShell(
   configOverride?: Partial<ResolvedGameConfig>,
@@ -115,11 +163,9 @@ describe('GameShell', () => {
 
   it('portals the top chrome to document.body with z-45 (above instructions z-40)', () => {
     renderShell();
-    const exit = screen.getByRole('button', { name: /exit/i });
-    const bar = exit.parentElement;
-    expect(bar).not.toBeNull();
-    expect(document.body.contains(exit)).toBe(true);
-    expect(bar).toHaveClass('fixed', 'z-[45]');
+    const chrome = screen.getByTestId('game-chrome');
+    expect(document.body.contains(chrome)).toBe(true);
+    expect(chrome).toHaveClass('fixed', 'z-[45]');
   });
 
   it('does not render a round counter (HUD now owns round display)', () => {
@@ -134,13 +180,8 @@ describe('GameShell', () => {
     ).toBeNull();
   });
 
-  it('renders timer when timerVisible is true', () => {
+  it('does not render a timer (lean game-mode chrome — games own their own HUD)', () => {
     renderShell({ timerVisible: true });
-    expect(screen.getByTestId('game-timer')).toBeInTheDocument();
-  });
-
-  it('hides timer when timerVisible is false', () => {
-    renderShell({ timerVisible: false });
     expect(screen.queryByTestId('game-timer')).not.toBeInTheDocument();
   });
 
@@ -195,5 +236,52 @@ describe('GameShell', () => {
       .findOne('sess-shell-001')
       .exec();
     expect(index?.status).toBe('abandoned');
+  });
+
+  describe('menu', () => {
+    it('renders a menu trigger', () => {
+      renderShell();
+      expect(
+        screen.getByRole('button', { name: /menu/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('opens the menu drawer when the menu trigger is clicked', async () => {
+      renderShell();
+      await userEvent.click(
+        screen.getByRole('button', { name: /menu/i }),
+      );
+      expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  describe('fullscreen', () => {
+    // i18n is not loaded in tests, so aria-labels render as the camelCase
+    // i18n keys (e.g. "shell.enterFullscreen"). The regex matches that key form.
+    it('renders the fullscreen control when the API is supported', () => {
+      setFullscreenSupport(true);
+      renderShell();
+      expect(
+        screen.getByRole('button', { name: /enterFullscreen/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('hides the fullscreen control when the API is not supported', () => {
+      setFullscreenSupport(false);
+      renderShell();
+      expect(
+        screen.queryByRole('button', { name: /fullscreen/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls requestFullscreen when the fullscreen button is clicked', async () => {
+      const request = vi.fn<() => Promise<void>>().mockResolvedValue();
+      setFullscreenSupport(true, request);
+      renderShell();
+      await userEvent.click(
+        screen.getByRole('button', { name: /enterFullscreen/i }),
+      );
+      expect(request).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/components/game/GameShell.tsx
+++ b/src/components/game/GameShell.tsx
@@ -1,9 +1,15 @@
 // src/components/game/GameShell.tsx
-import { useNavigate, useParams } from '@tanstack/react-router';
-import { X } from 'lucide-react';
+import {
+  useLocation,
+  useNavigate,
+  useParams,
+} from '@tanstack/react-router';
+import { Maximize, Menu, Minimize, X } from 'lucide-react';
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
+import { useFullscreen } from './useFullscreen';
+import type { AppLocale } from '@/components/AppMenuPanel';
 import type {
   GameEngineState,
   MoveHandler,
@@ -12,6 +18,7 @@ import type {
   SessionMeta,
 } from '@/lib/game-engine/types';
 import type { JSX, ReactNode } from 'react';
+import { AppMenuPanel } from '@/components/AppMenuPanel';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -22,6 +29,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import { Sheet, SheetTrigger } from '@/components/ui/sheet';
 import { useRxDB } from '@/db/hooks/useRxDB';
 import { GameEngineProvider } from '@/lib/game-engine/index';
 
@@ -36,21 +44,24 @@ export interface GameShellProps {
 }
 
 interface GameShellChromeProps {
-  config: ResolvedGameConfig;
   sessionId: string;
   children: ReactNode;
 }
 
+const ICON_BUTTON_CLASS =
+  'pointer-events-auto flex size-10 shrink-0 items-center justify-center rounded-full bg-background/90 text-foreground opacity-80 shadow-sm ring-1 ring-border transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none';
+
 const GameShellChrome = ({
-  config,
   sessionId,
   children,
 }: GameShellChromeProps): JSX.Element => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { t } = useTranslation('games');
   const { locale } = useParams({ from: '/$locale' });
   const { db } = useRxDB();
   const [exitOpen, setExitOpen] = useState(false);
+  const fullscreen = useFullscreen();
 
   const handleConfirmExit = async () => {
     if (db) {
@@ -64,31 +75,76 @@ const GameShellChrome = ({
     void navigate({ to: '/$locale', params: { locale } });
   };
 
-  const showTimer =
-    config.timerVisible && config.timerDurationSeconds !== null;
+  const switchLocale = (newLocale: AppLocale) => {
+    const newPath = location.pathname.replace(
+      /^\/(en|pt-BR)/,
+      `/${newLocale}`,
+    );
+    void navigate({ to: newPath });
+  };
 
-  // Portaled to `body` so the close control stays above the instructions overlay
+  // Portaled to `body` so the chrome stays above the instructions overlay
   // (also portaled, z-40). z-[45] is below the exit AlertDialog (z-50).
   const topChrome = (
-    <div className="pointer-events-none fixed inset-x-0 top-0 z-[45] flex items-start justify-between gap-3 px-4 pt-[max(1rem,env(safe-area-inset-top,0px))]">
-      {showTimer ? (
-        <div
-          className="pointer-events-none text-sm tabular-nums text-foreground"
-          data-testid="game-timer"
+    <div
+      data-testid="game-chrome"
+      className="pointer-events-none fixed inset-x-0 top-0 z-[45] flex items-start justify-between gap-3 px-4 pt-[max(1rem,env(safe-area-inset-top,0px))]"
+    >
+      {/* Left cluster: menu */}
+      <div className="flex items-center gap-2">
+        <Sheet>
+          <SheetTrigger asChild>
+            <button
+              type="button"
+              className={ICON_BUTTON_CLASS}
+              aria-label={t('shell.menu')}
+            >
+              <Menu aria-hidden className="size-5" strokeWidth={2.25} />
+            </button>
+          </SheetTrigger>
+          <AppMenuPanel locale={locale} onLocaleChange={switchLocale} />
+        </Sheet>
+      </div>
+
+      {/* Right cluster: fullscreen + close */}
+      <div className="flex items-center gap-2">
+        {fullscreen.supported ? (
+          <button
+            type="button"
+            className={ICON_BUTTON_CLASS}
+            onClick={() => {
+              void fullscreen.toggle();
+            }}
+            aria-label={
+              fullscreen.isFullscreen
+                ? t('shell.exitFullscreen')
+                : t('shell.enterFullscreen')
+            }
+          >
+            {fullscreen.isFullscreen ? (
+              <Minimize
+                aria-hidden
+                className="size-5"
+                strokeWidth={2.25}
+              />
+            ) : (
+              <Maximize
+                aria-hidden
+                className="size-5"
+                strokeWidth={2.25}
+              />
+            )}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className={ICON_BUTTON_CLASS}
+          onClick={() => setExitOpen(true)}
+          aria-label={t('shell.exit')}
         >
-          ⏱ {config.timerDurationSeconds}s
-        </div>
-      ) : (
-        <span className="min-w-0 flex-1" aria-hidden />
-      )}
-      <button
-        className="pointer-events-auto flex size-10 shrink-0 items-center justify-center rounded-full bg-background/90 text-foreground opacity-80 shadow-sm ring-1 ring-border transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-        type="button"
-        onClick={() => setExitOpen(true)}
-        aria-label={t('shell.exit')}
-      >
-        <X aria-hidden className="size-5" strokeWidth={2.25} />
-      </button>
+          <X aria-hidden className="size-5" strokeWidth={2.25} />
+        </button>
+      </div>
     </div>
   );
 
@@ -147,8 +203,6 @@ export const GameShell = ({
     meta={meta}
     initialLog={initialLog}
   >
-    <GameShellChrome config={config} sessionId={sessionId}>
-      {children}
-    </GameShellChrome>
+    <GameShellChrome sessionId={sessionId}>{children}</GameShellChrome>
   </GameEngineProvider>
 );

--- a/src/components/game/useFullscreen.ts
+++ b/src/components/game/useFullscreen.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type UseFullscreenResult = {
+  supported: boolean;
+  isFullscreen: boolean;
+  toggle: () => Promise<void>;
+};
+
+const isFullscreenEnabled = () =>
+  typeof document !== 'undefined' &&
+  document.fullscreenEnabled === true;
+
+export const useFullscreen = (): UseFullscreenResult => {
+  const [supported] = useState(isFullscreenEnabled);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    const sync = () => {
+      setIsFullscreen(Boolean(document.fullscreenElement));
+    };
+    sync();
+    document.addEventListener('fullscreenchange', sync);
+    return () => {
+      document.removeEventListener('fullscreenchange', sync);
+    };
+  }, []);
+
+  const toggle = useCallback(async () => {
+    if (typeof document === 'undefined' || !isFullscreenEnabled())
+      return;
+    await (document.fullscreenElement
+      ? document.exitFullscreen()
+      : document.documentElement.requestFullscreen());
+  }, []);
+
+  return { supported, isFullscreen, toggle };
+};

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -71,7 +71,12 @@ const SheetContent = ({
         <SheetPrimitive.Close data-slot="sheet-close" asChild>
           <Button
             variant="ghost"
-            className="absolute top-3 right-3"
+            className={cn(
+              'absolute top-3',
+              // Mirror the close affordance to the trigger side so the open
+              // and close tap targets share the same screen edge.
+              side === 'left' ? 'left-3' : 'right-3',
+            )}
             size="icon-sm"
           >
             <XIcon />

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -1,5 +1,6 @@
 {
   "appName": "BaseSkill",
+  "closeMenu": "Close menu",
   "home": {
     "title": "Home"
   },

--- a/src/lib/i18n/locales/en/games.json
+++ b/src/lib/i18n/locales/en/games.json
@@ -8,7 +8,10 @@
   "shell": {
     "undo": "Undo",
     "pause": "Pause",
-    "exit": "Exit"
+    "exit": "Exit",
+    "menu": "Menu",
+    "enterFullscreen": "Enter fullscreen",
+    "exitFullscreen": "Exit fullscreen"
   },
   "ui": {
     "choose-a-letter": "Choose a letter",

--- a/src/lib/i18n/locales/pt-BR/common.json
+++ b/src/lib/i18n/locales/pt-BR/common.json
@@ -1,5 +1,6 @@
 {
   "appName": "BaseSkill",
+  "closeMenu": "Fechar menu",
   "home": {
     "title": "Início"
   },

--- a/src/lib/i18n/locales/pt-BR/games.json
+++ b/src/lib/i18n/locales/pt-BR/games.json
@@ -8,7 +8,10 @@
   "shell": {
     "undo": "Desfazer",
     "pause": "Pausar",
-    "exit": "Sair"
+    "exit": "Sair",
+    "menu": "Menu",
+    "enterFullscreen": "Tela cheia",
+    "exitFullscreen": "Sair da tela cheia"
   },
   "ui": {
     "choose-a-letter": "Escolha uma letra",

--- a/src/routes/$locale/_app/game/$gameId.test.tsx
+++ b/src/routes/$locale/_app/game/$gameId.test.tsx
@@ -40,7 +40,23 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
   return {
     ...actual,
     useNavigate: () => mockNavigate,
+    useLocation: () => ({
+      pathname: '/en/game/word-builder',
+    }),
     useParams: () => ({ locale: 'en', gameId: 'word-builder' }),
+    Link: ({
+      children,
+      className,
+      to: _to,
+    }: {
+      children?: ReactNode;
+      className?: string;
+      to: string;
+    }): ReactNode => (
+      <a className={className} href="http://test/">
+        {children}
+      </a>
+    ),
   };
 });
 


### PR DESCRIPTION
## Summary

- Adds a **menu** drawer (top-left) and a **fullscreen** toggle (top-right) to the in-game chrome, alongside the existing close X — players can now reach settings, theme, voice, and language without abandoning the active session
- Drops the static timer pill from the chrome — per-game HUDs already own round/timer display, so the chrome stays lean
- Moves the home header's menu trigger to the **far left** for global consistency with the in-game trigger
- Anchors the drawer to the **left** with a transparent toggle button at the same pixel coords (and same hamburger icon) as the trigger, so opening and closing share a tap target — zero cursor travel for repeat toggles

## What changed

| File | Purpose |
| ---- | ------- |
| `src/components/AppMenuPanel.tsx` (new) | Shared drawer body — Docs, theme, volume, speech rate, voice, language. Used by both home header and in-game chrome |
| `src/components/game/useFullscreen.ts` (new) | `document.fullscreenEnabled` / `requestFullscreen` / `exitFullscreen` wrapped with React state. Hides the toggle when the platform doesn't support it (e.g. iPhone Safari) |
| `src/components/game/GameShell.tsx` | Split-nav chrome: \`[menu]\` left, \`[fullscreen][close]\` right. Timer pill removed |
| `src/components/Header.tsx` | Hamburger moves to far-left; reuses `AppMenuPanel` instead of an inline drawer body |
| `src/components/ui/sheet.tsx` | Default close button now mirrors the side prop (left-anchored sheets get left-aligned close) |
| i18n | New keys: `games.shell.menu`, `games.shell.enterFullscreen`, `games.shell.exitFullscreen`, `common.closeMenu` (en + pt-BR) |

## Test plan

- [x] All existing GameShell tests still pass; new ones cover the menu trigger opening the drawer and the fullscreen control's render/toggle behaviour
- [x] Updated the `\$gameId` route test mocks (`useLocation`, `Link`) since GameShell now reads them
- [x] `yarn typecheck` clean
- [x] `yarn vitest run src/components` — 429 passing
- [x] `yarn fix:md` clean
- [x] Pre-push hook gates passed (lint, typecheck, related unit tests)
- [ ] Manual smoke: open menu in-game → drawer slides from left, BaseSkill chip routes home, hamburger toggle button has no chrome until hover
- [ ] Manual smoke: tap fullscreen → app fills the viewport; tap again → restores
- [ ] Manual smoke: same drawer opens from home header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/307/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/307/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/307#issuecomment-)
<!-- /preview-urls -->
