### PR TITLE
feat(settings): split volume into soundEffectsVolume and voiceVolume

### DIFF
--- a/src/components/SettingsPanel/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel/SettingsPanel.test.tsx
@@ -50,9 +50,16 @@ afterEach(async () => {
 });
 
 describe('SettingsPanel', () => {
-  it('renders volume slider', () => {
+  it('renders sound effects volume slider with default 80%', () => {
     renderSettingsPanel(db);
-    expect(screen.getByText(/volume/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/sound effects \(80%\)/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders voice volume slider with default 80%', () => {
+    renderSettingsPanel(db);
+    expect(screen.getByText(/voice \(80%\)/i)).toBeInTheDocument();
   });
 
   it('renders speech rate slider', () => {

--- a/src/components/SettingsPanel/SettingsPanel.tsx
+++ b/src/components/SettingsPanel/SettingsPanel.tsx
@@ -36,7 +36,8 @@ export const SettingsPanel = ({
   const { settings, update } = useSettings();
   const { db } = useRxDB();
 
-  const volume = settings.volume ?? 0.8;
+  const soundEffectsVolume = settings.soundEffectsVolume ?? 0.8;
+  const voiceVolume = settings.voiceVolume ?? 0.8;
   const speechRate = settings.speechRate ?? 1;
   const preferredVoice = settings.preferredVoiceURI ?? '';
   const voiceSelectValue =
@@ -80,16 +81,36 @@ export const SettingsPanel = ({
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-2">
-        <Label htmlFor="settings-volume">
-          {t('volume', { percent: Math.round(volume * 100) })}
+        <Label htmlFor="settings-soundEffectsVolume">
+          {t('soundEffectsVolume', {
+            percent: Math.round(soundEffectsVolume * 100),
+          })}
         </Label>
         <Slider
-          id="settings-volume"
+          id="settings-soundEffectsVolume"
           min={0}
           max={1}
           step={0.05}
-          value={[volume]}
-          onValueChange={([v]) => void update({ volume: v })}
+          value={[soundEffectsVolume]}
+          onValueChange={([v]) =>
+            void update({ soundEffectsVolume: v })
+          }
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="settings-voiceVolume">
+          {t('voiceVolume', {
+            percent: Math.round(voiceVolume * 100),
+          })}
+        </Label>
+        <Slider
+          id="settings-voiceVolume"
+          min={0}
+          max={1}
+          step={0.05}
+          value={[voiceVolume]}
+          onValueChange={([v]) => void update({ voiceVolume: v })}
         />
       </div>
 

--- a/src/components/answer-game/useDraggableTile.test.tsx
+++ b/src/components/answer-game/useDraggableTile.test.tsx
@@ -298,7 +298,7 @@ describe('useDraggableTile', () => {
         tileId: 't2',
         zoneIndex: 0,
       });
-      expect(playSound).toHaveBeenCalledWith('wrong', 0.8);
+      expect(playSound).toHaveBeenCalledWith('wrong');
     });
 
     it('emits game:evaluate with expected field on rejection', () => {

--- a/src/components/answer-game/useDraggableTile.ts
+++ b/src/components/answer-game/useDraggableTile.ts
@@ -157,7 +157,7 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
           });
 
           if (!skin.suppressDefaultSounds) {
-            playSound('wrong', 0.8);
+            playSound('wrong');
           }
 
           dispatch({
@@ -202,7 +202,7 @@ export const useDraggableTile = (tile: TileItem): DraggableTile => {
       });
 
       if (!skin.suppressDefaultSounds) {
-        playSound('wrong', 0.8);
+        playSound('wrong');
       }
 
       // Tap/click path only — drag rejects are handled in useTileEvaluation.placeTile

--- a/src/components/answer-game/useGameTTS.ts
+++ b/src/components/answer-game/useGameTTS.ts
@@ -23,7 +23,7 @@ export const useGameTTS = (): GameTTS => {
       }
       speak(label, {
         rate: settings.speechRate ?? 1,
-        volume: settings.volume ?? 0.8,
+        volume: settings.voiceVolume ?? 0.8,
         voiceName: settings.preferredVoiceURI,
         lang: i18n.language,
       });
@@ -31,7 +31,7 @@ export const useGameTTS = (): GameTTS => {
     [
       config.ttsEnabled,
       settings.speechRate,
-      settings.volume,
+      settings.voiceVolume,
       settings.preferredVoiceURI,
       i18n.language,
     ],
@@ -42,7 +42,7 @@ export const useGameTTS = (): GameTTS => {
       if (!config.ttsEnabled) return;
       speak(text, {
         rate: settings.speechRate ?? 1,
-        volume: settings.volume ?? 0.8,
+        volume: settings.voiceVolume ?? 0.8,
         voiceName: settings.preferredVoiceURI,
         lang: i18n.language,
       });
@@ -50,7 +50,7 @@ export const useGameTTS = (): GameTTS => {
     [
       config.ttsEnabled,
       settings.speechRate,
-      settings.volume,
+      settings.voiceVolume,
       settings.preferredVoiceURI,
       i18n.language,
     ],

--- a/src/components/answer-game/useTileEvaluation.test.tsx
+++ b/src/components/answer-game/useTileEvaluation.test.tsx
@@ -93,7 +93,7 @@ describe('useTileEvaluation', () => {
       { wrapper: createWrapper(baseConfig) },
     );
     act(() => result.current.placeTile('t1', 0));
-    expect(playSound).toHaveBeenCalledWith('correct', 0.8);
+    expect(playSound).toHaveBeenCalledWith('correct');
   });
 
   it('plays "wrong" sound on incorrect tile placement', () => {
@@ -101,7 +101,7 @@ describe('useTileEvaluation', () => {
       wrapper: createWrapper(baseConfig),
     });
     act(() => result.current.placeTile('t2', 0));
-    expect(playSound).toHaveBeenCalledWith('wrong', 0.8);
+    expect(playSound).toHaveBeenCalledWith('wrong');
   });
 
   it('correct placement: zone not marked wrong', () => {

--- a/src/components/answer-game/useTileEvaluation.ts
+++ b/src/components/answer-game/useTileEvaluation.ts
@@ -32,7 +32,7 @@ export function useTileEvaluation(): TileEvaluation {
 
       const correct = tile.value === zone.expectedValue;
       if (!skin.suppressDefaultSounds) {
-        playSound(correct ? 'correct' : 'wrong', 0.8);
+        playSound(correct ? 'correct' : 'wrong');
       }
 
       // Drag path only — tap/click rejects are handled in useDraggableTile.handleClick
@@ -70,7 +70,7 @@ export function useTileEvaluation(): TileEvaluation {
       const correct =
         value.toLowerCase() === zone.expectedValue.toLowerCase();
       if (!skin.suppressDefaultSounds) {
-        playSound(correct ? 'correct' : 'wrong', 0.8);
+        playSound(correct ? 'correct' : 'wrong');
       }
       dispatch({
         type: 'TYPE_TILE',

--- a/src/db/create-database.ts
+++ b/src/db/create-database.ts
@@ -69,6 +69,16 @@ const COLLECTIONS = {
     migrationStrategies: {
       1: (oldDoc: Record<string, unknown>) => oldDoc,
       2: (oldDoc: Record<string, unknown>) => oldDoc,
+      3: (oldDoc: Record<string, unknown>) => {
+        const legacyVolume =
+          typeof oldDoc.volume === 'number' ? oldDoc.volume : 0.8;
+        const { volume: _removed, ...rest } = oldDoc;
+        return {
+          ...rest,
+          soundEffectsVolume: legacyVolume,
+          voiceVolume: legacyVolume,
+        };
+      },
     },
   },
   game_config_overrides: { schema: gameConfigOverridesSchema },

--- a/src/db/hooks/useAudioVolumes.ts
+++ b/src/db/hooks/useAudioVolumes.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useSettings } from './useSettings';
+import { setSoundEffectsVolume } from '@/lib/audio/AudioFeedback';
+
+export const useAudioVolumes = (): void => {
+  const { settings } = useSettings();
+  const soundEffectsVolume = settings.soundEffectsVolume ?? 0.8;
+
+  useEffect(() => {
+    setSoundEffectsVolume(soundEffectsVolume);
+  }, [soundEffectsVolume]);
+};

--- a/src/db/hooks/useSettings.demo.tsx
+++ b/src/db/hooks/useSettings.demo.tsx
@@ -9,7 +9,8 @@ const SettingsInner = () => {
 
   return (
     <div className="flex flex-col gap-2 p-4 font-mono text-sm">
-      <div>volume: {settings.volume}</div>
+      <div>soundEffectsVolume: {settings.soundEffectsVolume}</div>
+      <div>voiceVolume: {settings.voiceVolume}</div>
       <div>speechRate: {settings.speechRate}</div>
       <div>ttsEnabled: {String(settings.ttsEnabled)}</div>
       <div>showSubtitles: {String(settings.showSubtitles)}</div>

--- a/src/db/hooks/useSettings.test.tsx
+++ b/src/db/hooks/useSettings.test.tsx
@@ -35,16 +35,25 @@ afterEach(async () => {
 });
 
 describe('useSettings', () => {
-  it('returns default volume 0.8 when no settings doc exists', async () => {
+  it('returns default soundEffectsVolume 0.8 when no settings doc exists', async () => {
     db = await createTestDatabase();
     const { result } = renderHook(() => useSettingsUnderTest(), {
       wrapper: makeWrapper(db),
     });
     await waitFor(() => expect(result.current.isReady).toBe(true));
-    expect(result.current.settings.volume).toBe(0.8);
+    expect(result.current.settings.soundEffectsVolume).toBe(0.8);
   });
 
-  it('persists updated volume to RxDB', async () => {
+  it('returns default voiceVolume 0.8 when no settings doc exists', async () => {
+    db = await createTestDatabase();
+    const { result } = renderHook(() => useSettingsUnderTest(), {
+      wrapper: makeWrapper(db),
+    });
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    expect(result.current.settings.voiceVolume).toBe(0.8);
+  });
+
+  it('persists updated soundEffectsVolume to RxDB', async () => {
     db = await createTestDatabase();
     const { result } = renderHook(() => useSettingsUnderTest(), {
       wrapper: makeWrapper(db),
@@ -52,11 +61,11 @@ describe('useSettings', () => {
     await waitFor(() => expect(result.current.isReady).toBe(true));
 
     await act(async () => {
-      await result.current.update({ volume: 0.5 });
+      await result.current.update({ soundEffectsVolume: 0.5 });
     });
 
     await waitFor(() => {
-      expect(result.current.settings.volume).toBe(0.5);
+      expect(result.current.settings.soundEffectsVolume).toBe(0.5);
     });
   });
 
@@ -73,7 +82,7 @@ describe('useSettings', () => {
 
     await waitFor(() => {
       expect(result.current.settings.speechRate).toBe(1.5);
-      expect(result.current.settings.volume).toBe(0.8);
+      expect(result.current.settings.soundEffectsVolume).toBe(0.8);
     });
   });
 });

--- a/src/db/hooks/useSettings.ts
+++ b/src/db/hooks/useSettings.ts
@@ -10,7 +10,8 @@ const ANONYMOUS_SETTINGS_ID = 'settings:anonymous';
 const DEFAULT_SETTINGS: Omit<SettingsDoc, 'updatedAt'> = {
   id: ANONYMOUS_SETTINGS_ID,
   profileId: ANONYMOUS_PROFILE_ID,
-  volume: 0.8,
+  soundEffectsVolume: 0.8,
+  voiceVolume: 0.8,
   speechRate: 1,
   ttsEnabled: true,
   showSubtitles: true,

--- a/src/db/schemas/settings.ts
+++ b/src/db/schemas/settings.ts
@@ -3,7 +3,8 @@ import type { RxJsonSchema } from 'rxdb';
 export type SettingsDoc = {
   id: string;
   profileId: string;
-  volume?: number;
+  soundEffectsVolume?: number;
+  voiceVolume?: number;
   speechRate?: number;
   activeLanguage?: string;
   ttsEnabled?: boolean;
@@ -17,13 +18,24 @@ export type SettingsDoc = {
 };
 
 export const settingsSchema: RxJsonSchema<SettingsDoc> = {
-  version: 2,
+  version: 3,
   primaryKey: 'id',
   type: 'object',
   properties: {
     id: { type: 'string', maxLength: 36 },
     profileId: { type: 'string', maxLength: 36 },
-    volume: { type: 'number', minimum: 0, maximum: 1, default: 0.8 },
+    soundEffectsVolume: {
+      type: 'number',
+      minimum: 0,
+      maximum: 1,
+      default: 0.8,
+    },
+    voiceVolume: {
+      type: 'number',
+      minimum: 0,
+      maximum: 1,
+      default: 0.8,
+    },
     speechRate: {
       type: 'number',
       minimum: 0.5,

--- a/src/games/spot-all/SpotAllPrompt/SpotAllPrompt.tsx
+++ b/src/games/spot-all/SpotAllPrompt/SpotAllPrompt.tsx
@@ -20,7 +20,7 @@ export const SpotAllPrompt = ({
   const speakPrompt = (): void => {
     speak(prompt, {
       rate: settings.speechRate ?? 1,
-      volume: settings.volume ?? 0.8,
+      volume: settings.voiceVolume ?? 0.8,
       voiceName: settings.preferredVoiceURI,
       lang: i18n.language,
     });

--- a/src/lib/audio/AudioFeedback.ts
+++ b/src/lib/audio/AudioFeedback.ts
@@ -20,6 +20,11 @@ const SOUND_PATHS: Record<SoundKey, string> = {
 let currentAudio: HTMLAudioElement | null = null;
 let currentResolve: (() => void) | null = null;
 let queueTail: Promise<void> = Promise.resolve();
+let defaultSoundEffectsVolume = 0.8;
+
+export function setSoundEffectsVolume(volume: number): void {
+  defaultSoundEffectsVolume = volume;
+}
 
 function playSoundInternal(
   path: string,
@@ -55,7 +60,10 @@ function playSoundInternal(
  * Plays immediately, cancelling any current audio and resetting the queue.
  * Use for tile feedback (correct/wrong) where the latest sound always wins.
  */
-export function playSound(key: SoundKey, volume = 0.8): void {
+export function playSound(
+  key: SoundKey,
+  volume = defaultSoundEffectsVolume,
+): void {
   currentResolve?.();
   currentResolve = null;
   queueTail = playSoundInternal(SOUND_PATHS[key], volume);
@@ -66,7 +74,10 @@ export function playSound(key: SoundKey, volume = 0.8): void {
  * Use for phase sounds (round-complete, game-complete) so they don't cut off tile feedback.
  * Returns a promise that resolves when the queued sound **starts** (not ends).
  */
-export function queueSound(key: SoundKey, volume = 0.8): Promise<void> {
+export function queueSound(
+  key: SoundKey,
+  volume = defaultSoundEffectsVolume,
+): Promise<void> {
   const startsAt = queueTail;
   queueTail = startsAt.then(() =>
     playSoundInternal(SOUND_PATHS[key], volume),
@@ -83,7 +94,10 @@ export function whenSoundEnds(): Promise<void> {
 }
 
 /** Plays an arbitrary audio URL through the same queue/cancel machinery. */
-export function playSoundUrl(url: string, volume = 0.8): void {
+export function playSoundUrl(
+  url: string,
+  volume = defaultSoundEffectsVolume,
+): void {
   currentResolve?.();
   currentResolve = null;
   queueTail = playSoundInternal(url, volume);
@@ -92,7 +106,7 @@ export function playSoundUrl(url: string, volume = 0.8): void {
 /** Queues an arbitrary audio URL behind any in-flight audio. */
 export function queueSoundUrl(
   url: string,
-  volume = 0.8,
+  volume = defaultSoundEffectsVolume,
 ): Promise<void> {
   const startsAt = queueTail;
   queueTail = startsAt.then(() => playSoundInternal(url, volume));

--- a/src/lib/audio/index.ts
+++ b/src/lib/audio/index.ts
@@ -4,5 +4,6 @@ export {
   queueSound,
   queueSoundUrl,
   whenSoundEnds,
+  setSoundEffectsVolume,
   SOUND_KEYS,
 } from './AudioFeedback';

--- a/src/lib/i18n/locales/en/settings.json
+++ b/src/lib/i18n/locales/en/settings.json
@@ -1,6 +1,7 @@
 {
   "title": "Settings",
-  "volume": "Volume ({{percent}}%)",
+  "soundEffectsVolume": "Sound effects ({{percent}}%)",
+  "voiceVolume": "Voice ({{percent}}%)",
   "speechRate": "Speech rate ({{rate}}×)",
   "language": "Language",
   "theme": "Theme",

--- a/src/lib/i18n/locales/pt-BR/settings.json
+++ b/src/lib/i18n/locales/pt-BR/settings.json
@@ -1,6 +1,7 @@
 {
   "title": "Configurações",
-  "volume": "Volume ({{percent}}%)",
+  "soundEffectsVolume": "Efeitos sonoros ({{percent}}%)",
+  "voiceVolume": "Voz ({{percent}}%)",
   "speechRate": "Velocidade da fala ({{rate}}×)",
   "language": "Idioma",
   "theme": "Tema",

--- a/src/routes/$locale/_app.tsx
+++ b/src/routes/$locale/_app.tsx
@@ -9,34 +9,40 @@ import { Footer } from '@/components/Footer';
 import { Header } from '@/components/Header';
 import { OfflineIndicator } from '@/components/OfflineIndicator';
 import { UpdateBanner } from '@/components/UpdateBanner';
+import { useAudioVolumes } from '@/db/hooks/useAudioVolumes';
 import { seedThemesOnce } from '@/db/seed-themes';
 import { shouldRenderAppHeaderFooter } from '@/lib/app-paths';
 import { i18n } from '@/lib/i18n/i18n';
 import { DbProvider } from '@/providers/DbProvider';
 import { ThemeRuntimeProvider } from '@/providers/ThemeRuntimeProvider';
 
-const AppLayout = (): JSX.Element => {
+const AppLayoutInner = (): JSX.Element => {
   const { pathname } = useLocation();
   const showAppChrome = shouldRenderAppHeaderFooter(pathname);
+  useAudioVolumes();
 
   return (
-    <DbProvider onDatabaseReady={seedThemesOnce}>
-      <I18nextProvider i18n={i18n}>
-        <ThemeRuntimeProvider>
-          <div className="flex min-h-screen flex-col">
-            {showAppChrome ? <Header /> : null}
-            <OfflineIndicator />
-            <UpdateBanner />
-            <main className="flex-1">
-              <Outlet />
-            </main>
-            {showAppChrome ? <Footer /> : null}
-          </div>
-        </ThemeRuntimeProvider>
-      </I18nextProvider>
-    </DbProvider>
+    <ThemeRuntimeProvider>
+      <div className="flex min-h-screen flex-col">
+        {showAppChrome ? <Header /> : null}
+        <OfflineIndicator />
+        <UpdateBanner />
+        <main className="flex-1">
+          <Outlet />
+        </main>
+        {showAppChrome ? <Footer /> : null}
+      </div>
+    </ThemeRuntimeProvider>
   );
 };
+
+const AppLayout = (): JSX.Element => (
+  <DbProvider onDatabaseReady={seedThemesOnce}>
+    <I18nextProvider i18n={i18n}>
+      <AppLayoutInner />
+    </I18nextProvider>
+  </DbProvider>
+);
 
 export const Route = createFileRoute('/$locale/_app')({
   component: AppLayout,


### PR DESCRIPTION
## Summary

- Replaces the single `volume` setting with two independent controls: `soundEffectsVolume` (game sound effects) and `voiceVolume` (text-to-speech)
- Settings are persistent per-profile via RxDB (schema v3) with a migration that copies the legacy `volume` value to both new fields
- Sound effects volume is synced to the `AudioFeedback` module via a new `useAudioVolumes` hook mounted in `AppLayout`, so all `playSound` call sites pick it up without requiring settings to be threaded through each one

## Changes

- `db/schemas/settings.ts`: schema v3 — adds `soundEffectsVolume` and `voiceVolume`, removes `volume`
- `db/create-database.ts`: migration strategy 3 copies legacy `volume` → both new fields
- `db/hooks/useSettings.ts`: updated defaults
- `db/hooks/useAudioVolumes.ts`: new hook that calls `setSoundEffectsVolume` when settings change
- `lib/audio/AudioFeedback.ts`: adds `setSoundEffectsVolume` module-level setter; all functions default to the module-level value
- `routes/$locale/_app.tsx`: `AppLayoutInner` calls `useAudioVolumes()` so it runs for every route
- `components/answer-game/useGameTTS.ts` + `games/spot-all/SpotAllPrompt`: use `voiceVolume` instead of `volume`
- `components/SettingsPanel`: two sliders replace the single volume slider
- i18n: `soundEffectsVolume` and `voiceVolume` keys added in EN and PT-BR

Closes #326

## Test plan

- [x] TypeScript passes (`yarn typecheck`)
- [x] All 1834 unit tests pass (`yarn test`)
- [x] Lint passes (`yarn lint`)
- [x] Pre-push hook (prettier, eslint, knip, typecheck, unit) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/328/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/328/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/328#issuecomment-)
<!-- /preview-urls -->
