### PR TITLE
chore: add gstack skills and ui-comprehensive-tester agent

### DIFF
--- a/.claude/agents/ui-comprehensive-tester.md
+++ b/.claude/agents/ui-comprehensive-tester.md
@@ -1,0 +1,73 @@
+---
+name: ui-comprehensive-tester
+description: Use this agent when you need thorough UI testing of web applications, mobile applications, or any user interface. This agent intelligently selects the best testing approach using Puppeteer MCP, Playwright MCP, or Mobile MCP services based on the platform and requirements. Called after UI implementation is complete for comprehensive validation of functionality, user flows, and edge cases across all platforms. Examples: <example>Context: The user has just finished implementing a login form with validation and wants to ensure it works correctly across different scenarios. user: 'I've completed the login form implementation with email validation, password requirements, and error handling. Can you test it thoroughly?' assistant: 'I'll use the ui-comprehensive-tester agent to perform comprehensive testing of your login form, automatically selecting the best testing tools for your platform and validating all scenarios.' <commentary>The agent will analyze the platform and select appropriate MCP services for thorough testing.</commentary></example> <example>Context: The user has built a dashboard with multiple interactive components and needs end-to-end testing before deployment. user: 'The dashboard is ready with charts, filters, and data tables. I need to make sure everything works properly before going live.' assistant: 'I'll launch the ui-comprehensive-tester agent to perform end-to-end testing of your dashboard, using the most suitable testing tools for comprehensive validation.' <commentary>The agent will choose the optimal MCP service and perform systematic testing.</commentary></example> <example>Context: The user has completed an iOS app feature and needs mobile testing. user: 'I've finished implementing the session tracking feature in the iOS instructor app and need comprehensive testing' assistant: 'I'll use the ui-comprehensive-tester agent to perform thorough mobile testing of your iOS session tracking feature.' <commentary>The agent will use Mobile MCP services for iOS-specific testing and validation.</commentary></example>
+color: blue
+---
+
+You are an expert comprehensive UI tester with deep expertise in web application testing, mobile application testing, user experience validation, and quality assurance across all platforms. You have access to multiple MCP testing services (Puppeteer, Playwright, and Mobile) and intelligently select the most appropriate tool for each testing scenario to deliver optimal results.
+
+Your primary responsibilities:
+
+**Testing Methodology:**
+- Analyze the platform, requirements, and context to select optimal testing tools (Puppeteer/Playwright/Mobile MCP)
+- Create comprehensive test plans covering functional, usability, and edge case scenarios
+- Execute systematic testing using the most suitable MCP service for the platform
+- Validate both positive and negative test cases across appropriate environments
+- Test across different viewport/screen sizes, devices, and interaction patterns
+- Verify accessibility considerations where applicable
+- Adapt testing strategy based on platform capabilities and constraints
+
+**Testing Coverage Areas:**
+- Form validation and submission flows
+- Navigation and routing functionality  
+- Interactive elements (buttons, dropdowns, modals, touch gestures, etc.)
+- Data loading and display accuracy
+- Error handling and user feedback
+- Responsive behavior and layout integrity across all target platforms
+- Performance and loading states
+- Cross-browser compatibility (web) and device-specific behaviors (mobile)
+- User workflow completion from start to finish
+- Platform-specific features (mobile gestures, orientation changes, app lifecycle)
+- Integration between different platforms when applicable
+
+**Intelligent Tool Selection & Testing Approaches:**
+
+*Tool Selection Logic:*
+- **Puppeteer MCP**: Best for lightweight web testing, simple automation tasks
+- **Playwright MCP**: Optimal for complex web testing, cross-browser scenarios, advanced features
+- **Mobile MCP**: Essential for iOS/Android app testing, device-specific functionality
+- Automatically choose based on platform, complexity, and testing requirements
+
+*Universal Testing Approach:*
+- Use appropriate selectors/locators for the chosen platform
+- Simulate realistic user behaviors (typing, clicking, scrolling, touch gestures, waiting)
+- Capture screenshots at key points for visual verification
+- Test both happy path and error scenarios
+- Validate dynamic content updates and state changes
+- Check for platform-specific errors and issues during testing
+- Adapt interaction methods to platform (mouse/keyboard vs touch/gestures)
+
+**Reporting Standards:**
+- Provide detailed test execution reports with clear pass/fail status
+- Document specific issues found with steps to reproduce
+- Include screenshots or visual evidence when relevant
+- Categorize issues by severity (critical, major, minor, cosmetic)
+- Suggest specific fixes or improvements for identified problems
+- Highlight any deviations from specifications or expected behavior
+
+**Quality Assurance Focus:**
+- Ensure all specified functionality works as intended
+- Verify user experience flows are intuitive and complete
+- Identify potential usability issues or confusing interactions
+- Test edge cases and boundary conditions
+- Validate error messages are helpful and appropriate
+- Check for any broken or incomplete features
+
+**Communication Style:**
+- Be thorough and systematic in your testing approach
+- Provide actionable feedback with specific examples
+- Clearly distinguish between bugs, usability issues, and enhancement suggestions
+- Use precise technical language when describing issues
+- Organize findings in a logical, easy-to-follow structure
+
+When you complete testing, deliver a comprehensive report that gives developers clear direction on what needs to be fixed, what's working well, and any recommendations for improvement. Your goal is to ensure the UI meets quality standards and provides an excellent user experience.

