### PR TITLE
chore: move .specstory to private submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".specstory"]
+	path = .specstory
+	url = git@github.com:leocaseiro/base-skill-specstory.git


### PR DESCRIPTION
## Summary

- Extracted `.specstory/` into private repo [`leocaseiro/base-skill-specstory`](https://github.com/leocaseiro/base-skill-specstory)
- Added it back as a git submodule pointing to the private repo
- `.specstory` history was removed from this repo's git history (separate force push)

## Context

The `.specstory` directory contained 118MB of specstory session history that was bloating the public repo. It has been:
1. Extracted with full git history preserved into a private repo
2. Removed from all branches' git history via `git filter-repo`
3. Re-added as a submodule so it's still accessible locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)