### PR TITLE
docs(plans): implementation plans for #323 (M1) and #257 (useGameRound)

### DIFF
--- a/docs/superpowers/plans/2026-05-06-spec-1a-m1-tts-lifecycle.md
+++ b/docs/superpowers/plans/2026-05-06-spec-1a-m1-tts-lifecycle.md
@@ -1,0 +1,1767 @@
+# Spec 1a M1 — TTS Lifecycle Minimum Viable Copy Fix
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the user-visible TTS copy fixes from #229 — rename InstructionsOverlay, stop auto-speaking how-to-play, speak proper instructional templates, split ttsEnabled into autoSpeak + ttsOnDemandAllowed, add QuestionRow layout, add Talkativeness preset.
+
+**Architecture:** Introduce a `src/lib/lifecycle-tts/` module with types, a pure verbosity resolver, talkativeness presets, and per-game registry entries. A `useLifecycleTTS` hook subscribes to the `GameEventBus` and gates speech by `autoSpeak` / `ttsOnDemandAllowed`. Rename `InstructionsOverlay` → `GameOptionsOverlay`, refactor `AudioButton` to use lifecycle events, and add `QuestionRow` for consistent inline layout.
+
+**Tech Stack:** React 18, TypeScript, Vitest, i18next, Web Speech API, existing GameEventBus
+
+**Spec:** `docs/superpowers/specs/2026-05-03-instructions-tts-lifecycle-design.md` (§14 M1 criteria)
+
+**Spec Deltas:** None — plan follows spec exactly.
+
+**Required skills for executors:**
+
+- `write-storybook` — for `*.stories.tsx` files (Tasks 12, 16)
+- Markdown Authoring rules from CLAUDE.md — for this plan file
+
+---
+
+## File Structure
+
+### New files
+
+```text
+src/lib/lifecycle-tts/
+├── types.ts                          # LifecycleEvent, Verbosity, EventTemplate, registry types
+├── resolve.ts                        # resolveVerbosity() + resolveCopy() — pure functions
+├── resolve.test.ts                   # Verbosity + copy chain tests
+├── useLifecycleTTS.ts                # Hook: subscribes to bus, gates by autoSpeak/ttsOnDemandAllowed
+├── useLifecycleTTS.test.tsx          # Hook tests
+├── talkativeness-presets.ts          # Quiet / Default / Chatty profiles per gradeBand
+├── talkativeness-presets.test.ts     # Preset resolution tests
+├── registry/
+│   ├── index.ts                      # GameLifecycleRegistry assembly
+│   ├── word-spell.ts                 # WordSpell registry entry
+│   └── number-match.ts              # NumberMatch registry entry (fixes speak-the-answer)
+
+src/components/questions/QuestionRow/
+├── QuestionRow.tsx                   # Inline AudioButton + content layout
+└── QuestionRow.test.tsx              # Layout tests
+
+src/components/answer-game/GameOptions/
+├── GameOptionsOverlay.tsx            # Renamed from InstructionsOverlay
+├── GameOptionsOverlay.test.tsx       # Renamed tests
+├── GameOptionsOverlay.stories.tsx    # Renamed stories
+└── useConfigDraft.ts                 # Moved, unchanged content
+```
+
+### Modified files
+
+| File                                                             | Change                                                       |
+| ---------------------------------------------------------------- | ------------------------------------------------------------ |
+| `src/types/game-events.ts`                                       | Add `game:prepare` event type + interface                    |
+| `src/components/answer-game/types.ts`                            | Replace `ttsEnabled` with `autoSpeak` + `ttsOnDemandAllowed` |
+| `src/components/answer-game/useGameTTS.ts`                       | Split into `speakAuto` + `speakOnDemand`; keep `speakTile`   |
+| `src/components/answer-game/useGameTTS.test.tsx`                 | Update for new API                                           |
+| `src/components/answer-game/useRoundTTS.ts`                      | Update to use `autoSpeak` (stays in M1; removed in M2)       |
+| `src/components/answer-game/useRoundTTS.test.tsx`                | Update for `autoSpeak`                                       |
+| `src/components/questions/AudioButton/AudioButton.tsx`           | Switch to lifecycle event prop, gate by `ttsOnDemandAllowed` |
+| `src/components/questions/AudioButton/AudioButton.test.tsx`      | Update tests                                                 |
+| `src/components/questions/TextQuestion/TextQuestion.tsx`         | Route onClick through `speakOnDemand`                        |
+| `src/components/questions/ImageQuestion/ImageQuestion.tsx`       | Same                                                         |
+| `src/components/questions/EmojiQuestion/EmojiQuestion.tsx`       | Same                                                         |
+| `src/components/questions/DotGroupQuestion/DotGroupQuestion.tsx` | Same                                                         |
+| `src/components/questions/index.ts`                              | Add `QuestionRow` export                                     |
+| `src/games/word-spell/WordSpell/WordSpell.tsx`                   | Use `QuestionRow`; pass event to AudioButton                 |
+| `src/games/number-match/NumberMatch/NumberMatch.tsx`             | Use `QuestionRow`; registry-backed instructional copy        |
+| `src/games/sort-numbers/SortNumbers/SortNumbers.tsx`             | Add AudioButton via `QuestionRow`                            |
+| `src/games/spot-all/SpotAllPrompt/SpotAllPrompt.tsx`             | Consolidate `speakPrompt` into `useLifecycleTTS`             |
+| `src/components/AdvancedConfigModal.tsx`                         | Add Talkativeness preset section                             |
+| `src/lib/i18n/locales/en/games.json`                             | Add `tts.*` keys                                             |
+| `src/lib/i18n/locales/pt-BR/games.json`                          | Add `tts.*` keys (placeholder English)                       |
+| `src/routes/$locale/_app/game/$gameId.tsx`                       | Update import path                                           |
+| `src/components/answer-game/AnswerGameProvider.tsx`              | Emit `game:prepare` on panel mount path                      |
+
+### Deleted files
+
+| File                                                          | Reason                    |
+| ------------------------------------------------------------- | ------------------------- |
+| `src/components/answer-game/InstructionsOverlay/` (directory) | Renamed to `GameOptions/` |
+
+---
+
+## Task 1: Lifecycle TTS Types
+
+**Files:**
+
+- Create: `src/lib/lifecycle-tts/types.ts`
+- Test: typecheck only (no runtime test needed for pure types)
+
+- [ ] **Step 1: Create the types file**
+
+```ts
+// src/lib/lifecycle-tts/types.ts
+import type { GradeBand } from '@/types/game-events';
+
+export type LifecycleEvent =
+  | 'game.prepare'
+  | 'game.start'
+  | 'game.resume'
+  | 'game.over'
+  | 'round.start'
+  | 'round.idle'
+  | 'round.error'
+  | 'round.correct'
+  | 'round.celebrate'
+  | 'round.advance'
+  | 'level.complete';
+
+export type Verbosity = 'off' | 'brief' | 'full';
+
+export type TalkativenessPreset = 'quiet' | 'default' | 'chatty';
+
+export type EventTemplate = {
+  tts: { brief: string; full: string };
+  byGradeBand: Record<GradeBand, Verbosity>;
+  default: Verbosity;
+};
+
+export type GameLifecycleRegistryEntry = {
+  events: Record<LifecycleEvent, EventTemplate>;
+};
+
+export type GameLifecycleRegistry = Record<
+  string,
+  GameLifecycleRegistryEntry
+>;
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `yarn typecheck`
+Expected: PASS — no type errors from the new file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/lifecycle-tts/types.ts
+git commit -m "feat(lifecycle-tts): add type foundation for TTS lifecycle system"
+```
+
+---
+
+## Task 2: game:prepare Bus Event
+
+**Files:**
+
+- Modify: `src/types/game-events.ts:9-23` (GameEventType union)
+- Test: `src/lib/game-event-bus.test.ts` (or inline test)
+
+- [ ] **Step 1: Write failing test for game:prepare event**
+
+Create or add to the existing game-event-bus test file:
+
+```ts
+// src/lib/game-event-bus.test.ts (append)
+import { createGameEventBus } from './game-event-bus';
+import type { GameEvent } from '@/types/game-events';
+
+describe('game:prepare event', () => {
+  it('emits and receives game:prepare', () => {
+    const bus = createGameEventBus();
+    const received: GameEvent[] = [];
+    bus.subscribe('game:prepare', (e) => received.push(e));
+
+    const event: GameEvent = {
+      type: 'game:prepare',
+      gameId: 'word-spell',
+      sessionId: 'test',
+      profileId: 'test',
+      timestamp: Date.now(),
+      roundIndex: 0,
+    };
+    bus.emit(event);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe('game:prepare');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/game-event-bus.test.ts --reporter=verbose`
+Expected: FAIL — `'game:prepare'` is not assignable to `GameEventType`.
+
+- [ ] **Step 3: Add game:prepare to the event type union**
+
+In `src/types/game-events.ts`, add `'game:prepare'` to the `GameEventType` union (after line 10, before `'game:instructions_shown'`):
+
+```ts
+export type GameEventType =
+  | 'game:start'
+  | 'game:prepare'
+  | 'game:instructions_shown';
+// ... rest unchanged
+```
+
+Add the interface (after `GameStartEvent`):
+
+```ts
+export interface GamePrepareEvent extends BaseGameEvent {
+  type: 'game:prepare';
+}
+```
+
+Add to the `GameEvent` union type.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/game-event-bus.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/game-events.ts src/lib/game-event-bus.test.ts
+git commit -m "feat(events): add game:prepare bus event type"
+```
+
+---
+
+## Task 3: ttsEnabled → autoSpeak + ttsOnDemandAllowed
+
+This is the core flag split. Touch types first, then update `useGameTTS` and its consumers.
+
+**Files:**
+
+- Modify: `src/components/answer-game/types.ts:16-17`
+- Modify: `src/components/answer-game/useGameTTS.ts`
+- Modify: `src/components/answer-game/useGameTTS.test.tsx`
+- Modify: `src/components/answer-game/useRoundTTS.ts:11`
+- Modify: `src/components/answer-game/useRoundTTS.test.tsx`
+
+- [ ] **Step 1: Write failing test for new useGameTTS API**
+
+Update `src/components/answer-game/useGameTTS.test.tsx`:
+
+```ts
+// Add new tests for speakAuto and speakOnDemand
+describe('speakAuto', () => {
+  it('is gated by autoSpeak flag', () => {
+    // Test that speakAuto returns early when autoSpeak is false
+    // but speakOnDemand still works when ttsOnDemandAllowed is true
+  });
+});
+
+describe('speakOnDemand', () => {
+  it('is gated by ttsOnDemandAllowed flag', () => {
+    // Test that speakOnDemand returns early when ttsOnDemandAllowed is false
+    // but speakAuto still works when autoSpeak is true
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/answer-game/useGameTTS.test.tsx --reporter=verbose`
+Expected: FAIL — `speakAuto` and `speakOnDemand` don't exist yet.
+
+- [ ] **Step 3: Update AnswerGameConfig type**
+
+In `src/components/answer-game/types.ts`, replace:
+
+```ts
+/** Whether TTS is enabled for this profile */
+ttsEnabled: boolean;
+```
+
+with:
+
+```ts
+/** Gates all lifecycle auto-speech (every TTS lifecycle event). */
+autoSpeak: boolean;
+/** Gates user-initiated tap-to-speak: AudioButton, question onClick. */
+ttsOnDemandAllowed: boolean;
+```
+
+- [ ] **Step 4: Update useGameTTS**
+
+Replace the entire `src/components/answer-game/useGameTTS.ts` with:
+
+```ts
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAnswerGameContext } from './useAnswerGameContext';
+import { useSettings } from '@/db/hooks/useSettings';
+import { isSpeechActive, speak } from '@/lib/speech/SpeechOutput';
+
+export interface GameTTS {
+  speakTile: (label: string) => void;
+  speakAuto: (text: string) => void;
+  speakOnDemand: (text: string) => void;
+  /** @deprecated Use speakAuto or speakOnDemand. Removed in M2. */
+  speakPrompt: (text: string) => void;
+}
+
+export const useGameTTS = (): GameTTS => {
+  const { config } = useAnswerGameContext();
+  const { settings } = useSettings();
+  const { i18n } = useTranslation();
+
+  const speechOpts = useCallback(
+    () => ({
+      rate: settings.speechRate ?? 1,
+      volume: settings.voiceVolume ?? 0.8,
+      voiceName: settings.preferredVoiceURI,
+      lang: i18n.language,
+    }),
+    [
+      settings.speechRate,
+      settings.voiceVolume,
+      settings.preferredVoiceURI,
+      i18n.language,
+    ],
+  );
+
+  const speakTile = useCallback(
+    (label: string) => {
+      if (!config.autoSpeak) return;
+      if (isSpeechActive()) return;
+      speak(label, speechOpts());
+    },
+    [config.autoSpeak, speechOpts],
+  );
+
+  const speakAuto = useCallback(
+    (text: string) => {
+      if (!config.autoSpeak) return;
+      speak(text, speechOpts());
+    },
+    [config.autoSpeak, speechOpts],
+  );
+
+  const speakOnDemand = useCallback(
+    (text: string) => {
+      if (!config.ttsOnDemandAllowed) return;
+      speak(text, speechOpts());
+    },
+    [config.ttsOnDemandAllowed, speechOpts],
+  );
+
+  const speakPrompt = useCallback(
+    (text: string) => {
+      if (!config.autoSpeak) return;
+      speak(text, speechOpts());
+    },
+    [config.autoSpeak, speechOpts],
+  );
+
+  return { speakTile, speakAuto, speakOnDemand, speakPrompt };
+};
+```
+
+- [ ] **Step 5: Update useRoundTTS**
+
+In `src/components/answer-game/useRoundTTS.ts`, change `config.ttsEnabled` to `config.autoSpeak`:
+
+```ts
+export const useRoundTTS = (prompt: string): void => {
+  const { roundIndex, config } = useAnswerGameContext();
+  const { speakAuto } = useGameTTS();
+
+  useEffect(() => {
+    if (!config.autoSpeak) return;
+    if (!prompt) return;
+    let cancelled = false;
+    void whenSoundEnds().then(() => {
+      if (!cancelled) speakAuto(prompt);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally omit speakAuto and prompt to only re-speak on round change
+  }, [roundIndex, config.autoSpeak]);
+};
+```
+
+- [ ] **Step 6: Fix all TypeScript errors from ttsEnabled removal**
+
+Run `yarn typecheck` and fix every remaining reference to `ttsEnabled` in the codebase. Key files to update:
+
+- `src/components/questions/AudioButton/AudioButton.tsx` — change `config.ttsEnabled` to `config.ttsOnDemandAllowed`
+- `src/components/questions/TextQuestion/TextQuestion.tsx` — same pattern
+- `src/components/questions/ImageQuestion/ImageQuestion.tsx` — same pattern
+- `src/components/questions/EmojiQuestion/EmojiQuestion.tsx` — same pattern
+- `src/components/questions/DotGroupQuestion/DotGroupQuestion.tsx` — same pattern
+- `src/games/spot-all/SpotAllPrompt/SpotAllPrompt.tsx` — change `ttsEnabled` prop usage
+- `src/components/answer-game/InstructionsOverlay/InstructionsOverlay.tsx` — change `ttsEnabled` to `autoSpeak`
+- Every game component that constructs an `AnswerGameConfig` — update `ttsEnabled` to `autoSpeak` + `ttsOnDemandAllowed`
+- Every test that constructs a config with `ttsEnabled` — update to `autoSpeak` + `ttsOnDemandAllowed`
+
+Use `rg ttsEnabled src/` to find all occurrences. For each:
+
+- If it gates auto-speak → `autoSpeak`
+- If it gates on-demand button rendering/speech → `ttsOnDemandAllowed`
+- If it gates both (InstructionsOverlay prop) → pass both flags
+
+- [ ] **Step 7: Run tests**
+
+Run: `npx vitest run src/components/answer-game/ --reporter=verbose`
+Expected: PASS — all existing tests updated for new flag names.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "feat(tts): split ttsEnabled into autoSpeak + ttsOnDemandAllowed
+
+Lifecycle auto-speech gated by autoSpeak, on-demand tap gated by
+ttsOnDemandAllowed. Legacy migration: ttsEnabled:false maps to both off."
+```
+
+---
+
+## Task 4: Verbosity Resolver (Pure)
+
+**Files:**
+
+- Create: `src/lib/lifecycle-tts/resolve.ts`
+- Create: `src/lib/lifecycle-tts/resolve.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// src/lib/lifecycle-tts/resolve.test.ts
+import { describe, it, expect } from 'vitest';
+import { resolveVerbosity, resolveCopy } from './resolve';
+import type { EventTemplate, TalkativenessPreset } from './types';
+
+const template: EventTemplate = {
+  tts: {
+    brief: 'tts.test.brief',
+    full: 'tts.test.full',
+  },
+  byGradeBand: {
+    'pre-k': 'full',
+    k: 'full',
+    'year1-2': 'brief',
+    'year3-4': 'off',
+    'year5-6': 'off',
+  },
+  default: 'brief',
+};
+
+describe('resolveVerbosity', () => {
+  it('returns byGradeBand value when no overrides', () => {
+    expect(resolveVerbosity(template, 'pre-k')).toBe('full');
+    expect(resolveVerbosity(template, 'year3-4')).toBe('off');
+  });
+
+  it('per-event override takes precedence', () => {
+    expect(
+      resolveVerbosity(template, 'pre-k', { eventOverride: 'off' }),
+    ).toBe('off');
+  });
+
+  it('talkativeness preset overrides byGradeBand', () => {
+    expect(
+      resolveVerbosity(template, 'year3-4', {
+        talkativenessVerbosity: 'full',
+      }),
+    ).toBe('full');
+  });
+
+  it('per-event override takes precedence over talkativeness', () => {
+    expect(
+      resolveVerbosity(template, 'year3-4', {
+        eventOverride: 'brief',
+        talkativenessVerbosity: 'full',
+      }),
+    ).toBe('brief');
+  });
+});
+
+describe('resolveCopy', () => {
+  it('returns the i18n key for the resolved verbosity', () => {
+    expect(resolveCopy(template, 'full')).toBe('tts.test.full');
+    expect(resolveCopy(template, 'brief')).toBe('tts.test.brief');
+  });
+
+  it('returns null for off', () => {
+    expect(resolveCopy(template, 'off')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/lifecycle-tts/resolve.test.ts --reporter=verbose`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement resolver**
+
+```ts
+// src/lib/lifecycle-tts/resolve.ts
+import type { EventTemplate, Verbosity } from './types';
+import type { GradeBand } from '@/types/game-events';
+
+type ResolveOptions = {
+  eventOverride?: Verbosity;
+  talkativenessVerbosity?: Verbosity;
+};
+
+export const resolveVerbosity = (
+  template: EventTemplate,
+  gradeBand: GradeBand,
+  options?: ResolveOptions,
+): Verbosity => {
+  if (options?.eventOverride) return options.eventOverride;
+  if (options?.talkativenessVerbosity)
+    return options.talkativenessVerbosity;
+  return template.byGradeBand[gradeBand] ?? template.default;
+};
+
+export const resolveCopy = (
+  template: EventTemplate,
+  verbosity: Verbosity,
+): string | null => {
+  if (verbosity === 'off') return null;
+  return template.tts[verbosity];
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/lifecycle-tts/resolve.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/lifecycle-tts/resolve.ts src/lib/lifecycle-tts/resolve.test.ts
+git commit -m "feat(lifecycle-tts): add pure verbosity + copy resolver"
+```
+
+---
+
+## Task 5: Talkativeness Presets
+
+**Files:**
+
+- Create: `src/lib/lifecycle-tts/talkativeness-presets.ts`
+- Create: `src/lib/lifecycle-tts/talkativeness-presets.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// src/lib/lifecycle-tts/talkativeness-presets.test.ts
+import { describe, it, expect } from 'vitest';
+import { getTalkativenessProfile } from './talkativeness-presets';
+
+describe('getTalkativenessProfile', () => {
+  it('quiet at pre-k turns most events off except round.start brief', () => {
+    const profile = getTalkativenessProfile('quiet', 'pre-k');
+    expect(profile['game.start']).toBe('off');
+    expect(profile['round.start']).toBe('brief');
+  });
+
+  it('default returns undefined (fall through to registry)', () => {
+    const profile = getTalkativenessProfile('default', 'year1-2');
+    expect(profile['game.start']).toBeUndefined();
+  });
+
+  it('chatty at year3-4 upgrades to full', () => {
+    const profile = getTalkativenessProfile('chatty', 'year3-4');
+    expect(profile['game.start']).toBe('full');
+    expect(profile['round.start']).toBe('full');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/lifecycle-tts/talkativeness-presets.test.ts --reporter=verbose`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement presets**
+
+```ts
+// src/lib/lifecycle-tts/talkativeness-presets.ts
+import type { GradeBand } from '@/types/game-events';
+import type { LifecycleEvent, Verbosity } from './types';
+
+type TalkativenessProfile = Partial<Record<LifecycleEvent, Verbosity>>;
+
+const QUIET: Record<GradeBand, TalkativenessProfile> = {
+  'pre-k': {
+    'game.prepare': 'off',
+    'game.start': 'off',
+    'round.start': 'brief',
+    'round.idle': 'off',
+    'round.error': 'off',
+    'round.correct': 'off',
+    'round.celebrate': 'off',
+    'round.advance': 'off',
+    'level.complete': 'off',
+    'game.over': 'off',
+    'game.resume': 'off',
+  },
+  k: {
+    'game.prepare': 'off',
+    'game.start': 'off',
+    'round.start': 'brief',
+    'round.idle': 'off',
+    'round.error': 'off',
+    'round.correct': 'off',
+    'round.celebrate': 'off',
+    'round.advance': 'off',
+    'level.complete': 'off',
+    'game.over': 'off',
+    'game.resume': 'off',
+  },
+  'year1-2': {
+    'game.prepare': 'off',
+    'game.start': 'off',
+    'round.start': 'brief',
+    'round.idle': 'off',
+    'round.error': 'off',
+    'round.correct': 'off',
+    'round.celebrate': 'off',
+    'round.advance': 'off',
+    'level.complete': 'off',
+    'game.over': 'off',
+    'game.resume': 'off',
+  },
+  'year3-4': {
+    'game.prepare': 'off',
+    'game.start': 'off',
+    'round.start': 'off',
+    'round.idle': 'off',
+    'round.error': 'off',
+    'round.correct': 'off',
+    'round.celebrate': 'off',
+    'round.advance': 'off',
+    'level.complete': 'off',
+    'game.over': 'off',
+    'game.resume': 'off',
+  },
+  'year5-6': {
+    'game.prepare': 'off',
+    'game.start': 'off',
+    'round.start': 'off',
+    'round.idle': 'off',
+    'round.error': 'off',
+    'round.correct': 'off',
+    'round.celebrate': 'off',
+    'round.advance': 'off',
+    'level.complete': 'off',
+    'game.over': 'off',
+    'game.resume': 'off',
+  },
+};
+
+const CHATTY: Record<GradeBand, TalkativenessProfile> = {
+  'pre-k': {
+    'game.prepare': 'full',
+    'game.start': 'full',
+    'round.start': 'full',
+    'round.idle': 'full',
+    'round.error': 'full',
+    'round.correct': 'full',
+    'round.celebrate': 'full',
+    'round.advance': 'full',
+    'level.complete': 'full',
+    'game.over': 'full',
+    'game.resume': 'full',
+  },
+  k: {
+    'game.prepare': 'full',
+    'game.start': 'full',
+    'round.start': 'full',
+    'round.idle': 'full',
+    'round.error': 'full',
+    'round.correct': 'full',
+    'round.celebrate': 'full',
+    'round.advance': 'full',
+    'level.complete': 'full',
+    'game.over': 'full',
+    'game.resume': 'full',
+  },
+  'year1-2': {
+    'game.prepare': 'full',
+    'game.start': 'full',
+    'round.start': 'full',
+    'round.idle': 'full',
+    'round.error': 'full',
+    'round.correct': 'full',
+    'round.celebrate': 'full',
+    'round.advance': 'full',
+    'level.complete': 'full',
+    'game.over': 'full',
+    'game.resume': 'full',
+  },
+  'year3-4': {
+    'game.prepare': 'full',
+    'game.start': 'full',
+    'round.start': 'full',
+    'round.idle': 'brief',
+    'round.error': 'full',
+    'round.correct': 'brief',
+    'round.celebrate': 'brief',
+    'round.advance': 'full',
+    'level.complete': 'full',
+    'game.over': 'full',
+    'game.resume': 'full',
+  },
+  'year5-6': {
+    'game.prepare': 'brief',
+    'game.start': 'full',
+    'round.start': 'full',
+    'round.idle': 'off',
+    'round.error': 'brief',
+    'round.correct': 'off',
+    'round.celebrate': 'off',
+    'round.advance': 'brief',
+    'level.complete': 'brief',
+    'game.over': 'brief',
+    'game.resume': 'full',
+  },
+};
+
+export const getTalkativenessProfile = (
+  preset: 'quiet' | 'default' | 'chatty',
+  gradeBand: GradeBand,
+): TalkativenessProfile => {
+  if (preset === 'quiet') return QUIET[gradeBand];
+  if (preset === 'chatty') return CHATTY[gradeBand];
+  return {};
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/lifecycle-tts/talkativeness-presets.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/lifecycle-tts/talkativeness-presets.ts src/lib/lifecycle-tts/talkativeness-presets.test.ts
+git commit -m "feat(lifecycle-tts): add Quiet/Default/Chatty talkativeness presets"
+```
+
+---
+
+## Task 6: Per-Game Registry (WordSpell + NumberMatch)
+
+**Files:**
+
+- Create: `src/lib/lifecycle-tts/registry/word-spell.ts`
+- Create: `src/lib/lifecycle-tts/registry/number-match.ts`
+- Create: `src/lib/lifecycle-tts/registry/index.ts`
+
+- [ ] **Step 1: Write failing test for registry lookup**
+
+```ts
+// src/lib/lifecycle-tts/resolve.test.ts (append)
+import { getRegistry } from './registry';
+
+describe('getRegistry', () => {
+  it('returns word-spell registry entry', () => {
+    const entry = getRegistry('word-spell');
+    expect(entry).toBeDefined();
+    expect(entry!.events['game.start'].tts.full).toBe(
+      'tts.word-spell.game-start.full',
+    );
+  });
+
+  it('returns number-match registry entry', () => {
+    const entry = getRegistry('number-match');
+    expect(entry).toBeDefined();
+    expect(entry!.events['round.start'].tts.full).toBe(
+      'tts.number-match.round-start.full',
+    );
+  });
+
+  it('returns undefined for unknown gameId', () => {
+    expect(getRegistry('nonexistent')).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/lifecycle-tts/resolve.test.ts --reporter=verbose`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create word-spell registry entry**
+
+Create `src/lib/lifecycle-tts/registry/word-spell.ts` following the exact structure from Spec 1a §6.2. Every event gets `tts.brief` and `tts.full` i18n keys in the pattern `tts.word-spell.<event-kebab>.<mode>`, and `byGradeBand` defaults per spec.
+
+- [ ] **Step 4: Create number-match registry entry**
+
+Create `src/lib/lifecycle-tts/registry/number-match.ts` — key entry is `round.start` which uses `"Find the matching number for {{count}}."` instead of bare numeral. This fixes the speak-the-answer bug.
+
+- [ ] **Step 5: Create registry index**
+
+```ts
+// src/lib/lifecycle-tts/registry/index.ts
+import type {
+  GameLifecycleRegistry,
+  GameLifecycleRegistryEntry,
+} from '../types';
+import { wordSpellRegistry } from './word-spell';
+import { numberMatchRegistry } from './number-match';
+
+const registry: GameLifecycleRegistry = {
+  'word-spell': wordSpellRegistry,
+  'number-match': numberMatchRegistry,
+};
+
+export const getRegistry = (
+  gameId: string,
+): GameLifecycleRegistryEntry | undefined => registry[gameId];
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/lifecycle-tts/resolve.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/lifecycle-tts/registry/
+git commit -m "feat(lifecycle-tts): add WordSpell + NumberMatch registry entries
+
+NumberMatch round-start uses instructional template instead of bare numeral,
+fixing the speak-the-answer bug (#229)."
+```
+
+---
+
+## Task 7: i18n Keys
+
+**Files:**
+
+- Modify: `src/lib/i18n/locales/en/games.json`
+- Modify: `src/lib/i18n/locales/pt-BR/games.json`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// src/lib/lifecycle-tts/resolve.test.ts (append)
+import i18n from '@/lib/i18n/i18n';
+
+describe('i18n keys', () => {
+  it('resolves word-spell round-start full key', () => {
+    const result = i18n.t('games:tts.word-spell.round-start.full', {
+      word: 'cat',
+    });
+    expect(result).toBe('Spell the word cat.');
+  });
+
+  it('resolves number-match round-start full key', () => {
+    const result = i18n.t('games:tts.number-match.round-start.full', {
+      count: 'five',
+    });
+    expect(result).toBe('Find the matching number for five.');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/lifecycle-tts/resolve.test.ts --reporter=verbose`
+Expected: FAIL — missing i18n keys.
+
+- [ ] **Step 3: Add i18n keys to en/games.json**
+
+Add a top-level `"tts"` key to `src/lib/i18n/locales/en/games.json` with keys per Spec 1a §10. At minimum for M1:
+
+- `tts.word-spell.*` (all events)
+- `tts.number-match.round-start.*` (fixes speak-the-answer)
+- `tts.number-match.game-prepare.*` (panel mount)
+- `tts.number-match.game-start.*` (Let's go speech)
+
+- [ ] **Step 4: Add placeholder keys to pt-BR/games.json**
+
+Copy the same English strings as placeholders pending translation.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/lifecycle-tts/resolve.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/i18n/locales/en/games.json src/lib/i18n/locales/pt-BR/games.json
+git commit -m "feat(i18n): add tts.word-spell and tts.number-match i18n keys"
+```
+
+---
+
+## Task 8: useLifecycleTTS Hook
+
+**Files:**
+
+- Create: `src/lib/lifecycle-tts/useLifecycleTTS.ts`
+- Create: `src/lib/lifecycle-tts/useLifecycleTTS.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// src/lib/lifecycle-tts/useLifecycleTTS.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useLifecycleTTS } from './useLifecycleTTS';
+// Test with mock AnswerGameContext, GameEventBus, and i18n
+
+describe('useLifecycleTTS', () => {
+  it('speakOnDemand speaks full copy for the event', () => {
+    // Render hook with ttsOnDemandAllowed: true, gameId: 'word-spell'
+    // Call speakOnDemand('round.start')
+    // Assert speak() called with resolved full i18n string
+  });
+
+  it('speakOnDemand is silent when ttsOnDemandAllowed is false', () => {
+    // Render hook with ttsOnDemandAllowed: false
+    // Call speakOnDemand('round.start')
+    // Assert speak() NOT called
+  });
+
+  it('speakAuto is gated by autoSpeak ref', () => {
+    // Render hook with autoSpeak: false
+    // Call speakAuto('game.start')
+    // Assert speak() NOT called
+  });
+
+  it('resolves interpolation from AnswerGameContext', () => {
+    // Render hook with round context containing word: 'cat'
+    // Call speakOnDemand('round.start')
+    // Assert speak() called with "Spell the word cat."
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/lifecycle-tts/useLifecycleTTS.test.tsx --reporter=verbose`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement useLifecycleTTS**
+
+```ts
+// src/lib/lifecycle-tts/useLifecycleTTS.ts
+import { useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAnswerGameContext } from '@/components/answer-game/useAnswerGameContext';
+import { useSettings } from '@/db/hooks/useSettings';
+import { speak } from '@/lib/speech/SpeechOutput';
+import { getRegistry } from './registry';
+import { resolveCopy, resolveVerbosity } from './resolve';
+import { getTalkativenessProfile } from './talkativeness-presets';
+import type { LifecycleEvent, Verbosity } from './types';
+import type { GradeBand } from '@/types/game-events';
+
+type SpeakOptions = { mode?: 'brief' | 'full' };
+
+type UseLifecycleTTSReturn = {
+  speakAuto: (event: LifecycleEvent) => void;
+  speakOnDemand: (
+    event: LifecycleEvent,
+    options?: SpeakOptions,
+  ) => void;
+  ttsOnDemandAllowed: boolean;
+};
+
+export const useLifecycleTTS = (): UseLifecycleTTSReturn => {
+  const { config } = useAnswerGameContext();
+  const { settings } = useSettings();
+  const { t, i18n } = useTranslation('games');
+
+  const autoSpeakRef = useRef(config.autoSpeak);
+  autoSpeakRef.current = config.autoSpeak;
+
+  const onDemandRef = useRef(config.ttsOnDemandAllowed);
+  onDemandRef.current = config.ttsOnDemandAllowed;
+
+  const doSpeak = useCallback(
+    (i18nKey: string, interpolation: Record<string, unknown>) => {
+      const text = t(i18nKey, interpolation);
+      if (!text || text === i18nKey) return;
+      speak(text, {
+        rate: settings.speechRate ?? 1,
+        volume: settings.voiceVolume ?? 0.8,
+        voiceName: settings.preferredVoiceURI,
+        lang: i18n.language,
+      });
+    },
+    [
+      t,
+      settings.speechRate,
+      settings.voiceVolume,
+      settings.preferredVoiceURI,
+      i18n.language,
+    ],
+  );
+
+  const resolveAndSpeak = useCallback(
+    (event: LifecycleEvent, forcedVerbosity?: Verbosity) => {
+      const entry = getRegistry(config.gameId);
+      if (!entry) return;
+      const template = entry.events[event];
+      if (!template) return;
+
+      const gradeBand: GradeBand =
+        ((config as Record<string, unknown>).gradeBand as GradeBand) ??
+        'k';
+      const talkativeness =
+        ((config as Record<string, unknown>).talkativeness as string) ??
+        'default';
+      const talkProfile = getTalkativenessProfile(
+        talkativeness as 'quiet' | 'default' | 'chatty',
+        gradeBand,
+      );
+      const eventOverride = (
+        (config as Record<string, unknown>).events as
+          | Record<string, Verbosity>
+          | undefined
+      )?.[event];
+
+      const verbosity =
+        forcedVerbosity ??
+        resolveVerbosity(template, gradeBand, {
+          eventOverride,
+          talkativenessVerbosity: talkProfile[event],
+        });
+
+      const i18nKey = resolveCopy(template, verbosity);
+      if (!i18nKey) return;
+
+      const interpolation = buildInterpolation(config);
+      doSpeak(i18nKey, interpolation);
+    },
+    [config, doSpeak],
+  );
+
+  const speakAuto = useCallback(
+    (event: LifecycleEvent) => {
+      if (!autoSpeakRef.current) return;
+      resolveAndSpeak(event);
+    },
+    [resolveAndSpeak],
+  );
+
+  const speakOnDemand = useCallback(
+    (event: LifecycleEvent, options?: SpeakOptions) => {
+      if (!onDemandRef.current) return;
+      resolveAndSpeak(event, options?.mode ?? 'full');
+    },
+    [resolveAndSpeak],
+  );
+
+  return {
+    speakAuto,
+    speakOnDemand,
+    ttsOnDemandAllowed: config.ttsOnDemandAllowed,
+  };
+};
+
+const buildInterpolation = (
+  config: Record<string, unknown>,
+): Record<string, unknown> => ({
+  gameName: config.gameTitle ?? config.gameId ?? '',
+  word: (config as Record<string, unknown>).currentWord ?? '',
+  count: (config as Record<string, unknown>).currentCount ?? '',
+});
+```
+
+**Note to implementer:** The `buildInterpolation` function accesses game-specific context. The exact shape depends on how each game threads round data through context. Check how `useAnswerGameContext()` exposes round-level data and adjust accordingly. The hook reads `autoSpeak` / `ttsOnDemandAllowed` via refs so mid-round toggles take effect immediately without remount.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/lifecycle-tts/useLifecycleTTS.test.tsx --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/lifecycle-tts/useLifecycleTTS.ts src/lib/lifecycle-tts/useLifecycleTTS.test.tsx
+git commit -m "feat(lifecycle-tts): add useLifecycleTTS hook with auto/on-demand gates"
+```
+
+---
+
+## Task 9: Rename InstructionsOverlay → GameOptionsOverlay
+
+**Files:**
+
+- Rename: `src/components/answer-game/InstructionsOverlay/` → `src/components/answer-game/GameOptions/`
+- Rename: `InstructionsOverlay.tsx` → `GameOptionsOverlay.tsx` (plus .test.tsx, .stories.tsx)
+- Modify: every file that imports `InstructionsOverlay`
+
+- [ ] **Step 1: Identify all imports**
+
+Run: `rg -l 'InstructionsOverlay' src/`
+
+Expected files to update:
+
+- `src/routes/$locale/_app/game/$gameId.tsx`
+- `src/components/AdvancedConfigModal.tsx` (imports `Draft` type)
+- `src/components/AdvancedConfigModal.test.tsx`
+- Plus any e2e/VR test files
+
+- [ ] **Step 2: Rename directory and files using git mv**
+
+```bash
+git mv src/components/answer-game/InstructionsOverlay src/components/answer-game/GameOptions
+git mv src/components/answer-game/GameOptions/InstructionsOverlay.tsx src/components/answer-game/GameOptions/GameOptionsOverlay.tsx
+git mv src/components/answer-game/GameOptions/InstructionsOverlay.test.tsx src/components/answer-game/GameOptions/GameOptionsOverlay.test.tsx
+git mv src/components/answer-game/GameOptions/InstructionsOverlay.stories.tsx src/components/answer-game/GameOptions/GameOptionsOverlay.stories.tsx
+```
+
+- [ ] **Step 3: Update all internal references**
+
+Inside `GameOptionsOverlay.tsx`: rename the component export from `InstructionsOverlay` to `GameOptionsOverlay`. Update the Storybook title to `'AnswerGame/GameOptions/GameOptionsOverlay'` (PascalCase per CLAUDE.md).
+
+Update every importing file found in step 1. Key change in `$gameId.tsx`:
+
+```ts
+// Before
+import { InstructionsOverlay } from '@/components/answer-game/InstructionsOverlay/InstructionsOverlay';
+// After
+import { GameOptionsOverlay } from '@/components/answer-game/GameOptions/GameOptionsOverlay';
+```
+
+Also update `SaveCustomGameInput` type import if re-exported.
+
+- [ ] **Step 4: Run typecheck + tests**
+
+Run: `yarn typecheck && npx vitest run src/components/answer-game/GameOptions/ --reporter=verbose`
+Expected: PASS — all renamed tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: rename InstructionsOverlay → GameOptionsOverlay
+
+Component, directory, tests, and stories all renamed. All imports updated.
+Storybook title: AnswerGame/GameOptions/GameOptionsOverlay."
+```
+
+---
+
+## Task 10: GameOptionsOverlay Behavior — No Auto-Speak + game:prepare
+
+**Files:**
+
+- Modify: `src/components/answer-game/GameOptions/GameOptionsOverlay.tsx:173-179`
+- Modify: `src/components/answer-game/GameOptions/GameOptionsOverlay.test.tsx`
+
+- [ ] **Step 1: Write failing test — no auto-speak on mount**
+
+```ts
+// In GameOptionsOverlay.test.tsx, add:
+it('does not auto-speak instructions on mount', () => {
+  // Render GameOptionsOverlay with autoSpeak: true
+  // Assert speak() was NOT called
+});
+
+it('emits game:prepare on mount', () => {
+  // Render GameOptionsOverlay
+  // Assert getGameEventBus().emit was called with type: 'game:prepare'
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/answer-game/GameOptions/GameOptionsOverlay.test.tsx --reporter=verbose`
+Expected: FAIL — still auto-speaks on mount.
+
+- [ ] **Step 3: Remove auto-speak useEffect, add game:prepare**
+
+In `GameOptionsOverlay.tsx`, remove the useEffect at lines 173-179 that calls `speak(text)`. Replace with a `game:prepare` emission:
+
+```ts
+useEffect(() => {
+  getGameEventBus().emit({
+    type: 'game:prepare',
+    gameId,
+    sessionId: '',
+    profileId: '',
+    timestamp: Date.now(),
+    roundIndex: 0,
+  });
+  return () => {
+    cancelSpeech();
+  };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- emit once on mount
+}, []);
+```
+
+The `useLifecycleTTS` hook in the parent game component will subscribe to `game:prepare` and speak the brief `"{{gameName}}"` copy.
+
+- [ ] **Step 4: Add game.start speech after "Let's go"**
+
+In the `onStart` callback path (the "Let's go" button handler), add:
+
+```ts
+// After existing onStart() call:
+lifecycleTTS.speakAuto('game.start');
+```
+
+This speaks the full how-to-play copy when the user taps "Let's go". The exact wiring depends on how `onStart` flows through to the game component — the game component's `useLifecycleTTS` call handles the speech.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/components/answer-game/GameOptions/GameOptionsOverlay.test.tsx --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/answer-game/GameOptions/
+git commit -m "feat(GameOptions): remove auto-speak, emit game:prepare on mount
+
+Pre-game panel no longer speaks how-to-play instructions on mount.
+game:prepare event emitted for lifecycle TTS to speak brief game name.
+game.start speech triggered after Let's go button."
+```
+
+---
+
+## Task 11: QuestionRow Component
+
+**Files:**
+
+- Create: `src/components/questions/QuestionRow/QuestionRow.tsx`
+- Create: `src/components/questions/QuestionRow/QuestionRow.test.tsx`
+- Modify: `src/components/questions/index.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// src/components/questions/QuestionRow/QuestionRow.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QuestionRow } from './QuestionRow';
+
+describe('QuestionRow', () => {
+  it('renders audio button and content inline', () => {
+    render(
+      <QuestionRow audioSlot={<button>audio</button>}>
+        <span>content</span>
+      </QuestionRow>,
+    );
+    expect(screen.getByText('audio')).toBeInTheDocument();
+    expect(screen.getByText('content')).toBeInTheDocument();
+  });
+
+  it('renders without audio slot', () => {
+    render(
+      <QuestionRow>
+        <span>content only</span>
+      </QuestionRow>,
+    );
+    expect(screen.getByText('content only')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/questions/QuestionRow/QuestionRow.test.tsx --reporter=verbose`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement QuestionRow**
+
+```tsx
+// src/components/questions/QuestionRow/QuestionRow.tsx
+import type { ReactNode } from 'react';
+
+interface QuestionRowProps {
+  audioSlot?: ReactNode;
+  children: ReactNode;
+}
+
+export const QuestionRow = ({
+  audioSlot,
+  children,
+}: QuestionRowProps) => (
+  <div className="flex items-center justify-center gap-3">
+    {audioSlot}
+    <div className="min-w-0 flex-1">{children}</div>
+  </div>
+);
+```
+
+- [ ] **Step 4: Add to questions index**
+
+In `src/components/questions/index.ts`, add:
+
+```ts
+export { QuestionRow } from './QuestionRow/QuestionRow';
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/components/questions/QuestionRow/QuestionRow.test.tsx --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/questions/QuestionRow/ src/components/questions/index.ts
+git commit -m "feat(QuestionRow): add inline AudioButton + content layout component"
+```
+
+---
+
+## Task 12: AudioButton Refactor
+
+**Files:**
+
+- Modify: `src/components/questions/AudioButton/AudioButton.tsx`
+- Modify: `src/components/questions/AudioButton/AudioButton.test.tsx`
+- Modify: `src/components/questions/AudioButton/AudioButton.stories.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// AudioButton.test.tsx — update existing tests
+it('renders when ttsOnDemandAllowed is true', () => {
+  // Render with ttsOnDemandAllowed: true
+  // Assert button is in the document
+});
+
+it('returns null when ttsOnDemandAllowed is false', () => {
+  // Render with ttsOnDemandAllowed: false
+  // Assert button is NOT in the document
+});
+
+it('calls speakOnDemand with full mode on click', () => {
+  // Click button
+  // Assert speakOnDemand called with ('round.start', { mode: 'full' })
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/questions/AudioButton/AudioButton.test.tsx --reporter=verbose`
+Expected: FAIL — old API.
+
+- [ ] **Step 3: Refactor AudioButton**
+
+```tsx
+// src/components/questions/AudioButton/AudioButton.tsx
+import { Volume2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useLifecycleTTS } from '@/lib/lifecycle-tts/useLifecycleTTS';
+import type { LifecycleEvent } from '@/lib/lifecycle-tts/types';
+
+interface AudioButtonProps {
+  event?: LifecycleEvent;
+}
+
+export const AudioButton = ({
+  event = 'round.start',
+}: AudioButtonProps) => {
+  const { speakOnDemand, ttsOnDemandAllowed } = useLifecycleTTS();
+  const { t } = useTranslation('common');
+
+  if (!ttsOnDemandAllowed) return null;
+
+  return (
+    <button
+      type="button"
+      aria-label={t('audio.replay', {
+        defaultValue: 'Hear the question',
+      })}
+      className="flex size-14 shrink-0 items-center justify-center rounded-full shadow-md active:scale-95"
+      style={{
+        background: 'var(--skin-question-audio-bg)',
+        color: 'var(--skin-question-audio-fg)',
+      }}
+      onClick={() => speakOnDemand(event, { mode: 'full' })}
+    >
+      <Volume2 size={24} aria-hidden="true" />
+    </button>
+  );
+};
+```
+
+- [ ] **Step 4: Update stories**
+
+Update `AudioButton.stories.tsx`: title `'Questions/AudioButton'` (PascalCase). Add `event` control. Load `write-storybook` skill for conventions.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/components/questions/AudioButton/AudioButton.test.tsx --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/questions/AudioButton/
+git commit -m "refactor(AudioButton): switch to lifecycle event prop, gate by ttsOnDemandAllowed
+
+AudioButton no longer takes a prompt string. It calls speakOnDemand(event, { mode: 'full' })
+from useLifecycleTTS. Renders only when ttsOnDemandAllowed is true."
+```
+
+---
+
+## Task 13: Question Components — Honor ttsOnDemandAllowed
+
+**Files:**
+
+- Modify: `src/components/questions/TextQuestion/TextQuestion.tsx`
+- Modify: `src/components/questions/ImageQuestion/ImageQuestion.tsx`
+- Modify: `src/components/questions/EmojiQuestion/EmojiQuestion.tsx`
+- Modify: `src/components/questions/DotGroupQuestion/DotGroupQuestion.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+For each question component, add a test:
+
+```ts
+it('does not speak on click when ttsOnDemandAllowed is false', () => {
+  // Render with ttsOnDemandAllowed: false
+  // Click the question element
+  // Assert speak() NOT called
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/questions/ --reporter=verbose`
+Expected: FAIL — components still call speakPrompt (which checks autoSpeak, not ttsOnDemandAllowed).
+
+- [ ] **Step 3: Update each component**
+
+In each component, change `speakPrompt` to `speakOnDemand`:
+
+```ts
+// TextQuestion.tsx
+const { speakOnDemand } = useGameTTS();
+// ...
+onClick={() => speakOnDemand(text)}
+```
+
+Repeat for ImageQuestion, EmojiQuestion, DotGroupQuestion.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run src/components/questions/ --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/questions/
+git commit -m "feat(questions): route onClick speech through speakOnDemand
+
+All four question components now honor ttsOnDemandAllowed instead of autoSpeak
+for user-initiated tap-to-speak interactions."
+```
+
+---
+
+## Task 14: Game Integration — WordSpell + NumberMatch + SortNumbers
+
+**Files:**
+
+- Modify: `src/games/word-spell/WordSpell/WordSpell.tsx`
+- Modify: `src/games/number-match/NumberMatch/NumberMatch.tsx`
+- Modify: `src/games/sort-numbers/SortNumbers/SortNumbers.tsx`
+
+- [ ] **Step 1: Update WordSpell to use QuestionRow**
+
+In `WordSpell.tsx`, wrap the question display area with `<QuestionRow>`:
+
+```tsx
+<QuestionRow audioSlot={<AudioButton event="round.start" />}>
+  {/* existing question component rendering */}
+</QuestionRow>
+```
+
+Remove the separate AudioButton rendering that currently sits alongside the question.
+
+- [ ] **Step 2: Update NumberMatch to use QuestionRow**
+
+Same pattern. The registry-backed instructional copy replaces the bare numeral speech.
+
+- [ ] **Step 3: Add AudioButton to SortNumbers**
+
+SortNumbers currently has no AudioButton. Add:
+
+```tsx
+<QuestionRow audioSlot={<AudioButton event="round.start" />}>
+  {/* existing direction label display */}
+</QuestionRow>
+```
+
+- [ ] **Step 4: Run all game tests**
+
+Run: `npx vitest run src/games/ --reporter=verbose`
+Expected: PASS — all game tests pass with updated components.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/games/
+git commit -m "feat(games): adopt QuestionRow layout in WordSpell, NumberMatch, SortNumbers
+
+SortNumbers gains AudioButton for the first time. All three games use
+consistent inline AudioButton + question content layout."
+```
+
+---
+
+## Task 15: SpotAllPrompt Consolidation
+
+**Files:**
+
+- Modify: `src/games/spot-all/SpotAllPrompt/SpotAllPrompt.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+it('uses useLifecycleTTS instead of local speak()', () => {
+  // Render SpotAllPrompt with ttsOnDemandAllowed: true
+  // Click audio button
+  // Assert speakOnDemand called (not direct speak())
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — still uses local `speakPrompt` function.
+
+- [ ] **Step 3: Consolidate into useLifecycleTTS**
+
+Replace the local `speakPrompt` function and direct `speak()` call with `useLifecycleTTS`:
+
+```tsx
+export const SpotAllPrompt = ({
+  target,
+}: {
+  target: string;
+}): JSX.Element => {
+  const { t } = useTranslation('games');
+  const { speakOnDemand, ttsOnDemandAllowed } = useLifecycleTTS();
+  const prompt = t('spot-all-ui.prompt', { target });
+
+  return (
+    <div className="flex items-center justify-center gap-3">
+      <p className="text-center text-2xl font-semibold text-foreground">
+        {prompt}
+      </p>
+      {ttsOnDemandAllowed && (
+        <button
+          type="button"
+          aria-label={t('spot-all-ui.speak-prompt')}
+          className="flex size-10 shrink-0 items-center justify-center rounded-full shadow-md active:scale-95"
+          style={{
+            background: 'var(--skin-question-audio-bg)',
+            color: 'var(--skin-question-audio-fg)',
+          }}
+          onClick={() => speakOnDemand('round.start', { mode: 'full' })}
+        >
+          <Volume2 size={20} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+};
+```
+
+Remove the `ttsEnabled` prop — the hook reads flags from context. Remove the auto-speak useEffect (lifecycle TTS handles that). Remove direct `speak()` and `useSettings()` imports.
+
+**Note:** The parent `SpotAll` component that passes `ttsEnabled` to SpotAllPrompt must be updated to stop passing it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/games/spot-all/ --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/games/spot-all/
+git commit -m "refactor(SpotAll): consolidate SpotAllPrompt speech into useLifecycleTTS
+
+Remove local speakPrompt function and ttsEnabled prop. SpotAllPrompt now
+uses the shared lifecycle TTS API for on-demand speech."
+```
+
+---
+
+## Task 16: Talkativeness in AdvancedConfigModal
+
+**Files:**
+
+- Modify: `src/components/AdvancedConfigModal.tsx`
+- Modify: `src/components/AdvancedConfigModal.test.tsx`
+- Modify: `src/lib/i18n/locales/en/games.json` (add form labels)
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+it('renders Voice & Instructions section with talkativeness preset', () => {
+  // Render AdvancedConfigModal
+  // Assert "Voice & Instructions" heading exists
+  // Assert three radio buttons: Quiet, Default, Chatty
+});
+
+it('persists talkativeness selection to config draft', () => {
+  // Select "Chatty"
+  // Assert onChange called with { talkativeness: 'chatty' }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/AdvancedConfigModal.test.tsx --reporter=verbose`
+Expected: FAIL — no "Voice & Instructions" section.
+
+- [ ] **Step 3: Add Talkativeness section**
+
+In `AdvancedConfigModal.tsx`, add a new section before the ConfigFormFields section:
+
+```tsx
+{
+  /* Voice & Instructions */
+}
+<div className="space-y-2">
+  <h4 className="text-sm font-medium">
+    {t('instructions.voiceAndInstructions.title')}
+  </h4>
+  <div className="flex gap-4">
+    {(['quiet', 'default', 'chatty'] as const).map((preset) => (
+      <label key={preset} className="flex items-center gap-1.5">
+        <input
+          type="radio"
+          name="talkativeness"
+          value={preset}
+          checked={(value.talkativeness ?? 'default') === preset}
+          onChange={() => onChange({ talkativeness: preset })}
+        />
+        <span className="text-sm capitalize">
+          {t(`instructions.voiceAndInstructions.${preset}`)}
+        </span>
+      </label>
+    ))}
+  </div>
+</div>;
+```
+
+Add i18n keys:
+
+```json
+"instructions": {
+  "voiceAndInstructions": {
+    "title": "Voice & Instructions",
+    "quiet": "Quiet",
+    "default": "Default",
+    "chatty": "Chatty"
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/AdvancedConfigModal.test.tsx --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/AdvancedConfigModal.tsx src/components/AdvancedConfigModal.test.tsx src/lib/i18n/locales/
+git commit -m "feat(config): add Talkativeness preset (Quiet/Default/Chatty) to AdvancedConfigModal"
+```
+
+---
+
+## Task 17: ARIA Live Regions
+
+**Files:**
+
+- Modify: `src/components/answer-game/AnswerGameProvider.tsx` or the AnswerGame container component
+- Test: accessibility test
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+it('announces round outcome via ARIA live region regardless of TTS setting', () => {
+  // Render AnswerGame with autoSpeak: false
+  // Complete a round (correct answer)
+  // Assert aria-live="polite" element contains outcome text
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — no ARIA live region exists.
+
+- [ ] **Step 3: Add ARIA live region**
+
+Add a visually hidden `<div aria-live="polite">` that announces round outcomes (e.g. "Correct!", "Try again") based on phase transitions. This element renders text independently of the TTS layer — it always runs.
+
+```tsx
+<div role="status" aria-live="polite" className="sr-only">
+  {ariaAnnouncement}
+</div>
+```
+
+The `ariaAnnouncement` state updates when `phase` transitions to `'round-complete'` or on wrong placement.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/answer-game/ --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/answer-game/
+git commit -m "feat(a11y): add ARIA live region for round outcomes independent of TTS"
+```
+
+---
+
+## Task 18: Final Integration + Smoke Test
+
+- [ ] **Step 1: Run full typecheck**
+
+Run: `yarn typecheck`
+Expected: PASS — zero errors.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npx vitest run --reporter=verbose`
+Expected: PASS — all tests pass.
+
+- [ ] **Step 3: Run lint**
+
+Run: `yarn fix:md && yarn lint`
+Expected: PASS
+
+- [ ] **Step 4: Start dev server and manually verify**
+
+Run: `yarn dev`
+
+Verify:
+
+- Game Options panel does NOT auto-speak on mount
+- "Let's go" triggers full how-to-play speech
+- AudioButton appears on all four games (including SortNumbers)
+- Tapping AudioButton speaks full instructional text
+- NumberMatch says "Find the matching number for five" (not just "5")
+- Quiet/Default/Chatty preset works in Advanced Config
+- Setting autoSpeak: false silences auto-speech but AudioButton still works
+- Setting ttsOnDemandAllowed: false hides AudioButton
+
+- [ ] **Step 5: Commit any remaining fixes**
+
+```bash
+git add -A
+git commit -m "chore: final integration fixes for Spec 1a M1"
+```

--- a/docs/superpowers/plans/2026-05-06-use-game-round-extraction.md
+++ b/docs/superpowers/plans/2026-05-06-use-game-round-extraction.md
@@ -1,0 +1,1364 @@
+# useGameRound Extraction + Tap-Select Slot — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the duplicated round lifecycle from WordSpell, NumberMatch, and SortNumbers into a shared `useGameRound` hook; add 6 `round:*` events to the GameEventBus; add tap-select mode to the Slot component.
+
+**Architecture:** `useGameRound` lives in `src/lib/game-engine/` alongside existing engine code. It owns round index, phase, and timing — it dispatches `ADVANCE_ROUND` / `COMPLETE_GAME` into `answerGameReducer` and emits `round:*` events on the `GameEventBus`. The reducer gains `firstActionAt` tracking and `round:mistake` / `round:first-action` emission. A new `SELECT_SLOT` action + `selectedSlotIds` state supports tap-select mode for SpotAll v2.
+
+**Tech Stack:** React 18, TypeScript, Vitest, existing GameEventBus, existing answerGameReducer
+
+**Spec:** `docs/superpowers/specs/2026-05-03-use-game-round-design.md`
+
+**Spec Deltas:** None — plan follows spec exactly.
+
+**Required skills for executors:**
+
+- `update-architecture-docs` — for `.mdx` files under `src/lib/game-engine/`
+- Markdown Authoring rules from CLAUDE.md — for this plan file
+
+---
+
+## File Structure
+
+### New files
+
+```text
+src/lib/game-engine/
+├── useGameRound.ts               # Hook: round lifecycle, event emission
+├── useGameRound.test.ts          # Hook unit tests
+└── useVisibilityTracking.ts      # Visibility change listener + event emission
+```
+
+### Modified files
+
+| File                                                 | Change                                                                   |
+| ---------------------------------------------------- | ------------------------------------------------------------------------ |
+| `src/types/game-events.ts`                           | Add 6 `round:*` event types + payload interfaces                         |
+| `src/lib/game-event-bus.ts`                          | Support `round:*` wildcard subscription                                  |
+| `src/components/answer-game/answer-game-reducer.ts`  | Add `firstActionAt`, `round:first-action` + `round:mistake` emission     |
+| `src/components/answer-game/types.ts`                | Add `SELECT_SLOT` action, `selectedSlotIds` state, `firstActionAt` field |
+| `src/components/answer-game/Slot/Slot.tsx`           | Add `interactionMode` prop                                               |
+| `src/components/answer-game/Slot/useSlotBehavior.ts` | Tap-select click handling                                                |
+| `src/games/word-spell/WordSpell/WordSpell.tsx`       | Migrate to `useGameRound`                                                |
+| `src/games/number-match/NumberMatch/NumberMatch.tsx` | Migrate to `useGameRound`                                                |
+| `src/games/sort-numbers/SortNumbers/SortNumbers.tsx` | Migrate to `useGameRound`                                                |
+| `src/lib/game-engine/GameEngine.reference.mdx`       | Document useGameRound API                                                |
+| `src/lib/game-engine/GameEngine.flows.mdx`           | Document round lifecycle flow                                            |
+
+---
+
+## Task 1: round:\* Event Types
+
+**Files:**
+
+- Modify: `src/types/game-events.ts`
+- Test: `src/types/game-events.test.ts` (new — type-level + bus integration)
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// src/types/game-events.test.ts
+import { describe, it, expect } from 'vitest';
+import { createGameEventBus } from '@/lib/game-event-bus';
+import type { GameEvent } from './game-events';
+
+describe('round:* event types', () => {
+  const events: GameEvent['type'][] = [
+    'round:shown',
+    'round:first-action',
+    'round:mistake',
+    'round:tts-played',
+    'round:visibility-change',
+    'round:resolved',
+  ];
+
+  it.each(events)('%s is a valid event type', (type) => {
+    const bus = createGameEventBus();
+    const received: GameEvent[] = [];
+    bus.subscribe(type, (e) => received.push(e));
+
+    bus.emit({
+      type,
+      gameId: 'test',
+      sessionId: 'test',
+      profileId: 'test',
+      timestamp: Date.now(),
+      roundIndex: 0,
+    } as GameEvent);
+
+    expect(received).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/types/game-events.test.ts --reporter=verbose`
+Expected: FAIL — `round:*` types not in `GameEventType` union.
+
+- [ ] **Step 3: Add round:\* event types to GameEventType**
+
+In `src/types/game-events.ts`, extend the `GameEventType` union:
+
+```ts
+export type GameEventType =
+  | 'game:start'
+  | 'game:prepare'
+  | 'game:instructions_shown'
+  | 'game:action'
+  | 'game:evaluate'
+  | 'game:score'
+  | 'game:hint'
+  | 'game:retry'
+  | 'game:time_up'
+  | 'game:end'
+  | 'game:round-advance'
+  | 'game:level-advance'
+  | 'game:drag-start'
+  | 'game:drag-over-zone'
+  | 'game:tile-ejected'
+  | 'round:shown'
+  | 'round:first-action'
+  | 'round:mistake'
+  | 'round:tts-played'
+  | 'round:visibility-change'
+  | 'round:resolved';
+```
+
+Add payload interfaces:
+
+```ts
+export interface RoundShownEvent extends BaseGameEvent {
+  type: 'round:shown';
+  roundId: string;
+  itemId: string;
+}
+
+export interface RoundFirstActionEvent extends BaseGameEvent {
+  type: 'round:first-action';
+  roundId: string;
+  kind: 'tile' | 'key' | 'tap';
+}
+
+export interface RoundMistakeEvent extends BaseGameEvent {
+  type: 'round:mistake';
+  roundId: string;
+  expectedTile: string;
+  actualTile: string;
+  slotId: number;
+  distractorSource: string | null;
+}
+
+export interface RoundTtsPlayedEvent extends BaseGameEvent {
+  type: 'round:tts-played';
+  roundId: string;
+}
+
+export interface RoundVisibilityChangeEvent extends BaseGameEvent {
+  type: 'round:visibility-change';
+  hidden: boolean;
+}
+
+export interface RoundResolvedEvent extends BaseGameEvent {
+  type: 'round:resolved';
+  roundId: string;
+  outcome: 'correct' | 'timeout' | 'skip';
+  finalAnswer?: string;
+}
+```
+
+Add all to the `GameEvent` union.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/types/game-events.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/game-events.ts src/types/game-events.test.ts
+git commit -m "feat(events): add 6 round:* event types with payload interfaces"
+```
+
+---
+
+## Task 2: GameEventBus round:\* Wildcard
+
+**Files:**
+
+- Modify: `src/lib/game-event-bus.ts:25-47` (subscribe method)
+- Test: `src/lib/game-event-bus.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// src/lib/game-event-bus.test.ts (append)
+describe('round:* wildcard subscription', () => {
+  it('receives all round:* events', () => {
+    const bus = createGameEventBus();
+    const received: GameEvent[] = [];
+    bus.subscribe('round:*', (e) => received.push(e));
+
+    bus.emit({
+      type: 'round:shown',
+      gameId: 'test',
+      sessionId: 'test',
+      profileId: 'test',
+      timestamp: Date.now(),
+      roundIndex: 0,
+      roundId: 'r1',
+      itemId: 'i1',
+    } as GameEvent);
+
+    bus.emit({
+      type: 'round:resolved',
+      gameId: 'test',
+      sessionId: 'test',
+      profileId: 'test',
+      timestamp: Date.now(),
+      roundIndex: 0,
+      roundId: 'r1',
+      outcome: 'correct',
+    } as GameEvent);
+
+    expect(received).toHaveLength(2);
+    expect(received[0].type).toBe('round:shown');
+    expect(received[1].type).toBe('round:resolved');
+  });
+
+  it('does not receive game:* events on round:* subscription', () => {
+    const bus = createGameEventBus();
+    const received: GameEvent[] = [];
+    bus.subscribe('round:*', (e) => received.push(e));
+
+    bus.emit({
+      type: 'game:start',
+      gameId: 'test',
+      sessionId: 'test',
+      profileId: 'test',
+      timestamp: Date.now(),
+      roundIndex: 0,
+      locale: 'en',
+      difficulty: 'easy',
+      gradeBand: 'k',
+    } as GameEvent);
+
+    expect(received).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/game-event-bus.test.ts --reporter=verbose`
+Expected: FAIL — `'round:*'` not accepted by `subscribe()`.
+
+- [ ] **Step 3: Extend subscribe to support prefix wildcards**
+
+Replace the hardcoded `'game:*'` check with a generic prefix-wildcard system:
+
+```ts
+// src/lib/game-event-bus.ts
+type WildcardType = 'game:*' | 'round:*';
+
+export class TypedGameEventBus implements GameEventBus {
+  private readonly byType = new Map<GameEventType, Set<Handler>>();
+  private readonly prefixWildcards = new Map<string, Set<Handler>>();
+
+  emit(event: GameEvent): void {
+    for (const [prefix, handlers] of this.prefixWildcards) {
+      if (event.type.startsWith(prefix)) {
+        for (const h of handlers) h(event);
+      }
+    }
+    const specific = this.byType.get(event.type);
+    if (specific) {
+      for (const h of specific) h(event);
+    }
+  }
+
+  subscribe(
+    type: GameEventType | WildcardType,
+    handler: Handler,
+  ): () => void {
+    if (type.endsWith(':*')) {
+      const prefix = type.slice(0, -1);
+      let bucket = this.prefixWildcards.get(prefix);
+      if (!bucket) {
+        bucket = new Set();
+        this.prefixWildcards.set(prefix, bucket);
+      }
+      bucket.add(handler);
+      return () => {
+        bucket.delete(handler);
+        if (bucket.size === 0) this.prefixWildcards.delete(prefix);
+      };
+    }
+    let bucket = this.byType.get(type as GameEventType);
+    if (!bucket) {
+      bucket = new Set();
+      this.byType.set(type as GameEventType, bucket);
+    }
+    bucket.add(handler);
+    return () => {
+      bucket.delete(handler);
+      if (bucket.size === 0) this.byType.delete(type as GameEventType);
+    };
+  }
+}
+```
+
+Also update the `GameEventBus` interface in `game-events.ts` to accept `'round:*'`:
+
+```ts
+export interface GameEventBus {
+  emit(event: GameEvent): void;
+  subscribe(
+    type: GameEventType | 'game:*' | 'round:*',
+    handler: (event: GameEvent) => void,
+  ): () => void;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/game-event-bus.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/game-event-bus.ts src/types/game-events.ts src/lib/game-event-bus.test.ts
+git commit -m "feat(bus): add round:* wildcard subscription via prefix matching
+
+Replaces hardcoded game:* wildcard with generic prefix matching.
+Both game:* and round:* wildcards now work."
+```
+
+---
+
+## Task 3: useGameRound Hook — Basic Round Lifecycle
+
+**Files:**
+
+- Create: `src/lib/game-engine/useGameRound.ts`
+- Create: `src/lib/game-engine/useGameRound.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// src/lib/game-engine/useGameRound.test.ts
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useGameRound } from './useGameRound';
+import { createGameEventBus } from '@/lib/game-event-bus';
+import type { GameEvent } from '@/types/game-events';
+
+// Mock AnswerGameDispatchContext to capture dispatched actions
+// Mock GameEventBus to capture emitted events
+
+type Round = { id: string; word: string };
+
+const rounds: Round[] = [
+  { id: 'r1', word: 'cat' },
+  { id: 'r2', word: 'dog' },
+  { id: 'r3', word: 'hat' },
+];
+
+describe('useGameRound — basic lifecycle', () => {
+  it('starts on first round with phase playing', () => {
+    const { result } = renderHook(() =>
+      useGameRound({ rounds, advanceDelayMs: 0 }),
+    );
+    expect(result.current.roundIndex).toBe(0);
+    expect(result.current.currentRound).toBe(rounds[0]);
+    expect(result.current.phase).toBe('playing');
+    expect(result.current.isLastRound).toBe(false);
+    expect(result.current.totalRounds).toBe(3);
+  });
+
+  it('emits round:shown on mount', () => {
+    // Assert round:shown emitted with roundId 'r1'
+  });
+
+  it('transitions to round-complete on markResolved', () => {
+    const { result } = renderHook(() =>
+      useGameRound({ rounds, advanceDelayMs: 0 }),
+    );
+    act(() => result.current.markResolved('correct'));
+    expect(result.current.phase).toBe('round-complete');
+  });
+
+  it('advances to next round after delay', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useGameRound({ rounds, advanceDelayMs: 750 }),
+    );
+
+    act(() => result.current.markResolved('correct'));
+    expect(result.current.phase).toBe('round-complete');
+
+    act(() => vi.advanceTimersByTime(750));
+    expect(result.current.roundIndex).toBe(1);
+    expect(result.current.currentRound).toBe(rounds[1]);
+    expect(result.current.phase).toBe('playing');
+    vi.useRealTimers();
+  });
+
+  it('emits round:resolved on markResolved', () => {
+    // Assert round:resolved emitted with outcome 'correct'
+  });
+
+  it('emits round:shown on advance to next round', () => {
+    // Advance past round 0
+    // Assert second round:shown emitted with roundId 'r2'
+  });
+
+  it('sets phase to game-over on last round', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useGameRound({ rounds, advanceDelayMs: 0 }),
+    );
+
+    // Resolve all 3 rounds
+    act(() => result.current.markResolved('correct'));
+    act(() => vi.advanceTimersByTime(0));
+    act(() => result.current.markResolved('correct'));
+    act(() => vi.advanceTimersByTime(0));
+    act(() => result.current.markResolved('correct'));
+
+    expect(result.current.phase).toBe('game-over');
+    expect(result.current.isLastRound).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('dispatches ADVANCE_ROUND to reducer', () => {
+    // Assert dispatch called with { type: 'ADVANCE_ROUND', tiles, zones }
+  });
+
+  it('dispatches COMPLETE_GAME on last round', () => {
+    // Assert dispatch called with { type: 'COMPLETE_GAME' }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/game-engine/useGameRound.test.ts --reporter=verbose`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement useGameRound**
+
+```ts
+// src/lib/game-engine/useGameRound.ts
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getGameEventBus } from '@/lib/game-event-bus';
+import type { GameEvent } from '@/types/game-events';
+
+type RoundOutcome = 'correct' | 'timeout' | 'skip';
+
+type UseGameRoundOptions<TRound> = {
+  rounds: TRound[];
+  advanceDelayMs?: number;
+  levelBoundaries?: number[];
+  roundIdAccessor?: (round: TRound) => string;
+  itemIdAccessor?: (round: TRound) => string;
+  gameId: string;
+  sessionId?: string;
+  profileId?: string;
+};
+
+type UseGameRoundReturn<TRound> = {
+  currentRound: TRound;
+  roundIndex: number;
+  levelIndex: number;
+  totalRounds: number;
+  phase: 'playing' | 'round-complete' | 'level-complete' | 'game-over';
+  isLastRound: boolean;
+  markResolved: (outcome: RoundOutcome) => void;
+};
+
+export const useGameRound = <TRound>(
+  options: UseGameRoundOptions<TRound>,
+): UseGameRoundReturn<TRound> => {
+  const {
+    rounds,
+    advanceDelayMs = 750,
+    levelBoundaries,
+    roundIdAccessor,
+    itemIdAccessor,
+    gameId,
+    sessionId = '',
+    profileId = '',
+  } = options;
+
+  const [roundIndex, setRoundIndex] = useState(0);
+  const [levelIndex, setLevelIndex] = useState(0);
+  const [phase, setPhase] = useState<
+    'playing' | 'round-complete' | 'level-complete' | 'game-over'
+  >('playing');
+
+  const currentRound = rounds[roundIndex];
+  const isLastRound = roundIndex >= rounds.length - 1;
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const makeBaseEvent = useCallback(
+    () => ({
+      gameId,
+      sessionId,
+      profileId,
+      timestamp: Date.now(),
+      roundIndex,
+    }),
+    [gameId, sessionId, profileId, roundIndex],
+  );
+
+  const getRoundId = useCallback(
+    (round: TRound, idx: number) =>
+      roundIdAccessor?.(round) ?? `round-${idx}`,
+    [roundIdAccessor],
+  );
+
+  const getItemId = useCallback(
+    (round: TRound, idx: number) =>
+      itemIdAccessor?.(round) ?? `item-${idx}`,
+    [itemIdAccessor],
+  );
+
+  // Emit round:shown on mount and on each advance
+  useEffect(() => {
+    if (!currentRound) return;
+    getGameEventBus().emit({
+      ...makeBaseEvent(),
+      type: 'round:shown',
+      roundId: getRoundId(currentRound, roundIndex),
+      itemId: getItemId(currentRound, roundIndex),
+    } as GameEvent);
+  }, [roundIndex, currentRound, makeBaseEvent, getRoundId, getItemId]);
+
+  const markResolved = useCallback(
+    (outcome: RoundOutcome) => {
+      if (phase !== 'playing') return;
+
+      getGameEventBus().emit({
+        ...makeBaseEvent(),
+        type: 'round:resolved',
+        roundId: getRoundId(currentRound, roundIndex),
+        outcome,
+      } as GameEvent);
+
+      if (isLastRound) {
+        setPhase('game-over');
+        return;
+      }
+
+      const nextIndex = roundIndex + 1;
+      const isLevelBoundary =
+        levelBoundaries?.includes(nextIndex) ?? false;
+
+      setPhase(isLevelBoundary ? 'level-complete' : 'round-complete');
+
+      timerRef.current = globalThis.setTimeout(() => {
+        if (isLevelBoundary) {
+          setLevelIndex((prev) => prev + 1);
+        }
+        setRoundIndex(nextIndex);
+        setPhase('playing');
+      }, advanceDelayMs);
+    },
+    [
+      phase,
+      makeBaseEvent,
+      getRoundId,
+      currentRound,
+      roundIndex,
+      isLastRound,
+      levelBoundaries,
+      advanceDelayMs,
+    ],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) globalThis.clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return {
+    currentRound,
+    roundIndex,
+    levelIndex,
+    totalRounds: rounds.length,
+    phase,
+    isLastRound,
+    markResolved,
+  };
+};
+```
+
+**Note to implementer:** The hook above owns index/phase/timing state internally. In the final implementation, the game component that calls `useGameRound` is responsible for building the next round's tiles/zones and dispatching `ADVANCE_ROUND` / `COMPLETE_GAME` to the `answerGameReducer`. The hook should accept a `buildNextRound` callback or return enough info for the game to do this. Alternatively, the hook can dispatch to the reducer directly if it receives `dispatch` as an option. Decide based on what minimizes coupling — the spec says the hook "dispatches ADVANCE_ROUND and COMPLETE_GAME actions" (§1 State Ownership).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/game-engine/useGameRound.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/game-engine/useGameRound.ts src/lib/game-engine/useGameRound.test.ts
+git commit -m "feat(game-engine): add useGameRound hook with round lifecycle + event emission"
+```
+
+---
+
+## Task 4: useGameRound — Level Boundaries
+
+**Files:**
+
+- Modify: `src/lib/game-engine/useGameRound.test.ts` (add level tests)
+- Modify: `src/lib/game-engine/useGameRound.ts` (if needed)
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+describe('useGameRound — level boundaries', () => {
+  const rounds = Array.from({ length: 6 }, (_, i) => ({
+    id: `r${i}`,
+    word: `word${i}`,
+  }));
+  const levelBoundaries = [3]; // Level 1: rounds 0-2, Level 2: rounds 3-5
+
+  it('tracks levelIndex starting at 0', () => {
+    const { result } = renderHook(() =>
+      useGameRound({
+        rounds,
+        levelBoundaries,
+        advanceDelayMs: 0,
+        gameId: 'test',
+      }),
+    );
+    expect(result.current.levelIndex).toBe(0);
+  });
+
+  it('sets phase to level-complete at boundary', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useGameRound({
+        rounds,
+        levelBoundaries,
+        advanceDelayMs: 0,
+        gameId: 'test',
+      }),
+    );
+
+    // Advance through rounds 0, 1, 2
+    for (let i = 0; i < 3; i++) {
+      act(() => result.current.markResolved('correct'));
+      act(() => vi.advanceTimersByTime(0));
+    }
+    // Round 2 resolved, next is round 3 which is a level boundary
+    // Phase should be 'level-complete' before advance timer fires
+    // (Actually: markResolved at round 2 → next is round 3 → boundary → level-complete)
+    vi.useRealTimers();
+  });
+
+  it('increments levelIndex after level-complete delay', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useGameRound({
+        rounds,
+        levelBoundaries,
+        advanceDelayMs: 750,
+        gameId: 'test',
+      }),
+    );
+
+    // Resolve through to the level boundary
+    for (let i = 0; i < 3; i++) {
+      act(() => result.current.markResolved('correct'));
+      act(() => vi.advanceTimersByTime(750));
+    }
+    expect(result.current.levelIndex).toBe(1);
+    vi.useRealTimers();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `npx vitest run src/lib/game-engine/useGameRound.test.ts --reporter=verbose`
+Expected: If Task 3's implementation already handles `levelBoundaries`, tests pass. If not, they fail and you implement the boundary check.
+
+- [ ] **Step 3: Fix any failures**
+
+Ensure the `markResolved` function checks if `nextIndex` is in `levelBoundaries` and sets phase to `'level-complete'` before the advance timer.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/game-engine/useGameRound.test.ts src/lib/game-engine/useGameRound.ts
+git commit -m "feat(game-engine): useGameRound level boundary support for SortNumbers"
+```
+
+---
+
+## Task 5: Reducer — firstActionAt + round:first-action
+
+**Files:**
+
+- Modify: `src/components/answer-game/types.ts` — add `firstActionAt` to state
+- Modify: `src/components/answer-game/answer-game-reducer.ts` — track first action, emit event
+- Test: `src/components/answer-game/answer-game-reducer.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// In answer-game-reducer.test.ts, add:
+describe('round:first-action detection', () => {
+  it('emits round:first-action on first PLACE_TILE in a round', () => {
+    // Place a tile when firstActionAt is null
+    // Assert round:first-action emitted with kind: 'tile'
+  });
+
+  it('does not emit round:first-action on second PLACE_TILE', () => {
+    // Place two tiles
+    // Assert round:first-action emitted only once
+  });
+
+  it('emits with kind key on TYPE_TILE', () => {
+    // Type a tile when firstActionAt is null
+    // Assert kind: 'key'
+  });
+
+  it('resets firstActionAt on ADVANCE_ROUND', () => {
+    // Place tile (sets firstActionAt)
+    // Advance round
+    // Assert firstActionAt is null again
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/answer-game/answer-game-reducer.test.ts --reporter=verbose`
+Expected: FAIL — `firstActionAt` doesn't exist.
+
+- [ ] **Step 3: Add firstActionAt to state**
+
+In `src/components/answer-game/types.ts`, add to `AnswerGameState`:
+
+```ts
+firstActionAt: number | null;
+```
+
+In `makeInitialState`, set `firstActionAt: null`.
+
+- [ ] **Step 4: Track first action in reducer**
+
+In `answer-game-reducer.ts`, in the `PLACE_TILE` branch, after line 113:
+
+```ts
+case 'PLACE_TILE': {
+  const isFirstAction = state.firstActionAt === null;
+  // ... existing logic ...
+  // After computing the new state, set firstActionAt if first action:
+  const newFirstActionAt = isFirstAction ? Date.now() : state.firstActionAt;
+
+  if (isFirstAction) {
+    getGameEventBus().emit({
+      type: 'round:first-action',
+      gameId: state.config.gameId,
+      sessionId: '',
+      profileId: '',
+      timestamp: Date.now(),
+      roundIndex: state.roundIndex,
+      roundId: `round-${state.roundIndex}`,
+      kind: 'tile',
+    } as GameEvent);
+  }
+
+  return { ...newState, firstActionAt: newFirstActionAt };
+}
+```
+
+Same pattern for `TYPE_TILE` with `kind: 'key'`.
+
+In `ADVANCE_ROUND`, reset: `firstActionAt: null`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/components/answer-game/answer-game-reducer.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/answer-game/types.ts src/components/answer-game/answer-game-reducer.ts src/components/answer-game/answer-game-reducer.test.ts
+git commit -m "feat(reducer): track firstActionAt, emit round:first-action on first interaction"
+```
+
+---
+
+## Task 6: Reducer — round:mistake Emission
+
+**Files:**
+
+- Modify: `src/components/answer-game/answer-game-reducer.ts:126-132` (wrong-placement branch)
+- Test: `src/components/answer-game/answer-game-reducer.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+describe('round:mistake emission', () => {
+  it('emits round:mistake on wrong tile placement (reject mode)', () => {
+    // Place wrong tile in reject mode
+    // Assert round:mistake emitted with expectedTile, actualTile, slotId
+  });
+
+  it('emits round:mistake on wrong tile placement (lock mode)', () => {
+    // Place wrong tile in lock-auto-eject mode
+    // Assert round:mistake emitted
+  });
+
+  it('includes distractorSource from tile metadata', () => {
+    // Place a distractor tile
+    // Assert distractorSource matches tile.source
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — no `round:mistake` emission.
+
+- [ ] **Step 3: Add round:mistake emission to wrong-placement branches**
+
+In the `PLACE_TILE` branch, in both the `reject` path (line 126) and the `lock` path (line 186), emit:
+
+```ts
+getGameEventBus().emit({
+  type: 'round:mistake',
+  gameId: state.config.gameId,
+  sessionId: '',
+  profileId: '',
+  timestamp: Date.now(),
+  roundIndex: state.roundIndex,
+  roundId: `round-${state.roundIndex}`,
+  expectedTile: zone.expectedValue,
+  actualTile: tile.value,
+  slotId: action.zoneIndex,
+  distractorSource:
+    ((tile as Record<string, unknown>).source as string | null) ?? null,
+} as GameEvent);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/answer-game/answer-game-reducer.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/answer-game/answer-game-reducer.ts src/components/answer-game/answer-game-reducer.test.ts
+git commit -m "feat(reducer): emit round:mistake on wrong tile placement with full SRS payload"
+```
+
+---
+
+## Task 7: Visibility Change Tracking
+
+**Files:**
+
+- Create: `src/lib/game-engine/useVisibilityTracking.ts`
+- Test: `src/lib/game-engine/useGameRound.test.ts` (add visibility tests)
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+describe('useVisibilityTracking', () => {
+  it('emits round:visibility-change when document becomes hidden', () => {
+    // Render hook
+    // Simulate visibilitychange event with hidden = true
+    // Assert round:visibility-change emitted with hidden: true
+  });
+
+  it('emits round:visibility-change when document becomes visible', () => {
+    // Simulate visibilitychange with hidden = false
+    // Assert round:visibility-change emitted with hidden: false
+  });
+
+  it('unsubscribes on unmount', () => {
+    // Render and unmount
+    // Simulate visibilitychange
+    // Assert no event emitted after unmount
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement useVisibilityTracking**
+
+```ts
+// src/lib/game-engine/useVisibilityTracking.ts
+import { useEffect } from 'react';
+import { getGameEventBus } from '@/lib/game-event-bus';
+import type { GameEvent } from '@/types/game-events';
+
+export const useVisibilityTracking = (
+  gameId: string,
+  sessionId = '',
+  profileId = '',
+): void => {
+  useEffect(() => {
+    const handler = () => {
+      getGameEventBus().emit({
+        type: 'round:visibility-change',
+        gameId,
+        sessionId,
+        profileId,
+        timestamp: Date.now(),
+        roundIndex: 0,
+        hidden: document.hidden,
+      } as GameEvent);
+    };
+    document.addEventListener('visibilitychange', handler);
+    return () =>
+      document.removeEventListener('visibilitychange', handler);
+  }, [gameId, sessionId, profileId]);
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/game-engine/useGameRound.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/game-engine/useVisibilityTracking.ts src/lib/game-engine/useGameRound.test.ts
+git commit -m "feat(game-engine): add useVisibilityTracking for round:visibility-change events"
+```
+
+---
+
+## Task 8: Slot Tap-Select Mode
+
+**Files:**
+
+- Modify: `src/components/answer-game/types.ts` — add `SELECT_SLOT`, `selectedSlotIds`
+- Modify: `src/components/answer-game/answer-game-reducer.ts` — handle `SELECT_SLOT`
+- Modify: `src/components/answer-game/Slot/Slot.tsx` — add `interactionMode` prop
+- Modify: `src/components/answer-game/Slot/useSlotBehavior.ts` — tap handler
+- Test: `src/components/answer-game/answer-game-reducer.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+describe('SELECT_SLOT action (tap-select mode)', () => {
+  it('adds slot to selectedSlotIds on correct tap', () => {
+    // Dispatch SELECT_SLOT for a correct tile
+    // Assert selectedSlotIds contains the slot id
+  });
+
+  it('triggers round-complete when all correct slots selected', () => {
+    // Select all correct tiles
+    // Assert phase is 'round-complete'
+  });
+
+  it('increments retryCount on wrong tap', () => {
+    // Dispatch SELECT_SLOT for a wrong tile
+    // Assert retryCount incremented
+    // Assert selectedSlotIds does NOT contain the slot
+  });
+
+  it('emits round:first-action with kind tap', () => {
+    // First SELECT_SLOT in a round
+    // Assert round:first-action emitted with kind: 'tap'
+  });
+
+  it('emits round:mistake on wrong tap', () => {
+    // SELECT_SLOT wrong tile
+    // Assert round:mistake emitted
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — `SELECT_SLOT` action doesn't exist.
+
+- [ ] **Step 3: Add types**
+
+In `src/components/answer-game/types.ts`:
+
+Add to `AnswerGameState`:
+
+```ts
+selectedSlotIds: Set<string>;
+```
+
+Add to `AnswerGameAction` union:
+
+```ts
+| { type: 'SELECT_SLOT'; slotId: string; tileId: string }
+```
+
+In `makeInitialState`, set `selectedSlotIds: new Set()`.
+
+- [ ] **Step 4: Implement SELECT_SLOT in reducer**
+
+In `answer-game-reducer.ts`, add a new case:
+
+```ts
+case 'SELECT_SLOT': {
+  const tile = state.allTiles.find((t) => t.id === action.tileId);
+  if (!tile) return state;
+
+  const zone = state.zones.find((z) => z.placedTileId === action.tileId);
+  const isCorrect = tile.value === zone?.expectedValue;
+  const isFirstAction = state.firstActionAt === null;
+
+  if (isFirstAction) {
+    getGameEventBus().emit({
+      type: 'round:first-action',
+      gameId: state.config.gameId,
+      sessionId: '', profileId: '',
+      timestamp: Date.now(),
+      roundIndex: state.roundIndex,
+      roundId: `round-${state.roundIndex}`,
+      kind: 'tap',
+    } as GameEvent);
+  }
+
+  if (isCorrect) {
+    const next = new Set(state.selectedSlotIds);
+    next.add(action.slotId);
+    const allCorrectSelected = state.zones
+      .filter((z) => z.placedTileId !== null)
+      .every((z) => next.has(z.placedTileId!));
+    return {
+      ...state,
+      selectedSlotIds: next,
+      firstActionAt: isFirstAction ? Date.now() : state.firstActionAt,
+      phase: allCorrectSelected ? resolveCompletionPhase(state) : 'playing',
+    };
+  }
+
+  // Wrong tap
+  getGameEventBus().emit({
+    type: 'round:mistake',
+    gameId: state.config.gameId,
+    sessionId: '', profileId: '',
+    timestamp: Date.now(),
+    roundIndex: state.roundIndex,
+    roundId: `round-${state.roundIndex}`,
+    expectedTile: zone?.expectedValue ?? '',
+    actualTile: tile.value,
+    slotId: state.zones.indexOf(zone!),
+    distractorSource: (tile as Record<string, unknown>).source as string | null ?? null,
+  } as GameEvent);
+
+  return {
+    ...state,
+    retryCount: state.retryCount + 1,
+    firstActionAt: isFirstAction ? Date.now() : state.firstActionAt,
+  };
+}
+```
+
+Reset `selectedSlotIds: new Set()` in `ADVANCE_ROUND` and `INIT_ROUND`.
+
+- [ ] **Step 5: Add interactionMode prop to Slot**
+
+In `src/components/answer-game/Slot/Slot.tsx`, add to `SlotProps`:
+
+```ts
+interactionMode?: 'drag' | 'tap-select';
+```
+
+Default to `'drag'`. When `interactionMode === 'tap-select'`, wire an `onClick` handler that dispatches `SELECT_SLOT` instead of using `useDroppable`.
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx vitest run src/components/answer-game/ --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/answer-game/
+git commit -m "feat(answer-game): add SELECT_SLOT action + tap-select Slot mode
+
+Slot gains interactionMode prop ('drag' | 'tap-select'). Tap-select mode
+uses selectedSlotIds Set, emits round:first-action and round:mistake."
+```
+
+---
+
+## Task 9: WordSpell Migration to useGameRound
+
+**Files:**
+
+- Modify: `src/games/word-spell/WordSpell/WordSpell.tsx:128-182` (round lifecycle useEffect)
+- Test: `src/games/word-spell/WordSpell/WordSpell.test.tsx` (existing tests must pass)
+
+- [ ] **Step 1: Run existing WordSpell tests as baseline**
+
+Run: `npx vitest run src/games/word-spell/ --reporter=verbose`
+Expected: PASS — baseline before migration.
+
+- [ ] **Step 2: Replace round lifecycle with useGameRound**
+
+Replace the ~55 LOC useEffect (lines 128-182) with:
+
+```ts
+const { phase, markResolved, roundIndex, isLastRound } = useGameRound({
+  rounds: roundOrder.map((i) => rounds[i]),
+  advanceDelayMs: 750,
+  gameId: wordSpellConfig.gameId,
+  roundIdAccessor: (r) => r.word,
+  itemIdAccessor: (r) => r.word,
+});
+```
+
+The `useGameRound` hook replaces:
+
+- The `phase === 'round-complete'` check
+- The completion token
+- The 750ms delay
+- The `ADVANCE_ROUND` / `COMPLETE_GAME` dispatch logic
+- The next-round building logic
+
+**Important:** The game still needs to build `nextTiles` and `nextZones` via `buildTilesAndZones()` or `buildSentenceGapRound()`. Pass a `buildNextRound` callback to useGameRound, or have useGameRound call back with the next round object and let the game build tiles.
+
+Call `markResolved('correct')` from the existing confetti-ready path where `phase === 'round-complete'` was previously detected. The detection point moves to wherever `allFilledCorrectly` is confirmed in the reducer.
+
+- [ ] **Step 3: Run WordSpell tests**
+
+Run: `npx vitest run src/games/word-spell/ --reporter=verbose`
+Expected: PASS — all existing tests pass unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/games/word-spell/
+git commit -m "refactor(WordSpell): migrate round lifecycle to useGameRound
+
+Replaces ~55 LOC of manual round-advance logic with useGameRound hook.
+All existing tests pass unchanged."
+```
+
+---
+
+## Task 10: NumberMatch Migration to useGameRound
+
+**Files:**
+
+- Modify: `src/games/number-match/NumberMatch/NumberMatch.tsx:151-207`
+- Test: `src/games/number-match/NumberMatch/NumberMatch.test.tsx`
+
+- [ ] **Step 1: Run existing NumberMatch tests as baseline**
+
+Run: `npx vitest run src/games/number-match/ --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 2: Replace round lifecycle with useGameRound**
+
+Same pattern as WordSpell. Replace the ~55 LOC useEffect with:
+
+```ts
+const { phase, markResolved, roundIndex, isLastRound } = useGameRound({
+  rounds: roundOrder.map((i) => numberMatchConfig.rounds[i]),
+  advanceDelayMs: 750,
+  gameId: numberMatchConfig.gameId,
+  roundIdAccessor: (r) => String(r.value),
+  itemIdAccessor: (r) => String(r.value),
+});
+```
+
+Build next-round tiles/zones via `buildNumeralRound()` in a callback.
+
+- [ ] **Step 3: Run NumberMatch tests**
+
+Run: `npx vitest run src/games/number-match/ --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/games/number-match/
+git commit -m "refactor(NumberMatch): migrate round lifecycle to useGameRound"
+```
+
+---
+
+## Task 11: SortNumbers Migration to useGameRound
+
+**Files:**
+
+- Modify: `src/games/sort-numbers/SortNumbers/SortNumbers.tsx:131-205`
+- Test: `src/games/sort-numbers/SortNumbers/SortNumbers.test.tsx`
+
+This is the most complex migration because SortNumbers has level progression and emits `game:round-advance` / `game:level-advance`.
+
+- [ ] **Step 1: Run existing SortNumbers tests as baseline**
+
+Run: `npx vitest run src/games/sort-numbers/ --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 2: Replace round lifecycle with useGameRound**
+
+```ts
+const { phase, markResolved, roundIndex, levelIndex, isLastRound } =
+  useGameRound({
+    rounds: roundOrder.map((i) => sortNumbersConfig.rounds[i]),
+    advanceDelayMs: resolveTiming(
+      'roundAdvanceDelay',
+      skin,
+      sortNumbersConfig.timing,
+    ),
+    levelBoundaries: sortNumbersConfig.levelMode?.boundaries,
+    gameId: sortNumbersConfig.gameId,
+    roundIdAccessor: (r) => r.sequence.join('-'),
+    itemIdAccessor: (r) => r.sequence.join('-'),
+  });
+```
+
+**Backward compatibility:** The existing `game:round-advance` and `game:level-advance` events must continue to fire. Option A: useGameRound emits them internally. Option B: the game emits them in a `useEffect` that watches `roundIndex` and `levelIndex`. Option B is simpler and preserves existing behavior without coupling useGameRound to game-specific events.
+
+- [ ] **Step 3: Preserve existing event emission**
+
+Add a `useEffect` that watches `roundIndex` changes and emits `game:round-advance`:
+
+```ts
+const prevRoundIndex = useRef(roundIndex);
+useEffect(() => {
+  if (prevRoundIndex.current !== roundIndex && roundIndex > 0) {
+    getGameEventBus().emit({
+      type: 'game:round-advance',
+      gameId: sortNumbersConfig.gameId,
+      sessionId: '',
+      profileId: '',
+      timestamp: Date.now(),
+      roundIndex,
+    });
+  }
+  prevRoundIndex.current = roundIndex;
+}, [roundIndex, sortNumbersConfig.gameId]);
+```
+
+Same pattern for `game:level-advance` watching `levelIndex`.
+
+- [ ] **Step 4: Run SortNumbers tests**
+
+Run: `npx vitest run src/games/sort-numbers/ --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/games/sort-numbers/
+git commit -m "refactor(SortNumbers): migrate round lifecycle to useGameRound
+
+Preserves game:round-advance and game:level-advance events for backward
+compatibility. Level boundaries passed to useGameRound for level tracking."
+```
+
+---
+
+## Task 12: Architecture Docs Update
+
+**Files:**
+
+- Modify: `src/lib/game-engine/GameEngine.reference.mdx`
+- Modify: `src/lib/game-engine/GameEngine.flows.mdx`
+
+Per CLAUDE.md: "When modifying game state logic — update the co-located `.mdx` docs in the same PR."
+
+- [ ] **Step 1: Load the update-architecture-docs skill**
+
+Invoke `update-architecture-docs` to get guided prompts.
+
+- [ ] **Step 2: Update GameEngine.reference.mdx**
+
+Add a section documenting:
+
+- `useGameRound` API (options, return type)
+- `round:*` event namespace
+- Tap-select Slot mode
+- `firstActionAt` tracking
+
+- [ ] **Step 3: Update GameEngine.flows.mdx**
+
+Add a flow diagram for the round lifecycle:
+
+```text
+mount → round:shown → playing → markResolved → round:resolved
+  → round-complete → (delay) → ADVANCE_ROUND → round:shown → playing
+  → ... → game-over → COMPLETE_GAME
+```
+
+- [ ] **Step 4: Run markdown lint**
+
+Run: `yarn fix:md`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/game-engine/*.mdx
+git commit -m "docs(game-engine): document useGameRound API and round:* event lifecycle"
+```
+
+---
+
+## Task 13: Final Integration + Smoke Test
+
+- [ ] **Step 1: Run full typecheck**
+
+Run: `yarn typecheck`
+Expected: PASS
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npx vitest run --reporter=verbose`
+Expected: PASS — all tests pass including WordSpell, NumberMatch, SortNumbers.
+
+- [ ] **Step 3: Run lint**
+
+Run: `yarn fix:md && yarn lint`
+Expected: PASS
+
+- [ ] **Step 4: Start dev server and verify**
+
+Run: `yarn dev`
+
+Verify:
+
+- WordSpell rounds advance correctly (same behavior as before)
+- NumberMatch rounds advance correctly
+- SortNumbers levels + rounds advance, direction label changes
+- `game:round-advance` still fires in SortNumbers (check console or event bus spy)
+- All four games compile and run without errors
+
+- [ ] **Step 5: Commit any remaining fixes**
+
+```bash
+git add -A
+git commit -m "chore: final integration fixes for useGameRound extraction"
+```


### PR DESCRIPTION
## Summary

- **M1 plan** (`2026-05-06-spec-1a-m1-tts-lifecycle.md`): 18 TDD tasks covering the Spec 1a M1 acceptance criteria — lifecycle TTS types, `ttsEnabled` → `autoSpeak` + `ttsOnDemandAllowed` split, verbosity resolver, talkativeness presets, WordSpell + NumberMatch registry entries, `useLifecycleTTS` hook, `InstructionsOverlay` → `GameOptionsOverlay` rename, `QuestionRow` component, `AudioButton` refactor, SpotAllPrompt consolidation, SortNumbers AudioButton, ARIA live regions.
- **#257 plan** (`2026-05-06-use-game-round-extraction.md`): 13 TDD tasks covering `useGameRound` extraction — `round:*` event types, bus wildcard support, hook implementation with level boundaries, `firstActionAt` tracking, `round:mistake` emission, visibility tracking, tap-select Slot mode, per-game migrations (WordSpell, NumberMatch, SortNumbers), architecture docs.

Both plans are scoped to their respective specs and can be executed in parallel (M1 does not depend on #257).

Closes #323 (tracking issue — plans enable execution)

## Test plan

- [ ] Review M1 plan against Spec 1a §14 M1 acceptance criteria
- [ ] Review #257 plan against the useGameRound spec
- [ ] Verify file paths reference current codebase files
- [ ] Verify no duplicate work between the two plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)