### PR TITLE
chore(handoffs): PR 1c kickoff + issue #343 tracking update

### DIFF
--- a/.claude/handoffs/2026-05-13-issue-343-body.md
+++ b/.claude/handoffs/2026-05-13-issue-343-body.md
@@ -1,0 +1,73 @@
+Single source of truth for the work shipping in this cluster: **#229 M1 + #257 + SRS v1 implementation + #300**.
+
+> **Last updated:** 2026-05-13 — Phase 1 PRs 1a + 1b have shipped. PR 1c (reducer removal) is the next active engine work; SRS v1 remains blocked on Phase 2 which requires PR 1d (SpotAll).
+
+## Foundation status: GameDefinition engine
+
+The declarative `GameDefinition<TRound>` engine that superseded `useGameRound` has shipped through Phase 1's first two PRs:
+
+- ✅ **PR 1a (#355, merged 2026-05-11)** — GameEngine foundation: XState v5 install, GameDefinition types, useGameEngine, side-effects, interaction-adapter, NumberMatch full XState migration. Canonical plan in `docs/superpowers/plans/2026-05-11-number-match-xstate-implementation-plan.md`.
+- ✅ **PR 1b (#357 + review fixes #360, merged 2026-05-13)** — WordSpell + SortNumbers full XState migrations; `useGameSounds` deleted; round-event semantics finalized.
+- ⏳ **PR 1c — Reducer Removal & Cleanup** — NEXT. Delete `answer-game-reducer.ts`, delete or shim `useAnswerGameContext`, migrate `GameEngineProvider` off `useGameLifecycle`, delete `lifecycle.ts`, migrate `SessionRecorderGate`, consolidate types, optional `CelebrationHost`.
+- ⏳ **PR 1d — SpotAll engine integration** — after PR 1c. First-time engine integration for SpotAll, not a migration. Unblocks Phase 2.
+- ⏳ **Phase 2 — Reducer unification** — after PR 1d. Unblocks SRS v1.
+
+## Updated dependency graph
+
+```text
+✅ PR #350 (GameDefinition engine design) — superseded by #354
+✅ PR #354 (Phase 1 plan + Spec Delta) — merged 2026-05-13
+✅ PR #355 (PR 1a impl) — merged
+✅ PR #357 + #360 (PR 1b impl) — merged
+⏳ PR 1c (reducer removal) — next
+⏳ PR 1d (SpotAll integration)
+⏳ Phase 2 (reducer unification) → unblocks SRS v1
+
+#323 (Spec 1a M1 — user-visible TTS fix)
+  ├── plan partially exists in PR #349 (hook/types/UI parts still valid)
+  ├── registry section now obsolete — per-game entries shipped via GameDefinition.tts in PR 1a/1b
+  └── soft-blocked by #300 (falls back to SimpleConfigForm without it)
+
+#300 (Custom Game Options preset picker)
+  └── independent — can ship anytime
+```
+
+## Spec status
+
+- [x] Spec 1a — Instructions + TTS Lifecycle: merged via PR #322
+- [x] SRS v1: merged via PR #302 → `docs/superpowers/specs/2026-05-01-srs-v1-design.md`
+- [x] SpotAll redesign: merged → `docs/superpowers/specs/2026-04-30-confusable-spotall-redesign-design.md`
+- [x] GameDefinition engine design: merged via PR #354 (replaces #350)
+- [x] useGameRound spec: merged via PR #345; XState engine handle Spec Delta merged via PR #354
+- [ ] #300 spec: **not written yet** — needs brainstorming
+
+## Plan status
+
+- [x] Phase 1 implementation plan — merged via PR #354 (NumberMatch plan + engine foundation plan)
+- [ ] Plan for PR 1c — not yet written; design doc's PR 1c section is the seed
+- [ ] Plan for PR 1d (SpotAll integration) — not yet written
+- [ ] Plan for #323 (M1) — partially exists in PR #349. Hook/types/UI parts valid; registry section now moot (handled by GameDefinition.tts).
+- [ ] Plan for SRS v1 implementation — blocked on Phase 2
+- [ ] Spec + plan for #300 — needs spec first (`superpowers:brainstorming`)
+
+## Recommended sequence
+
+1. ✅ Merge PR #350 design → done (superseded by #354)
+2. ✅ Write Phase 1 implementation plan → done in PR #354
+3. ✅ Execute PR 1a (NumberMatch) → done via #355
+4. ✅ Execute PR 1b (WordSpell + SortNumbers) → done via #357 + #360
+5. ⏳ **Execute PR 1c (reducer removal)** ← next
+6. ⏳ Execute PR 1d (SpotAll integration)
+7. ⏳ Phase 2 (reducer unification) — unblocks SRS v1
+8. ⏳ SRS v1 implementation
+9. ⏳ M1 plan (PR #349) — hook/types/UI parts can proceed anytime; registry section is now moot
+10. ⏳ #300 — independent
+
+## Infra fixes shipped alongside
+
+- PR #344 (merged) — removed auto-prune from post-merge hook
+- PR #347 (merged) — prune script classifies worktrees and prompts before removing local-only work
+
+## Parent
+
+Tracks #229.

--- a/.claude/handoffs/2026-05-13-issue-343-tracking-update.md
+++ b/.claude/handoffs/2026-05-13-issue-343-tracking-update.md
@@ -1,0 +1,67 @@
+# Handoff: Issue #343 tracking update — Spec 1a M1 ship cluster
+
+**Date:** 2026-05-13
+**Status:** Ready to apply
+**Type:** Admin / tracking-issue body edit. ~5 min task.
+**Issue:** [#343 — Tracking: Spec 1a M1 ship cluster — #229 + #257 + SRS v1 + #300](https://github.com/leocaseiro/base-skill/issues/343)
+
+## Why this update is needed
+
+Issue #343 was last updated 2026-05-08 and is now stale on several fronts:
+
+- References **PR #350** as "OPEN, ready to merge" — actually CLOSED since 2026-05-11 (superseded by #354).
+- References **"Phase 1 implementation plan (to write — replaces useGameRound plan)"** — the plan was written and shipped via #354.
+- The dependency graph lists PR 1a, PR 1b, PR 1c as pending — actually PR 1a (#355) and PR 1b (#357 + #360) have shipped on master.
+- The recommended-sequence step 1 ("Merge PR #350") is obsolete. The rest of the sequence needs status update.
+- Lists **PR #345** under "superseded; can be closed" — but #345 actually merged as the useGameRound spec (the spec then received a Spec Delta via #354).
+
+## Verification before editing
+
+Re-confirm state on master before applying the new body (these are fast `gh` commands):
+
+```bash
+gh pr view 350 --json state --jq .state            # expect "CLOSED"
+gh pr view 354 --json state --jq .state            # expect "MERGED"
+gh pr view 355 --json state --jq .state            # expect "MERGED"
+gh pr view 357 --json state --jq .state            # expect "MERGED"
+gh pr view 360 --json state --jq .state            # expect "MERGED"
+gh pr view 345 --json state --jq .state            # expect "MERGED"
+```
+
+If any of these differ from expected, surface the divergence and update the proposed body before applying — don't ship outdated state into a tracking doc that's supposed to be authoritative.
+
+## Proposed new body
+
+The full proposed body content lives in a sibling file so the markdown renders cleanly without nested-fence issues:
+
+**`worktrees/chore-handoff-pr1c-and-343-update/.claude/handoffs/2026-05-13-issue-343-body.md`**
+
+Read it end-to-end before applying. It updates: foundation status, dependency graph, spec status, plan status, recommended sequence, and infra-fixes-shipped sections.
+
+## Apply command
+
+From the project root (or any directory with the body file accessible):
+
+```bash
+gh issue edit 343 --body-file .claude/handoffs/2026-05-13-issue-343-body.md
+```
+
+Replace the path if the handoff worktree has been merged and the file has moved to master (it will live at the same path either way, just on a different branch).
+
+## Verification after editing
+
+```bash
+gh issue view 343 --json updatedAt --jq '.updatedAt'
+```
+
+The edit history is visible from GitHub's edit dropdown on the issue body, so the prior version is preserved for reference even after the edit.
+
+## What this handoff does NOT change
+
+- Does not close any issue. #343 stays open as the active tracking issue.
+- Does not edit any labels, assignees, or milestones — body-only edit.
+- Does not touch the other tracking issues (#229, #257, #300, #323) — only #343 is updated here. If those need similar status sweeps, they're separate handoffs.
+
+## Verdict
+
+Small, low-risk admin task. The proposed body content reflects the current state of master and PR landscape. Apply, verify, done.

--- a/.claude/handoffs/2026-05-13-pr1c-reducer-removal-kickoff.md
+++ b/.claude/handoffs/2026-05-13-pr1c-reducer-removal-kickoff.md
@@ -1,0 +1,94 @@
+# Handoff: PR 1c — Reducer Removal & Cleanup kickoff
+
+**Date:** 2026-05-13
+**Status:** Ready to start
+**Predecessors merged on master:**
+
+- **PR #354** (`2026-05-13`) — PR 1a + NumberMatch implementation plan + Spec Delta on `useGameRound` + archived review/handoff.
+- **PR #355** (`2026-05-11`) — PR 1a implementation: XState v5 install, GameDefinition types, `useGameEngine`, side-effects, `interaction-adapter`, NumberMatch full XState migration.
+- **PR #357** (`2026-05-13`) — PR 1b implementation: WordSpell + SortNumbers full XState migrations; `useGameSounds` deleted.
+- **PR #360** (`2026-05-13`) — PR 1b review fixes layered on top of #357.
+
+All three answer-game children (NumberMatch, WordSpell, SortNumbers) are now XState-driven. The legacy `answer-game-reducer.ts` and `useAnswerGameContext` have no remaining game consumers but still exist on disk. PR 1c removes them.
+
+## Goal
+
+Pure code-only cleanup PR. No new features. The test suite should pass at every commit. PR 1c executes the "Reducer Removal & Cleanup" task list from the design doc on master at `docs/superpowers/plans/2026-05-07-game-definition-engine-design.md` (search for the section starting `**PR 1c — Reducer Removal & Cleanup:**`).
+
+## Read first (full paths from project root)
+
+1. `CLAUDE.md` — project conventions: worktree rules, markdown authoring, TDD, gating, branch protection, MCP / gstack pointers.
+2. `docs/superpowers/plans/2026-05-07-game-definition-engine-design.md` — architecture authority. Search for `PR 1c` for the explicit task list (lines around 107–127). Also see the "Architecture docs to update per PR" subsection and the "New files" / "Phase 1 narrows this union" subsections for what consolidates into the canonical `types.ts`.
+3. `docs/superpowers/plans/2026-05-11-spec-1a-pr1b-wordspell-sortnumbers.md` — the PR 1b plan just shipped. Useful for understanding the migration patterns immediately preceding PR 1c.
+4. `docs/superpowers/plans/2026-05-11-number-match-xstate-implementation-plan.md` — the NumberMatch implementation plan. Canonical reference for the engine-driven pattern.
+5. `src/components/answer-game/answer-game-reducer.ts` — the legacy reducer being deleted.
+6. `src/components/answer-game/answer-game-reducer.test.ts` — the reducer test file. Removed alongside the reducer.
+7. `src/components/answer-game/useAnswerGameContext.ts` and `AnswerGameProvider.tsx` — the Context provider. Either deleted entirely or shimmed; prefer deletion unless audit reveals a non-game consumer.
+8. `src/components/answer-game/useAnswerGameDispatch.ts` — the dispatch hook. Same disposition as the context.
+9. `src/lib/game-engine/lifecycle.ts` — `useGameLifecycle` and `createReducer` legacy module.
+10. `src/lib/game-engine/index.tsx` — `GameEngineProvider` still imports `useGameLifecycle` and `createReducer` from `lifecycle.ts`. Must be migrated before `lifecycle.ts` can be deleted.
+11. `src/lib/game-engine/session-recorder.ts` and tests — `SessionRecorderGate` currently reads `state.phase` from `useGameLifecycle`. PR 1c migrates it to read from `useGameEngineContext()`.
+12. `src/components/answer-game/types.ts` — shared types (`AnswerZone`, `TileItem`, `AnswerGameDraftState`, `AnswerGameAction`). Audit for SpotAll consumers before deletion (M1 risk surfaced in the archived adversarial review). Split into a leaf module that survives reducer deletion if needed.
+13. `src/lib/game-engine/definition-types.ts` and `types.ts` — `definition-types.ts` content folds into the canonical `types.ts` per the design doc, then `definition-types.ts` is deleted.
+
+## Task list (from the design doc, expanded)
+
+1. **Migrate `GameEngineProvider` off `useGameLifecycle` and `createReducer`** in `src/lib/game-engine/index.tsx`. Replace the `useGameLifecycle` call site with engine-driven equivalents. This is the prerequisite for deleting `lifecycle.ts`.
+2. **Migrate `SessionRecorderGate`** in `src/lib/game-engine/session-recorder.ts` to read from `useGameEngineContext()` instead of `useGameLifecycle`'s `state.phase`. Update `src/lib/game-engine/session-recorder.test.tsx` accordingly.
+3. **Delete `src/lib/game-engine/lifecycle.ts` and `lifecycle.test.ts`** once all imports are removed. If the migration in step 1 cannot complete in PR 1c, defer deletion to Phase 2 and flag the deferral explicitly in the PR description.
+4. **Audit shared types in `src/components/answer-game/types.ts`** for SpotAll consumers. Run `grep -rn "AnswerZone\|TileItem\|AnswerGameDraftState\|AnswerGameAction" src/games/spot-all src/components --include="*.ts" --include="*.tsx"`. If SpotAll imports any of them, split shared types into a leaf module (e.g., `src/components/answer-game/shared-types.ts`) and update imports.
+5. **Delete `src/components/answer-game/answer-game-reducer.ts` and `answer-game-reducer.test.ts`**. Confirm with `grep -rn "answer-game-reducer\|answerGameReducer\|AnswerGameAction" src/ --include="*.ts" --include="*.tsx"` that no `import` references remain.
+6. **Delete or shim `useAnswerGameContext.ts`, `useAnswerGameDispatch.ts`, and `AnswerGameProvider.tsx`**. Audit consumers with `grep -rn "useAnswerGameContext\|useAnswerGameDispatch\|AnswerGameProvider" src/ --include="*.ts" --include="*.tsx"`. Delete if no consumers remain (preferred). Shim with a no-op or thin wrapper only if a non-game consumer is found and migration is out of scope.
+7. **Fold `src/lib/game-engine/definition-types.ts` content into `src/lib/game-engine/types.ts`**, then delete `definition-types.ts`. Update all imports across the codebase.
+8. **Optional — introduce `CelebrationHost`** to take over celebration overlay mounting (engine-mounted equivalent of what NumberMatch / WordSpell / SortNumbers currently render component-side per Spec Delta #1 of PR 1a). If this expands scope significantly, defer to a follow-up PR and document the deferral with a `TODO(PR 1c-follow-up)` or open a tracking issue.
+9. **Update architecture MDX docs** per `CLAUDE.md` and the design doc's "Architecture docs to update per PR" subsection. Run `/update-architecture-docs` for guided prompts. Cross-reference cleanup across:
+   - `src/lib/game-engine/GameEngine.flows.mdx`
+   - `src/lib/game-engine/GameEngine.reference.mdx`
+   - `src/lib/game-engine/debugging.mdx`
+   - `src/components/answer-game/AnswerGame/AnswerGame.reference.mdx`
+
+## Project conventions to honor (from CLAUDE.md)
+
+- **Worktree first.** From the project root:
+
+  ```bash
+  cd /Users/leocaseiro/Sites/base-skill
+  git worktree add ./worktrees/feat-spec-1a-pr1c-reducer-removal -b feat/spec-1a-pr1c-reducer-removal origin/master
+  cd ./worktrees/feat-spec-1a-pr1c-reducer-removal
+  yarn install
+  ```
+
+- **TDD for every change.** For pure-deletion work, the equivalent is "run the existing test suite, confirm all tests still pass after each deletion step." Don't batch deletions — one focused commit per logical removal, so reviewers can follow the history and bisect cleanly.
+- **Baby-step commits.** Suggested grouping:
+  1. `GameEngineProvider` lifecycle.ts migration (task 1)
+  2. `SessionRecorderGate` migration (task 2)
+  3. `lifecycle.ts` deletion (task 3) — or deferral note if step 1 cannot complete
+  4. Shared types audit + leaf-module split if needed (task 4)
+  5. `answer-game-reducer.ts` deletion + grep proof (task 5)
+  6. Provider / context / dispatch hook deletion or shim (task 6)
+  7. `definition-types.ts` fold into `types.ts` (task 7)
+  8. Architecture MDX updates (task 9)
+  9. Optional `CelebrationHost` (task 8) — separate commit, easy to revert
+
+- **Markdown authoring.** Any `.md` file you author or edit must pass `yarn fix:md` before commit. Project enforces `yarn lint:md` and `npx prettier --check` in CI.
+- **PR base: master.** Always. Project memory `feedback_pr_base_master.md` confirms.
+- **Pre-push gating.** The smart-pipelines pre-push hook runs only the atomic checks affected by changed files. Don't `SKIP_*` unless documented in the commit message (per memory `feedback_skip_hooks_minor.md`).
+- **Architecture docs in same PR.** When modifying game-state logic (any file under `src/components/answer-game/` or `src/lib/game-engine/`), update co-located `.mdx` docs in the same PR. Run `/update-architecture-docs`.
+
+## How to start the new session
+
+Once you're at the project root in a fresh Claude Code session:
+
+1. Read this handoff in full (you're reading it now if you're following the prompt).
+2. Read `CLAUDE.md` and the design doc's PR 1c section.
+3. Produce a brief gap analysis: which files exist that the design doc names, which don't, which can be deleted cleanly without breaking master. Surface anything surprising before writing code.
+4. Once the gap analysis is confirmed, propose a task breakdown using the 9-step list above as a starting point and start with task 1.
+5. Create the implementation worktree as shown above and proceed task-by-task.
+
+## After PR 1c lands
+
+The natural follow-up is **PR 1d — SpotAll engine integration**. SpotAll's reducer (`spot-all-reducer.ts`) survives PR 1c — it's a separate adoption track that lands once XState + GameDefinition are stable across the three answer games. PR 1d is the first-time engine integration for SpotAll (not a strict migration), and **Phase 2** (reducer unification, which unblocks SRS v1) depends on PR 1d. The design doc has the PR 1d engine-boundary specifics; a separate handoff or plan should be written when PR 1c lands.
+
+## Verdict
+
+PR 1c is well-scoped: a fixed list of deletions + two migrations + an optional addition (`CelebrationHost`). All prerequisites are on master. The test suite covers the existing game behaviour and will catch regressions if a deletion is premature. The audit-before-delete steps (4 and 6) are the only places where deeper investigation is needed.


### PR DESCRIPTION
## Summary

Two handoffs prepared for the next session, both rooted in the now-merged state of master (PR 1a + PR 1b shipped via #354, #355, #357, #360).

- **`.claude/handoffs/2026-05-13-pr1c-reducer-removal-kickoff.md`** — kickoff handoff for PR 1c (Reducer Removal & Cleanup). Lists predecessors, the 9-task list from the design doc on master (`docs/superpowers/plans/2026-05-07-game-definition-engine-design.md`), the read-first file map, project conventions to honor, and suggested baby-step commit groupings.
- **`.claude/handoffs/2026-05-13-issue-343-tracking-update.md`** — kickoff handoff for the issue #343 body refresh. Documents why the current body is stale (references PR #350 as "ready to merge" while it's closed; lists PR 1a/1b as pending while they shipped). Includes a verification-before-edit checklist and an `gh issue edit 343 --body-file` apply command.
- **`.claude/handoffs/2026-05-13-issue-343-body.md`** — the proposed new body content for issue #343, as a sibling file so the apply command can consume it directly (no nested-fence parsing issues).

Both handoffs are standalone-readable. The PR 1c kickoff cross-references the merged design doc on master; the #343 handoff references the body file in the same directory.

## What this PR does NOT include

- Does not start PR 1c implementation — that's a separate session in a separate worktree (`worktrees/feat-spec-1a-pr1c-reducer-removal` per the kickoff handoff).
- Does not apply the #343 body update — the new session runs `gh issue edit` once the verification checklist passes.

## Test plan

- [ ] Read both handoffs end-to-end; confirm they're standalone-readable.
- [ ] Read `.claude/handoffs/2026-05-13-issue-343-body.md` and confirm the proposed body content is accurate.
- [ ] Confirm `yarn lint:md` and `npx prettier --check` pass (CI verifies).
- [ ] Optionally land this PR before starting the next session so the handoffs are on master.

## Why a handoff PR rather than starting PR 1c directly

Two reasons:

1. The handoffs are reviewable artifacts. Landing them in their own PR means the kickoff context is on master for any future session (or any human reader) without depending on the PR 1c branch existing.
2. Issue #343's body refresh is independent of PR 1c. Splitting them into two handoffs preserves that independence — a session could apply the #343 update without starting PR 1c, or start PR 1c without touching #343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)