### PR TITLE
fix(routing): redirect PR preview deep links on GitHub Pages

### DIFF
--- a/src/lib/spa-redirect.test.ts
+++ b/src/lib/spa-redirect.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { detectPrPreviewRedirect } from './spa-redirect';
+
+describe('detectPrPreviewRedirect', () => {
+  it('returns redirect target for a PR preview deep link', () => {
+    expect(
+      detectPrPreviewRedirect(
+        '/base-skill/pr/317/app/en/game/spot-all',
+        '/base-skill',
+      ),
+    ).toBe('/base-skill/pr/317/app/');
+  });
+
+  it('returns redirect target with different PR numbers', () => {
+    expect(
+      detectPrPreviewRedirect(
+        '/base-skill/pr/42/app/en/',
+        '/base-skill',
+      ),
+    ).toBe('/base-skill/pr/42/app/');
+  });
+
+  it('returns null for production deep links', () => {
+    expect(
+      detectPrPreviewRedirect(
+        '/base-skill/en/game/spot-all',
+        '/base-skill',
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for production root', () => {
+    expect(
+      detectPrPreviewRedirect('/base-skill/', '/base-skill'),
+    ).toBeNull();
+  });
+
+  it('returns null when the app is already a PR preview build', () => {
+    expect(
+      detectPrPreviewRedirect(
+        '/base-skill/pr/317/app/en/game/spot-all',
+        '/base-skill/pr/317/app',
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for PR path without /app/ segment', () => {
+    expect(
+      detectPrPreviewRedirect(
+        '/base-skill/pr/317/docs/',
+        '/base-skill',
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for non-numeric PR identifier', () => {
+    expect(
+      detectPrPreviewRedirect(
+        '/base-skill/pr/abc/app/en/',
+        '/base-skill',
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null when pathname does not start with base', () => {
+    expect(
+      detectPrPreviewRedirect(
+        '/other-repo/pr/317/app/en/',
+        '/base-skill',
+      ),
+    ).toBeNull();
+  });
+
+  it('works with root base path', () => {
+    expect(detectPrPreviewRedirect('/pr/5/app/en/', '')).toBe(
+      '/pr/5/app/',
+    );
+  });
+});

--- a/src/lib/spa-redirect.ts
+++ b/src/lib/spa-redirect.ts
@@ -1,0 +1,12 @@
+export const detectPrPreviewRedirect = (
+  pathname: string,
+  base: string,
+): string | null => {
+  if (base.includes('/pr/')) return null;
+  const prefix = `${base}/pr/`;
+  if (!pathname.startsWith(prefix)) return null;
+  const rest = pathname.slice(prefix.length);
+  const match = rest.match(/^(\d+)\/app\//);
+  if (!match) return null;
+  return `${prefix}${match[1]}/app/`;
+};

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -11,6 +11,23 @@ import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { Toaster } from '@/components/ui/sonner';
 import { ServiceWorkerProvider } from '@/lib/service-worker/ServiceWorkerProvider';
 
+/**
+ * GitHub Pages SPA redirect for PR previews.
+ *
+ * GitHub Pages has a single 404.html at the site root. When a PR preview deep
+ * link like /base-skill/pr/317/app/en/game/spot-all is refreshed, GH Pages
+ * serves the production 404.html (= index.html). The production router can't
+ * match the /pr/N/app/ prefix, so it falls back to the wrong route.
+ *
+ * This inline script runs before the router and handles two cases:
+ * 1. REDIRECT: if the URL targets a PR preview but this is the production app,
+ *    store the full URL in sessionStorage and redirect to the PR preview's
+ *    index.html (which exists as a real file on GH Pages).
+ * 2. RESTORE: if sessionStorage contains a stored redirect, restore the
+ *    original URL via history.replaceState before the router initialises.
+ */
+const SPA_REDIRECT_SCRIPT = String.raw`(function(){try{var b=${JSON.stringify(import.meta.env.BASE_URL.replace(/\/$/, ''))};var l=window.location;var r=sessionStorage.getItem('spa-redirect');if(r){sessionStorage.removeItem('spa-redirect');history.replaceState(null,'',r);return}if(b.indexOf('/pr/')>=0)return;if(l.pathname.indexOf(b+'/pr/')!==0)return;var s=l.pathname.substring((b+'/pr/').length);var n=s.match(/^(\d+)\/app\//);if(!n)return;sessionStorage.setItem('spa-redirect',l.pathname+l.search+l.hash);l.replace(b+'/pr/'+n[1]+'/app/')}catch(e){}})();`;
+
 /** First paint only: class + color-scheme from system preference (no localStorage). */
 const THEME_INIT_SCRIPT =
   "(function(){try{var prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;var resolved=prefersDark?'dark':'light';var root=document.documentElement;root.classList.remove('light','dark');root.classList.add(resolved);root.removeAttribute('data-theme');root.style.colorScheme=resolved;}catch(e){}})();";
@@ -18,6 +35,9 @@ const THEME_INIT_SCRIPT =
 const RootDocument = ({ children }: { children: React.ReactNode }) => (
   <html lang="en" suppressHydrationWarning>
     <head>
+      <script
+        dangerouslySetInnerHTML={{ __html: SPA_REDIRECT_SCRIPT }}
+      />
       <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
       <HeadContent />
     </head>


### PR DESCRIPTION
## Summary

- Fixes PR preview deep links (e.g. `/pr/317/app/en/game/spot-all`) redirecting to production `/en/` on page refresh
- Adds an inline `<script>` to the HTML shell that detects PR preview URLs served by the root `404.html`, stores the full path in `sessionStorage`, and redirects to the correct PR preview's `index.html`
- The PR preview app restores the original URL via `history.replaceState` before the router initialises

**Root cause:** GitHub Pages uses a single `404.html` at the site root. PR preview deep links serve the production app, whose router doesn't understand the `/pr/N/app/` prefix.

Closes #325

## Test plan

- [x] Unit tests for `detectPrPreviewRedirect` (9 test cases covering PR paths, production paths, non-numeric PR IDs, wrong base, etc.)
- [ ] Deploy PR preview and verify deep links survive a page refresh
- [ ] Verify production routes still work without regression (no extra redirect for non-PR paths)
- [ ] Verify first-time visit to PR preview deep link works (before SW is installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/327/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/327/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/327#issuecomment-)
<!-- /preview-urls -->
