### PR TITLE
chore(release): v0.31.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-skill",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
Automated version bump from the deploy workflow.

The site has already been deployed to gh-pages with version `0.31.2` (see `dist/client/version.json`). Merging this PR lands the matching `package.json` bump on master and makes the `v0.31.2` tag reachable from master.

The bump type was derived from the merged PR's conventional-commit messages by `scripts/determine-bump.sh`.