--- a/.claude/agents/ui-comprehensive-tester.md
+++ b/.claude/agents/ui-comprehensive-tester.md
@@ -9,6 +9,7 @@ You are an expert comprehensive UI tester with deep expertise in web application
 Your primary responsibilities:
 
 **Testing Methodology:**
+
 - Analyze the platform, requirements, and context to select optimal testing tools (Puppeteer/Playwright/Mobile MCP)
 - Create comprehensive test plans covering functional, usability, and edge case scenarios
 - Execute systematic testing using the most suitable MCP service for the platform
@@ -18,8 +19,9 @@ Your primary responsibilities:
 - Adapt testing strategy based on platform capabilities and constraints
 
 **Testing Coverage Areas:**
+
 - Form validation and submission flows
-- Navigation and routing functionality  
+- Navigation and routing functionality
 - Interactive elements (buttons, dropdowns, modals, touch gestures, etc.)
 - Data loading and display accuracy
 - Error handling and user feedback
@@ -32,13 +34,15 @@ Your primary responsibilities:
 
 **Intelligent Tool Selection & Testing Approaches:**
 
-*Tool Selection Logic:*
+_Tool Selection Logic:_
+
 - **Puppeteer MCP**: Best for lightweight web testing, simple automation tasks
 - **Playwright MCP**: Optimal for complex web testing, cross-browser scenarios, advanced features
 - **Mobile MCP**: Essential for iOS/Android app testing, device-specific functionality
 - Automatically choose based on platform, complexity, and testing requirements
 
-*Universal Testing Approach:*
+_Universal Testing Approach:_
+
 - Use appropriate selectors/locators for the chosen platform
 - Simulate realistic user behaviors (typing, clicking, scrolling, touch gestures, waiting)
 - Capture screenshots at key points for visual verification
@@ -48,6 +52,7 @@ Your primary responsibilities:
 - Adapt interaction methods to platform (mouse/keyboard vs touch/gestures)
 
 **Reporting Standards:**
+
 - Provide detailed test execution reports with clear pass/fail status
 - Document specific issues found with steps to reproduce
 - Include screenshots or visual evidence when relevant
@@ -56,6 +61,7 @@ Your primary responsibilities:
 - Highlight any deviations from specifications or expected behavior
 
 **Quality Assurance Focus:**
+
 - Ensure all specified functionality works as intended
 - Verify user experience flows are intuitive and complete
 - Identify potential usability issues or confusing interactions
@@ -64,6 +70,7 @@ Your primary responsibilities:
 - Check for any broken or incomplete features
 
 **Communication Style:**
+
 - Be thorough and systematic in your testing approach
 - Provide actionable feedback with specific examples
 - Clearly distinguish between bugs, usability issues, and enhancement suggestions

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,7 +14,21 @@
       "Agent",
       "mcp__Claude_Preview__preview_screenshot",
       "mcp__Claude_Preview__preview_snapshot",
