### PR TITLE
feat(mini-games): CoinTap — time-limited coin collecting with star rating

### DIFF
--- a/src/components/mini-games/CoinTap/CoinTap.stories.tsx
+++ b/src/components/mini-games/CoinTap/CoinTap.stories.tsx
@@ -1,0 +1,29 @@
+import { fn } from 'storybook/test';
+
+import { CoinTap } from './CoinTap';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof CoinTap> = {
+  component: CoinTap,
+  title: 'MiniGames/CoinTap',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    starRating: {
+      control: { type: 'radio' },
+      options: [1, 2, 3, 4, 5],
+    },
+    onComplete: { table: { disable: true } },
+  },
+  args: {
+    starRating: 3,
+    onComplete: fn(),
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof CoinTap>;
+
+export const Playground: Story = {};

--- a/src/components/mini-games/CoinTap/CoinTap.tsx
+++ b/src/components/mini-games/CoinTap/CoinTap.tsx
@@ -18,10 +18,10 @@ const getStarsFromCoins = (coins: number): number => {
 
 const StarDisplay = ({ count }: { count: number }) => (
   <div className="flex justify-center gap-1 text-4xl">
-    {Array.from({ length: 5 }, (_, i) => (
+    {[1, 2, 3, 4, 5].map((star) => (
       <span
-        key={i}
-        className={i < count ? 'opacity-100' : 'opacity-30'}
+        key={star}
+        className={star <= count ? 'opacity-100' : 'opacity-30'}
       >
         ⭐
       </span>

--- a/src/components/mini-games/CoinTap/CoinTap.tsx
+++ b/src/components/mini-games/CoinTap/CoinTap.tsx
@@ -180,7 +180,7 @@ export const CoinTap = ({
 
       {/* Coin counter */}
       <p className="text-4xl font-bold text-yellow-300">
-        {coins} coin{coins !== 1 ? 's' : ''}
+        {coins} coin{coins === 1 ? '' : 's'}
       </p>
 
       {/* Streak display */}

--- a/src/components/mini-games/CoinTap/CoinTap.tsx
+++ b/src/components/mini-games/CoinTap/CoinTap.tsx
@@ -92,11 +92,9 @@ export const CoinTap = ({
     setLastTapTime(now);
     setPopKey((prev) => prev + 1);
 
-    if (timeSinceLastTap <= 300 && lastTapTime !== 0) {
-      setStreak((prev) => prev + 1);
-    } else {
-      setStreak(1);
-    }
+    setStreak(
+      timeSinceLastTap <= 300 && lastTapTime !== 0 ? (prev) => prev + 1 : 1,
+    );
   };
 
   const progressPercent =

--- a/src/components/mini-games/CoinTap/CoinTap.tsx
+++ b/src/components/mini-games/CoinTap/CoinTap.tsx
@@ -93,7 +93,9 @@ export const CoinTap = ({
     setPopKey((prev) => prev + 1);
 
     setStreak(
-      timeSinceLastTap <= 300 && lastTapTime !== 0 ? (prev) => prev + 1 : 1,
+      timeSinceLastTap <= 300 && lastTapTime !== 0
+        ? (prev) => prev + 1
+        : 1,
     );
   };
 

--- a/src/components/mini-games/CoinTap/CoinTap.tsx
+++ b/src/components/mini-games/CoinTap/CoinTap.tsx
@@ -1,5 +1,11 @@
 import confetti from 'canvas-confetti';
-import { type CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 interface CoinTapProps {
   starRating?: 1 | 2 | 3 | 4 | 5;
@@ -24,7 +30,9 @@ const getTimerBarColor = (percent: number): string => {
   return 'bg-red-400';
 };
 
-const getGoldGlowStyle = (streak: number): CSSProperties | undefined => {
+const getGoldGlowStyle = (
+  streak: number,
+): CSSProperties | undefined => {
   if (streak >= 10) {
     return {
       filter: `drop-shadow(0 0 ${String(Math.min(streak, 20))}px gold) drop-shadow(0 0 ${String(Math.min(streak * 2, 40))}px rgba(255,215,0,0.6))`,

--- a/src/components/mini-games/CoinTap/CoinTap.tsx
+++ b/src/components/mini-games/CoinTap/CoinTap.tsx
@@ -1,6 +1,5 @@
 import confetti from 'canvas-confetti';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { JSX } from 'react';
 
 interface CoinTapProps {
   starRating?: 1 | 2 | 3 | 4 | 5;
@@ -17,7 +16,7 @@ const getStarsFromCoins = (coins: number): number => {
   return 5;
 };
 
-const StarDisplay = ({ count }: { count: number }): JSX.Element => (
+const StarDisplay = ({ count }: { count: number }) => (
   <div className="flex justify-center gap-1 text-4xl">
     {Array.from({ length: 5 }, (_, i) => (
       <span
@@ -33,7 +32,7 @@ const StarDisplay = ({ count }: { count: number }): JSX.Element => (
 export const CoinTap = ({
   starRating = 3,
   onComplete,
-}: CoinTapProps): JSX.Element => {
+}: CoinTapProps) => {
   const totalDuration = getDuration(starRating);
 
   const [coins, setCoins] = useState(0);

--- a/src/components/mini-games/CoinTap/CoinTap.tsx
+++ b/src/components/mini-games/CoinTap/CoinTap.tsx
@@ -1,0 +1,202 @@
+import confetti from 'canvas-confetti';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { JSX } from 'react';
+
+interface CoinTapProps {
+  starRating?: 1 | 2 | 3 | 4 | 5;
+  onComplete?: (coins: number) => void;
+}
+
+const getDuration = (stars: number): number => stars * 5;
+
+const getStarsFromCoins = (coins: number): number => {
+  if (coins < 10) return 1;
+  if (coins < 20) return 2;
+  if (coins < 35) return 3;
+  if (coins < 50) return 4;
+  return 5;
+};
+
+const StarDisplay = ({ count }: { count: number }): JSX.Element => (
+  <div className="flex justify-center gap-1 text-4xl">
+    {Array.from({ length: 5 }, (_, i) => (
+      <span
+        key={i}
+        className={i < count ? 'opacity-100' : 'opacity-30'}
+      >
+        ⭐
+      </span>
+    ))}
+  </div>
+);
+
+export const CoinTap = ({
+  starRating = 3,
+  onComplete,
+}: CoinTapProps): JSX.Element => {
+  const totalDuration = getDuration(starRating);
+
+  const [coins, setCoins] = useState(0);
+  const [timeLeft, setTimeLeft] = useState(totalDuration);
+  const [isRunning, setIsRunning] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+  const [lastTapTime, setLastTapTime] = useState(0);
+  const [streak, setStreak] = useState(0);
+  const [popKey, setPopKey] = useState(0);
+
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+  const coinsRef = useRef(coins);
+  coinsRef.current = coins;
+
+  const handleComplete = useCallback(() => {
+    setIsComplete(true);
+    void confetti({
+      particleCount: 150,
+      spread: 80,
+      origin: { y: 0.6 },
+      colors: ['#FFD700', '#FFA500', '#FFE066', '#FFEC8B', '#FFF8DC'],
+    });
+    onCompleteRef.current?.(coinsRef.current);
+  }, []);
+
+  useEffect(() => {
+    if (!isRunning || isComplete) return;
+
+    const interval = globalThis.setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          globalThis.clearInterval(interval);
+          handleComplete();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => {
+      globalThis.clearInterval(interval);
+    };
+  }, [isRunning, isComplete, handleComplete]);
+
+  const handleCoinTap = (): void => {
+    if (isComplete) return;
+
+    if (!isRunning) {
+      setIsRunning(true);
+    }
+
+    const now = Date.now();
+    const timeSinceLastTap = now - lastTapTime;
+
+    setCoins((prev) => prev + 1);
+    setLastTapTime(now);
+    setPopKey((prev) => prev + 1);
+
+    if (timeSinceLastTap <= 300 && lastTapTime !== 0) {
+      setStreak((prev) => prev + 1);
+    } else {
+      setStreak(1);
+    }
+  };
+
+  const progressPercent =
+    totalDuration > 0 ? (timeLeft / totalDuration) * 100 : 0;
+
+  const timerBarColor =
+    progressPercent > 50
+      ? 'bg-green-400'
+      : progressPercent > 25
+        ? 'bg-orange-400'
+        : 'bg-red-400';
+
+  const coinSize = coins >= 100 ? 'text-[10rem]' : 'text-[8rem]';
+
+  const goldGlowStyle =
+    streak >= 10
+      ? {
+          filter: `drop-shadow(0 0 ${String(Math.min(streak, 20))}px gold) drop-shadow(0 0 ${String(Math.min(streak * 2, 40))}px rgba(255,215,0,0.6))`,
+        }
+      : streak >= 5
+        ? {
+            filter: `drop-shadow(0 0 8px gold)`,
+          }
+        : undefined;
+
+  if (isComplete) {
+    const earnedStars = getStarsFromCoins(coins);
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-gradient-to-b from-yellow-950 to-amber-900 p-8 text-center">
+        <div className="flex flex-col items-center gap-6 rounded-3xl bg-black/30 p-10">
+          <div className="text-6xl">🎉</div>
+          <h1 className="text-3xl font-bold text-yellow-300">
+            You collected {coins} coins! 🪙
+          </h1>
+          <StarDisplay count={earnedStars} />
+          <p className="text-lg text-yellow-100/80">
+            {earnedStars >= 4
+              ? 'Amazing tapping!'
+              : earnedStars >= 3
+                ? 'Great job!'
+                : earnedStars >= 2
+                  ? 'Nice work!'
+                  : 'Keep practising!'}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-gradient-to-b from-yellow-950 to-amber-900 p-6">
+      {/* Timer bar */}
+      <div className="w-full max-w-sm">
+        <div className="mb-2 flex items-center justify-between text-yellow-300">
+          <span className="text-sm font-semibold uppercase tracking-wide">
+            Time
+          </span>
+          <span className="text-2xl font-bold tabular-nums">
+            {timeLeft}s
+          </span>
+        </div>
+        <div className="h-4 w-full overflow-hidden rounded-full bg-black/40">
+          <div
+            className={`h-full rounded-full transition-all duration-1000 ${timerBarColor}`}
+            style={{ width: `${String(progressPercent)}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Coin */}
+      <button
+        key={popKey}
+        type="button"
+        onClick={handleCoinTap}
+        aria-label="Tap the coin"
+        className={`animate-pop cursor-pointer select-none leading-none ${coinSize}`}
+        style={goldGlowStyle}
+      >
+        🪙
+      </button>
+
+      {/* Coin counter */}
+      <p className="text-4xl font-bold text-yellow-300">
+        {coins} coin{coins !== 1 ? 's' : ''}
+      </p>
+
+      {/* Streak display */}
+      {streak >= 5 && (
+        <div className="animate-bounce rounded-2xl bg-orange-500/80 px-6 py-3 text-xl font-bold text-white shadow-lg">
+          🔥 x{streak} COMBO!
+        </div>
+      )}
+
+      {/* Before first tap instruction */}
+      {!isRunning && (
+        <p className="animate-pulse text-lg font-semibold text-yellow-200/80">
+          Tap the coin!
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/components/mini-games/CoinTap/CoinTap.tsx
+++ b/src/components/mini-games/CoinTap/CoinTap.tsx
@@ -1,11 +1,6 @@
 import confetti from 'canvas-confetti';
-import {
-  type CSSProperties,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
 
 interface CoinTapProps {
   starRating?: 1 | 2 | 3 | 4 | 5;
@@ -77,9 +72,11 @@ export const CoinTap = ({
   const [popKey, setPopKey] = useState(0);
 
   const onCompleteRef = useRef(onComplete);
-  onCompleteRef.current = onComplete;
   const coinsRef = useRef(coins);
-  coinsRef.current = coins;
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+    coinsRef.current = coins;
+  });
 
   const handleComplete = useCallback(() => {
     setIsComplete(true);

--- a/src/components/mini-games/CoinTap/CoinTap.tsx
+++ b/src/components/mini-games/CoinTap/CoinTap.tsx
@@ -16,6 +16,8 @@ const getStarsFromCoins = (coins: number): number => {
   return 5;
 };
 
+const increment = (prev: number) => prev + 1;
+
 const StarDisplay = ({ count }: { count: number }) => (
   <div className="flex justify-center gap-1 text-4xl">
     {[1, 2, 3, 4, 5].map((star) => (
@@ -88,14 +90,12 @@ export const CoinTap = ({
     const now = Date.now();
     const timeSinceLastTap = now - lastTapTime;
 
-    setCoins((prev) => prev + 1);
+    setCoins(increment);
     setLastTapTime(now);
-    setPopKey((prev) => prev + 1);
+    setPopKey(increment);
 
     setStreak(
-      timeSinceLastTap <= 300 && lastTapTime !== 0
-        ? (prev) => prev + 1
-        : 1,
+      timeSinceLastTap <= 300 && lastTapTime !== 0 ? increment : 1,
     );
   };
 

--- a/src/components/mini-games/CoinTap/CoinTap.tsx
+++ b/src/components/mini-games/CoinTap/CoinTap.tsx
@@ -1,5 +1,5 @@
 import confetti from 'canvas-confetti';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { type CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 
 interface CoinTapProps {
   starRating?: 1 | 2 | 3 | 4 | 5;
@@ -17,6 +17,29 @@ const getStarsFromCoins = (coins: number): number => {
 };
 
 const increment = (prev: number) => prev + 1;
+
+const getTimerBarColor = (percent: number): string => {
+  if (percent > 50) return 'bg-green-400';
+  if (percent > 25) return 'bg-orange-400';
+  return 'bg-red-400';
+};
+
+const getGoldGlowStyle = (streak: number): CSSProperties | undefined => {
+  if (streak >= 10) {
+    return {
+      filter: `drop-shadow(0 0 ${String(Math.min(streak, 20))}px gold) drop-shadow(0 0 ${String(Math.min(streak * 2, 40))}px rgba(255,215,0,0.6))`,
+    };
+  }
+  if (streak >= 5) return { filter: `drop-shadow(0 0 8px gold)` };
+  return undefined;
+};
+
+const getEarnedMessage = (stars: number): string => {
+  if (stars >= 4) return 'Amazing tapping!';
+  if (stars >= 3) return 'Great job!';
+  if (stars >= 2) return 'Nice work!';
+  return 'Keep practising!';
+};
 
 const StarDisplay = ({ count }: { count: number }) => (
   <div className="flex justify-center gap-1 text-4xl">
@@ -102,25 +125,11 @@ export const CoinTap = ({
   const progressPercent =
     totalDuration > 0 ? (timeLeft / totalDuration) * 100 : 0;
 
-  const timerBarColor =
-    progressPercent > 50
-      ? 'bg-green-400'
-      : progressPercent > 25
-        ? 'bg-orange-400'
-        : 'bg-red-400';
+  const timerBarColor = getTimerBarColor(progressPercent);
 
   const coinSize = coins >= 100 ? 'text-[10rem]' : 'text-[8rem]';
 
-  const goldGlowStyle =
-    streak >= 10
-      ? {
-          filter: `drop-shadow(0 0 ${String(Math.min(streak, 20))}px gold) drop-shadow(0 0 ${String(Math.min(streak * 2, 40))}px rgba(255,215,0,0.6))`,
-        }
-      : streak >= 5
-        ? {
-            filter: `drop-shadow(0 0 8px gold)`,
-          }
-        : undefined;
+  const goldGlowStyle = getGoldGlowStyle(streak);
 
   if (isComplete) {
     const earnedStars = getStarsFromCoins(coins);
@@ -133,13 +142,7 @@ export const CoinTap = ({
           </h1>
           <StarDisplay count={earnedStars} />
           <p className="text-lg text-yellow-100/80">
-            {earnedStars >= 4
-              ? 'Amazing tapping!'
-              : earnedStars >= 3
-                ? 'Great job!'
-                : earnedStars >= 2
-                  ? 'Nice work!'
-                  : 'Keep practising!'}
+            {getEarnedMessage(earnedStars)}
           </p>
         </div>
       </div>

--- a/src/routes/$locale/_app/game/$gameId.tsx
+++ b/src/routes/$locale/_app/game/$gameId.tsx
@@ -1173,6 +1173,10 @@ export const GameRoute = ({
 export const buildGamePageTitle = (name: string | null): string =>
   name ? `${name} | BaseSkill` : 'BaseSkill';
 
+const resetDocumentTitle = () => {
+  document.title = 'BaseSkill';
+};
+
 const RouteComponent = (): JSX.Element => {
   const data = Route.useLoaderData();
   const search = Route.useSearch();
@@ -1183,9 +1187,7 @@ const RouteComponent = (): JSX.Element => {
 
   useEffect(() => {
     document.title = buildGamePageTitle(gameName);
-    return () => {
-      document.title = 'BaseSkill';
-    };
+    return resetDocumentTitle;
   }, [gameName]);
 
   return <GameRoute {...data} debug={debug} />;

--- a/src/routes/$locale/_app/game/$gameId.tsx
+++ b/src/routes/$locale/_app/game/$gameId.tsx
@@ -1179,8 +1179,7 @@ const RouteComponent = (): JSX.Element => {
   const debug = search.debug === true || import.meta.env.DEV;
   const { t } = useTranslation('games');
   const gameId = data.config.gameId;
-  const gameName =
-    data.customGameName ?? t(gameId);
+  const gameName = data.customGameName ?? t(gameId);
 
   useEffect(() => {
     document.title = buildGamePageTitle(gameName);

--- a/src/routes/$locale/_app/game/$gameId.tsx
+++ b/src/routes/$locale/_app/game/$gameId.tsx
@@ -1180,7 +1180,7 @@ const RouteComponent = (): JSX.Element => {
   const { t } = useTranslation('games');
   const gameId = data.config.gameId;
   const gameName =
-    data.customGameName ?? t(gameId as Parameters<typeof t>[0]);
+    data.customGameName ?? t(gameId);
 
   useEffect(() => {
     document.title = buildGamePageTitle(gameName);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a new `CoinTap` celebration mini game at `src/components/mini-games/CoinTap/CoinTap.tsx`
- Game duration scales with star rating via `getDuration(stars) = stars * 5` — giving 5s (1 star) to 25s (5 stars), rewarding better performance with more tapping time
- Streak combo system detects rapid consecutive taps (within 300ms) and shows a 🔥 `x{streak} COMBO!` banner at streak ≥ 5, with golden glow on the coin at streak ≥ 10
- On completion, fires a `canvas-confetti` burst and renders an end-screen with coin count, star rating (calculated from coins collected), and an encouraging message
- Storybook story at `MiniGames/CoinTap` with a `Playground` story and `starRating` radio control

## Mechanic details

| Star rating | Time |
|-------------|------|
| ⭐ 1        | 5s   |
| ⭐⭐ 2      | 10s  |
| ⭐⭐⭐ 3    | 15s  |
| ⭐⭐⭐⭐ 4  | 20s  |
| ⭐⭐⭐⭐⭐ 5 | 25s  |

Coins-to-stars thresholds (end-screen display): <10 = 1★, 10–19 = 2★, 20–34 = 3★, 35–49 = 4★, 50+ = 5★.

The timer bar is colour-coded green → orange → red as time runs out. The coin emoji grows from `text-[8rem]` to `text-[10rem]` once 100+ coins are collected.

## Storybook

Story lives at: `MiniGames/CoinTap` → `Playground`

- `starRating` radio control (1–5) to switch game durations
- `onComplete` wired to `fn()` (Storybook action spy, hidden from Controls table)

## Test plan

- [ ] Open Storybook → `MiniGames/CoinTap` → `Playground`
- [ ] Confirm instruction text "Tap the coin!" is visible before first tap
- [ ] Tap the coin — timer bar should start shrinking, instruction fades
- [ ] Rapid-tap to trigger streak ≥ 5 — COMBO banner should appear with `animate-bounce`
- [ ] Streak ≥ 10 — golden glow should intensify on the coin
- [ ] Let timer reach 0 — confetti fires, end-screen shows coin count and stars
- [ ] Switch `starRating` to 1 — confirm game lasts ~5 seconds
- [ ] Switch `starRating` to 5 — confirm game lasts ~25 seconds

https://claude.ai/code/session_01EkLUc3TJmA3jFRBXSdjTR8
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkLUc3TJmA3jFRBXSdjTR8)_

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/314/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/314/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/314#issuecomment-)
<!-- /preview-urls -->

