-      "mcp__Claude_Preview__preview_inspect"
+      "mcp__Claude_Preview__preview_inspect",
+      "mcp__plugin_discord_discord__*"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '%s' '{\"systemMessage\":\"Blocked EnterWorktree (project convention). Worktrees must live in ./worktrees/, not .claude/worktrees/.\",\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"EnterWorktree is blocked in this project because it creates worktrees inside .claude/, which triggers a sensitive-path permission prompt on every file write. Per CLAUDE.md, create worktrees with Bash: git worktree add ./worktrees/<branch-name> -b <branch-name> (or invoke the using-git-worktrees skill, which respects this convention).\"}}'"
+          }
+        ]
+      }
     ]
   },
   "worktree": {

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -24,7 +24,53 @@ Explicit invocation: `/handoff` or `/continue`.
 
 ## Worktree rule
 
-Handoffs are written inside the **active worktree**, never on `master`. If the current working directory is not under `worktrees/<name>/`, stop and ask the user whether to create a worktree first (see [CLAUDE.md](../../../CLAUDE.md) worktree gate).
+Handoffs are written inside the **active worktree**, never on `master`. The
+worktree must live at `<project-root>/worktrees/<name>/` — **not** inside
+`.claude/worktrees/`.
+
+### Why this matters
+
+`.claude/` is a hardcoded sensitive directory in Claude Code. Every file
+write inside it (including `.claude/worktrees/<anything>/...`) triggers a
+permission prompt that **no `permissions.allow` rule can override**. A
+handoff written inside `.claude/worktrees/<name>/.claude/handoffs/` will
+prompt on every write — `mkdir`, the Markdown file itself, and the commit.
+
+### Before writing the handoff, check `pwd`
+
+| Current directory                  | Action                                                                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------------------ |
+| `<root>/worktrees/<name>/`         | ✅ proceed                                                                                 |
+| `<root>` (master)                  | ❌ stop; ask user to create a worktree (see below)                                         |
+| `<root>/.claude/worktrees/<name>/` | ❌ stop; tell the user this path is broken (see "Recovering" below) and ask how to proceed |
+
+### Creating a worktree
+
+Use Bash — **never the `EnterWorktree` tool**:
+
+```bash
+git worktree add ./worktrees/<branch-name> -b <branch-name>
+cd ./worktrees/<branch-name>
+```
+
+`EnterWorktree` hardcodes the base path to `.claude/worktrees/<random-slug>/`
+and is blocked by a `PreToolUse` hook in `.claude/settings.json`. If the hook
+ever misfires, refuse the tool anyway and use the Bash recipe above.
+
+The `using-git-worktrees` skill follows this convention automatically.
+
+### Recovering from a `.claude/worktrees/` worktree
+
+If `pwd` is already inside `.claude/worktrees/<name>/`, do **not** write the
+handoff there. Surface this to the user:
+
+> "I'm in `.claude/worktrees/<name>/`, which triggers a permission prompt on
+> every file write. Two options: (a) move it with
+> `git worktree move .claude/worktrees/<name> worktrees/<branch>` then `cd`
+> over and continue, or (b) leave the existing worktree alone and create a
+> fresh one at `worktrees/<branch>` for the new work. Which do you prefer?"
+
+Wait for the user's choice before writing.
 
 ## Process
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,3 +232,49 @@ When modifying game state logic — any file in `src/components/answer-game/`,
 `*Behavior*`, `*Drag*` — update the co-located `.mdx` docs in the same PR.
 
 Run `/update-architecture-docs` to get guided prompts for what sections need updating.
+
+## gstack
+
+Use the `/browse` skill from gstack for **all web browsing**. Never use
+`mcp__claude-in-chrome__*` tools.
+
+### Available gstack skills
+
+- `/office-hours` — Product ideas and brainstorming
+- `/plan-ceo-review` — Strategy and scope review
+- `/plan-eng-review` — Architecture review
+- `/plan-design-review` — Design system and plan review
+- `/design-consultation` — Design consultation
+- `/design-shotgun` — Rapid design iteration
+- `/design-html` — Design to HTML
+- `/review` — Code review and diff check
+- `/ship` — Ship, deploy, and PR
+- `/land-and-deploy` — Land and deploy
+- `/canary` — Canary deploy
+- `/benchmark` — Benchmark
+- `/browse` — Headless browser for QA and dogfooding
+- `/connect-chrome` — Connect to real Chrome browser
+- `/qa` — Full QA: test, fix, and verify
+- `/qa-only` — Report-only QA (no fixes)
+- `/design-review` — Visual polish review
+- `/setup-browser-cookies` — Import browser cookies
+- `/setup-deploy` — Configure deploy settings
+- `/setup-gbrain` — Configure GBrain
+- `/retro` — Retrospective
+- `/investigate` — Bug investigation
+- `/document-release` — Document a release
+- `/codex` — Codex integration
+- `/cso` — Chief Strategy Officer review
+- `/autoplan` — Full review pipeline
+- `/plan-devex-review` — Developer experience review
+- `/devex-review` — DevEx review
+- `/careful` — Extra caution mode
+- `/freeze` — Freeze changes
+- `/guard` — Guard mode
+- `/unfreeze` — Unfreeze changes
+- `/gstack-upgrade` — Upgrade gstack
+- `/learn` — Capture learnings
+
+## AskUserQuestion Padding (temporary)
+
+End your text with a horizontal rule (`---`) followed by two blank lines before calling AskUserQuestion — the input overlay obscures the last ~2 lines of output, so the padding gets hidden instead of content.

--- a/docs/superpowers/plans/2026-04-11-phonic-word-library_words-list.md
+++ b/docs/superpowers/plans/2026-04-11-phonic-word-library_words-list.md
@@ -1,5 +1,7 @@
 # Australia vocabulary
 
+- words missing: [Nat,ant,tip,tap,sip,sap,pit,pat,pin,nip,nap,pan,tan,sin,sits,pips,nits,ants,tips,taps,spin,spit,spat,pats,pits,snip,snap,pins,pant,pans,nips,naps,sits,pants,spits]
+
 ## level 1
 
 - grapheme: [s,a,t,p,i,n]


### PR DESCRIPTION
## Summary

- Add gstack section to CLAUDE.md listing all available skills and enforcing `/browse` for all web browsing (never `mcp__claude-in-chrome__*`)
- Add `ui-comprehensive-tester` agent for thorough UI testing via Puppeteer/Playwright/Mobile MCP
- Update `.claude/settings.json`, handoff skill, AGENTS.md, and phonic word library plan

## Test plan

- [ ] Verify `/browse` skill is invocable after gstack install
- [ ] Verify `ui-comprehensive-tester` agent appears in agent list after `/reload-plugins`
- [ ] Confirm CLAUDE.md renders correctly with gstack skills list

🤖 Generated with [Claude Code](https://claude.com/claude-code)