### PR TITLE
feat(speak-spell): speech recognition game prototype

### DIFF
--- a/src/games/config-fields-registry.tsx
+++ b/src/games/config-fields-registry.tsx
@@ -12,7 +12,8 @@ import type { JSX } from 'react';
 
 export const getConfigFields = (gameId: string): ConfigField[] => {
   switch (gameId) {
-    case 'word-spell': {
+    case 'word-spell':
+    case 'speak-spell': {
       return wordSpellConfigFields;
     }
     case 'number-match': {
@@ -45,7 +46,8 @@ export const getSimpleConfigFormRenderer = (
   gameId: string,
 ): ConfigFormRenderer | undefined => {
   switch (gameId) {
-    case 'word-spell': {
+    case 'word-spell':
+    case 'speak-spell': {
       return WordSpellSimpleConfigForm;
     }
     case 'number-match': {
@@ -72,7 +74,8 @@ export const getAdvancedHeaderRenderer = (
   gameId: string,
 ): ConfigFormRenderer | undefined => {
   switch (gameId) {
-    case 'word-spell': {
+    case 'word-spell':
+    case 'speak-spell': {
       return WordSpellAdvancedHeader;
     }
     default: {
@@ -95,7 +98,7 @@ export const isPlayableConfig = (
   gameId: string,
   config: Record<string, unknown>,
 ): boolean => {
-  if (gameId !== 'word-spell') return true;
+  if (gameId !== 'word-spell' && gameId !== 'speak-spell') return true;
   if (config.mode === 'picture' || config.mode === 'sentence-gap') {
     return true;
   }

--- a/src/games/registry.ts
+++ b/src/games/registry.ts
@@ -50,6 +50,18 @@ export const GAME_CATALOG: GameCatalogEntry[] = [
     },
   },
   {
+    id: 'speak-spell',
+    titleKey: 'speak-spell',
+    descriptionKey: 'speak-spell-description',
+    levels: ['PK', 'K', '1'],
+    subject: 'reading',
+    defaultCover: {
+      kind: 'emoji',
+      emoji: '🎙️',
+      gradient: ['#c4b5fd', '#6366f1'],
+    },
+  },
+  {
     id: 'spot-all',
     titleKey: 'spot-all',
     descriptionKey: 'spot-all-description',

--- a/src/games/speak-spell/SpeakSpell.tsx
+++ b/src/games/speak-spell/SpeakSpell.tsx
@@ -1,0 +1,320 @@
+import { useNavigate } from '@tanstack/react-router';
+import { Mic, MicOff, Volume2 } from 'lucide-react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useSpeechRecognition } from './useSpeechRecognition';
+import type { SpeechResult } from './useSpeechRecognition';
+import type {
+  WordSpellConfig,
+  WordSpellRound,
+} from '@/games/word-spell/types';
+import { useSeenWordsStore } from '@/db/hooks/useSeenWordsStore';
+import { buildRoundOrder } from '@/games/build-round-order';
+import { useLibraryRounds } from '@/games/word-spell/useLibraryRounds';
+import { isSpeechInputAvailable } from '@/lib/speech/SpeechInput';
+import { cancelSpeech, speak } from '@/lib/speech/SpeechOutput';
+
+type RoundResult = 'correct' | 'incorrect' | null;
+
+interface SpeakSpellProps {
+  config: WordSpellConfig;
+  seed?: string;
+}
+
+const FEEDBACK_DELAY_MS = 1500;
+
+const SpeakSpellRound = ({
+  round,
+  onCorrect,
+  ttsEnabled,
+}: {
+  round: WordSpellRound;
+  onCorrect: () => void;
+  ttsEnabled: boolean;
+}) => {
+  const [roundResult, setRoundResult] = useState<RoundResult>(null);
+  const [lastResult, setLastResult] = useState<SpeechResult | null>(
+    null,
+  );
+  const targetWord = round.word.trim().toLowerCase();
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  const handleSpeechResult = useCallback(
+    (speechResult: SpeechResult) => {
+      const matched = speechResult.alternatives.some(
+        (alt) => alt.toLowerCase() === targetWord,
+      );
+      setLastResult(speechResult);
+
+      if (matched) {
+        setRoundResult('correct');
+        feedbackTimerRef.current = setTimeout(
+          onCorrect,
+          FEEDBACK_DELAY_MS,
+        );
+      } else {
+        setRoundResult('incorrect');
+        feedbackTimerRef.current = setTimeout(() => {
+          setRoundResult(null);
+          setLastResult(null);
+        }, FEEDBACK_DELAY_MS);
+      }
+    },
+    [targetWord, onCorrect],
+  );
+
+  const { isListening, start, stop, reset } = useSpeechRecognition({
+    lang: 'en-AU',
+    maxAlternatives: 10,
+    timeoutMs: 5000,
+    onResult: handleSpeechResult,
+  });
+
+  const handleMicClick = () => {
+    if (isListening) {
+      stop();
+    } else {
+      cancelSpeech();
+      if (feedbackTimerRef.current) {
+        clearTimeout(feedbackTimerRef.current);
+        feedbackTimerRef.current = null;
+      }
+      setRoundResult(null);
+      setLastResult(null);
+      reset();
+      start();
+    }
+  };
+
+  const handleSpeak = () => {
+    cancelSpeech();
+    speak(round.word);
+  };
+
+  const hasEmoji = Boolean(round.emoji?.trim());
+  const hasImage = Boolean(round.image);
+
+  return (
+    <div className="flex w-full max-w-md flex-col items-center gap-8 px-4 py-8">
+      <div className="flex flex-col items-center gap-4">
+        {hasEmoji ? (
+          <button
+            type="button"
+            onClick={handleSpeak}
+            className="rounded-2xl bg-white/80 p-4 shadow-lg active:scale-95"
+            aria-label={`${round.word} — tap to hear`}
+          >
+            <span className="block text-[7rem] leading-none select-none">
+              {round.emoji}
+            </span>
+          </button>
+        ) : hasImage ? (
+          <button
+            type="button"
+            onClick={handleSpeak}
+            className="overflow-hidden rounded-2xl shadow-lg active:scale-95"
+            aria-label={`${round.word} — tap to hear`}
+          >
+            <img
+              src={round.image}
+              alt={round.word}
+              className="h-40 w-40 object-cover"
+            />
+          </button>
+        ) : null}
+
+        {ttsEnabled ? (
+          <button
+            type="button"
+            onClick={handleSpeak}
+            className="flex size-14 items-center justify-center rounded-full bg-blue-500 text-white shadow-md active:scale-95"
+            aria-label="Hear the word"
+          >
+            <Volume2 size={24} />
+          </button>
+        ) : null}
+      </div>
+
+      <p className="text-center text-3xl font-bold tracking-wide text-foreground">
+        {round.word}
+      </p>
+
+      <button
+        type="button"
+        onClick={handleMicClick}
+        disabled={roundResult === 'correct'}
+        className={`flex h-24 w-24 items-center justify-center rounded-full shadow-xl transition-all active:scale-95 ${
+          isListening
+            ? 'animate-pulse bg-red-500 text-white'
+            : roundResult === 'correct'
+              ? 'bg-green-500 text-white'
+              : roundResult === 'incorrect'
+                ? 'bg-orange-400 text-white'
+                : 'bg-indigo-500 text-white hover:bg-indigo-600'
+        }`}
+        aria-label={isListening ? 'Stop listening' : 'Start listening'}
+      >
+        {isListening ? <Mic size={40} /> : <MicOff size={40} />}
+      </button>
+
+      <p
+        className={`text-center text-lg font-semibold ${
+          roundResult === 'correct'
+            ? 'text-green-600'
+            : roundResult === 'incorrect'
+              ? 'text-orange-500'
+              : isListening
+                ? 'text-red-500'
+                : 'text-muted-foreground'
+        }`}
+      >
+        {isListening
+          ? 'Listening…'
+          : roundResult === 'correct'
+            ? 'Correct!'
+            : roundResult === 'incorrect'
+              ? `Try again! (heard: "${lastResult?.transcript ?? ''}")`
+              : 'Tap the microphone and say the word'}
+      </p>
+
+      {lastResult && roundResult === 'incorrect' ? (
+        <p className="text-center text-xs text-muted-foreground">
+          Alternatives: {lastResult.alternatives.join(', ')}
+        </p>
+      ) : null}
+    </div>
+  );
+};
+
+export const SpeakSpell = ({ config, seed }: SpeakSpellProps) => {
+  const navigate = useNavigate();
+  const seenWordsStore = useSeenWordsStore();
+  const [roundIndex, setRoundIndex] = useState(0);
+  const [sessionEpoch, setSessionEpoch] = useState(0);
+  const [gameOver, setGameOver] = useState(false);
+
+  const sampleSeed = useMemo(
+    () => `${seed}-epoch-${sessionEpoch}`,
+    [seed, sessionEpoch],
+  );
+
+  const { rounds: resolvedRounds, isLoading } = useLibraryRounds(
+    config,
+    sampleSeed,
+    seenWordsStore,
+  );
+
+  const roundOrder = useMemo(() => {
+    void sessionEpoch;
+    return buildRoundOrder(
+      resolvedRounds.length,
+      config.roundsInOrder === true,
+      seed,
+    );
+  }, [resolvedRounds.length, config.roundsInOrder, seed, sessionEpoch]);
+
+  const totalRounds = roundOrder.length;
+  const configRoundIndex = roundOrder[roundIndex];
+  const currentRound =
+    configRoundIndex === undefined
+      ? undefined
+      : resolvedRounds[configRoundIndex];
+
+  const handleCorrect = useCallback(() => {
+    if (roundIndex + 1 >= totalRounds) {
+      setGameOver(true);
+    } else {
+      setRoundIndex((i) => i + 1);
+    }
+  }, [roundIndex, totalRounds]);
+
+  const handlePlayAgain = () => {
+    setRoundIndex(0);
+    setGameOver(false);
+    setSessionEpoch((e) => e + 1);
+  };
+
+  const handleHome = () => {
+    void navigate({ to: '/$locale', params: { locale: 'en' } });
+  };
+
+  if (!isSpeechInputAvailable()) {
+    return (
+      <div className="flex min-h-[300px] w-full flex-col items-center justify-center gap-4 text-foreground">
+        <MicOff size={48} className="text-muted-foreground" />
+        <p className="text-lg font-semibold">
+          Speech recognition is not available
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Please use Chrome or Edge for speech recognition support.
+        </p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        className="flex min-h-[200px] w-full items-center justify-center text-foreground"
+      >
+        Loading words…
+      </div>
+    );
+  }
+
+  if (!currentRound && !gameOver) {
+    return (
+      <div
+        role="alert"
+        className="flex min-h-[200px] w-full flex-col items-center justify-center gap-2 text-muted-foreground"
+      >
+        <p>No words matched the current filter.</p>
+      </div>
+    );
+  }
+
+  if (gameOver) {
+    return (
+      <div className="flex min-h-[400px] w-full flex-col items-center justify-center gap-6 text-foreground">
+        <span className="text-[6rem] leading-none">🎉</span>
+        <p className="text-2xl font-bold">Great job!</p>
+        <p className="text-muted-foreground">
+          You completed all {totalRounds} words!
+        </p>
+        <div className="flex gap-4">
+          <button
+            type="button"
+            onClick={handlePlayAgain}
+            className="rounded-xl bg-indigo-500 px-6 py-3 text-lg font-semibold text-white shadow-md hover:bg-indigo-600 active:scale-95"
+          >
+            Play Again
+          </button>
+          <button
+            type="button"
+            onClick={handleHome}
+            className="rounded-xl bg-gray-200 px-6 py-3 text-lg font-semibold text-gray-700 shadow-md hover:bg-gray-300 active:scale-95"
+          >
+            Home
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="game-container flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-indigo-50 to-white">
+      <div className="mb-4 text-sm text-muted-foreground">
+        {roundIndex + 1} / {totalRounds}
+      </div>
+
+      <SpeakSpellRound
+        key={`${sessionEpoch}-${roundIndex}`}
+        round={currentRound!}
+        onCorrect={handleCorrect}
+        ttsEnabled={config.ttsEnabled}
+      />
+    </div>
+  );
+};

--- a/src/games/speak-spell/useSpeechRecognition.ts
+++ b/src/games/speak-spell/useSpeechRecognition.ts
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  createSpeechRecognition,
+  isSpeechInputAvailable,
+} from '@/lib/speech/SpeechInput';
+
+export interface SpeechResult {
+  transcript: string;
+  alternatives: string[];
+}
+
+interface UseSpeechRecognitionOptions {
+  lang?: string;
+  maxAlternatives?: number;
+  timeoutMs?: number;
+  onResult?: (result: SpeechResult) => void;
+}
+
+interface UseSpeechRecognitionReturn {
+  isListening: boolean;
+  isAvailable: boolean;
+  result: SpeechResult | null;
+  start: () => void;
+  stop: () => void;
+  reset: () => void;
+}
+
+export const useSpeechRecognition = ({
+  lang = 'en-AU',
+  maxAlternatives = 5,
+  timeoutMs = 3000,
+  onResult,
+}: UseSpeechRecognitionOptions = {}): UseSpeechRecognitionReturn => {
+  const [isListening, setIsListening] = useState(false);
+  const [result, setResult] = useState<SpeechResult | null>(null);
+  const recognitionRef = useRef<ReturnType<
+    typeof createSpeechRecognition
+  > | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onResultRef = useRef(onResult);
+  useEffect(() => {
+    onResultRef.current = onResult;
+  }, [onResult]);
+
+  const cleanup = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    if (recognitionRef.current) {
+      recognitionRef.current.onresult = null;
+      recognitionRef.current.onend = null;
+      recognitionRef.current = null;
+    }
+  }, []);
+
+  const stop = useCallback(() => {
+    if (recognitionRef.current) {
+      try {
+        recognitionRef.current.stop();
+      } catch {
+        // already stopped
+      }
+    }
+    setIsListening(false);
+    cleanup();
+  }, [cleanup]);
+
+  const start = useCallback(() => {
+    setResult(null);
+    const recognition = createSpeechRecognition();
+    if (!recognition) return;
+
+    recognition.lang = lang;
+    recognition.continuous = false;
+    recognition.interimResults = false;
+    recognition.maxAlternatives = maxAlternatives;
+
+    recognition.onresult = (ev: unknown) => {
+      const event = ev as {
+        results: Array<{
+          length: number;
+          item: (j: number) => { transcript: string };
+        }>;
+      };
+      const resultList = event.results[0];
+      if (!resultList) return;
+
+      const alternatives: string[] = [];
+      for (let i = 0; i < resultList.length; i++) {
+        const alt = resultList.item(i);
+        if (alt.transcript) {
+          alternatives.push(alt.transcript.trim().toLowerCase());
+        }
+      }
+
+      const speechResult: SpeechResult = {
+        transcript: alternatives[0] ?? '',
+        alternatives,
+      };
+      setResult(speechResult);
+      setIsListening(false);
+      cleanup();
+      onResultRef.current?.(speechResult);
+    };
+
+    // eslint-disable-next-line unicorn/prefer-add-event-listener -- SpeechRecognitionLike only exposes .onerror
+    recognition.onerror = () => {
+      setIsListening(false);
+      cleanup();
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+
+    recognitionRef.current = recognition;
+    recognition.start();
+    setIsListening(true);
+
+    timeoutRef.current = setTimeout(() => {
+      stop();
+    }, timeoutMs);
+  }, [lang, maxAlternatives, timeoutMs, stop, cleanup]);
+
+  const reset = useCallback(() => {
+    setResult(null);
+  }, []);
+
+  return {
+    isListening,
+    isAvailable: isSpeechInputAvailable(),
+    result,
+    start,
+    stop,
+    reset,
+  };
+};

--- a/src/lib/i18n/locales/en/games.json
+++ b/src/lib/i18n/locales/en/games.json
@@ -3,6 +3,8 @@
   "word-spell-description": "Drag letter tiles to spell the word.",
   "number-match": "Match the Number!",
   "number-match-description": "Match numerals to groups by dragging tiles.",
+  "speak-spell": "Say It!",
+  "speak-spell-description": "Say the word out loud using your microphone.",
   "sort-numbers": "Count in Order",
   "sort-numbers-description": "Put the numbers in order!",
   "shell": {
@@ -24,6 +26,7 @@
     "word-spell": "Drag the letters into the boxes to spell the word. Tap the picture or the speaker to hear the word.",
     "number-match": "Drag the tiles to match each number. Tap the number to hear it.",
     "sort-numbers": "Put the numbers in order! Drag each number to the right place.",
+    "speak-spell": "Look at the picture and say the word out loud. Tap the microphone to start, then speak clearly!",
     "spot-all": "Tap every tile that shows the highlighted character. Some tiles look similar but are flipped or different — only tap the correct ones.",
     "lets-go": "Let's go!",
     "settings": "⚙️ Settings",

--- a/src/lib/i18n/locales/pt-BR/games.json
+++ b/src/lib/i18n/locales/pt-BR/games.json
@@ -3,6 +3,8 @@
   "word-spell-description": "Arraste as letras para soletrar a palavra mostrada na imagem.",
   "number-match": "Ache o Número!",
   "number-match-description": "Combine numerais com grupos arrastando as peças para o lugar certo.",
+  "speak-spell": "Fale!",
+  "speak-spell-description": "Diga a palavra em voz alta usando o microfone.",
   "sort-numbers": "Conte na Ordem",
   "sort-numbers-description": "Coloque os números em ordem do menor para o maior — ou do maior para o menor.",
   "shell": {
@@ -24,6 +26,7 @@
     "word-spell": "Arraste as letras para as caixas e forme a palavra. Toque na imagem ou no alto-falante para ouvir a palavra.",
     "number-match": "Arraste as peças para combinar cada número. Toque no número para ouvir.",
     "sort-numbers": "Coloque os números em ordem! Arraste cada número para o lugar certo.",
+    "speak-spell": "Olhe a imagem e diga a palavra em voz alta. Toque no microfone para começar e fale com clareza!",
     "spot-all": "Toque em cada peça que mostra o caractere destacado. Algumas peças parecem similares mas estão invertidas ou são diferentes — toque apenas nas corretas.",
     "lets-go": "Vamos lá!",
     "advanced": "Avançado",

--- a/src/lib/speech/SpeechInput.ts
+++ b/src/lib/speech/SpeechInput.ts
@@ -2,6 +2,7 @@ export type SpeechRecognitionLike = {
   lang: string;
   continuous: boolean;
   interimResults: boolean;
+  maxAlternatives: number;
   onresult: ((ev: unknown) => void) | null;
   onerror: ((ev: unknown) => void) | null;
   onend: (() => void) | null;

--- a/src/routes/$locale/_app/game/$gameId.tsx
+++ b/src/routes/$locale/_app/game/$gameId.tsx
@@ -35,6 +35,7 @@ import { generateSortRounds } from '@/games/sort-numbers/build-sort-round';
 import { isRoundsStale } from '@/games/sort-numbers/is-rounds-stale';
 import { resolveSimpleConfig } from '@/games/sort-numbers/resolve-simple-config';
 import { SortNumbers } from '@/games/sort-numbers/SortNumbers/SortNumbers';
+import { SpeakSpell } from '@/games/speak-spell/SpeakSpell';
 import { resolveSimpleConfig as resolveSpotAllSimpleConfig } from '@/games/spot-all/resolve-simple-config';
 import { SpotAll } from '@/games/spot-all/SpotAll/SpotAll';
 import { defaultSelection } from '@/games/word-spell/level-unit-selection';
@@ -596,6 +597,132 @@ const WordSpellGameBody = ({
   );
 };
 
+const SpeakSpellGameBody = ({
+  gameId,
+  sessionId,
+  seed,
+  gameSpecificConfig,
+  customGameId,
+  customGameName,
+  customGameColor,
+  customGameCover,
+  debug,
+}: {
+  gameId: string;
+  sessionId: string;
+  seed: string;
+  gameSpecificConfig: Record<string, unknown> | null;
+  customGameId: string | null;
+  customGameName: string | null;
+  customGameColor: string | null;
+  customGameCover: Cover | null;
+  debug: boolean;
+}): JSX.Element => {
+  const { t } = useTranslation('games');
+  const {
+    save,
+    update,
+    remove,
+    customGames,
+    persistLastSessionConfig,
+  } = useCustomGames();
+  const { isBookmarked, toggle } = useBookmarks();
+  const bookmarkTarget = customGameId
+    ? ({ targetType: 'customGame', targetId: customGameId } as const)
+    : ({ targetType: 'game', targetId: gameId } as const);
+  const navigate = useNavigate({ from: '/$locale/game/$gameId' });
+  const existingCustomGameNames = useMemo(
+    () =>
+      customGames.filter((d) => d.gameId === gameId).map((d) => d.name),
+    [customGames, gameId],
+  );
+  const cfg = useMemo(
+    () => resolveWordSpellConfig(gameSpecificConfig),
+    [gameSpecificConfig],
+  );
+  const [showInstructions, setShowInstructions] = useState(true);
+
+  const debugPanel = debug ? (
+    <DebugPanel
+      gameId={gameId}
+      resolvedConfig={cfg as unknown as Record<string, unknown>}
+      rawSavedConfig={gameSpecificConfig}
+      customGame={{
+        id: customGameId,
+        name: customGameName,
+        color: customGameColor,
+        cover: customGameCover,
+      }}
+      session={{
+        sessionId,
+        seed,
+        draftState: null,
+        persistedContent: null,
+      }}
+      rounds={cfg.rounds as unknown[]}
+    />
+  ) : null;
+
+  if (showInstructions) {
+    return (
+      <>
+        <InstructionsOverlay
+          text={t('instructions.speak-spell')}
+          onStart={() => setShowInstructions(false)}
+          ttsEnabled={cfg.ttsEnabled}
+          gameTitle={t('speak-spell')}
+          gameId={gameId}
+          cover={customGameCover ?? undefined}
+          customGameId={customGameId ?? undefined}
+          customGameName={customGameName ?? undefined}
+          customGameColor={
+            (customGameColor ?? undefined) as GameColorKey | undefined
+          }
+          config={cfg as unknown as Record<string, unknown>}
+          onConfigChange={() => {}}
+          onSaveCustomGame={async ({ name, color, config, cover }) =>
+            save({ gameId, name, color, config, cover })
+          }
+          onUpdateCustomGame={
+            customGameId
+              ? async (name, config, extras) => {
+                  await update(customGameId, config, name, extras);
+                }
+              : undefined
+          }
+          onDeleteCustomGame={
+            customGameId
+              ? async (id) => {
+                  await remove(id);
+                  await navigate({
+                    search: (prev) => ({
+                      ...prev,
+                      configId: undefined,
+                    }),
+                  });
+                }
+              : undefined
+          }
+          existingCustomGameNames={existingCustomGameNames}
+          isBookmarked={isBookmarked(bookmarkTarget)}
+          onToggleBookmark={() => void toggle(bookmarkTarget)}
+          onPersistLastSession={(c) =>
+            void persistLastSessionConfig(gameId, c)
+          }
+        />
+        {debugPanel}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SpeakSpell config={cfg} seed={seed} />
+      {debugPanel}
+    </>
+  );
+};
+
 const NumberMatchGameBody = ({
   gameId,
   sessionId,
@@ -1085,6 +1212,22 @@ const GameBody = ({
         customGameColor={customGameColor}
         customGameCover={customGameCover}
         persistedContent={persistedContent}
+        debug={debug}
+      />
+    );
+  }
+
+  if (gameId === 'speak-spell') {
+    return (
+      <SpeakSpellGameBody
+        gameId={gameId}
+        sessionId={sessionId}
+        seed={seed}
+        gameSpecificConfig={gameSpecificConfig}
+        customGameId={customGameId}
+        customGameName={customGameName}
+        customGameColor={customGameColor}
+        customGameCover={customGameCover}
         debug={debug}
       />
     );

--- a/src/routes/$locale/_app/game/$gameId.tsx
+++ b/src/routes/$locale/_app/game/$gameId.tsx
@@ -636,10 +636,14 @@ const SpeakSpellGameBody = ({
       customGames.filter((d) => d.gameId === gameId).map((d) => d.name),
     [customGames, gameId],
   );
-  const cfg = useMemo(
+  const initial = useMemo(
     () => resolveWordSpellConfig(gameSpecificConfig),
     [gameSpecificConfig],
   );
+  const [cfg, setCfg] = useState(initial);
+  useEffect(() => {
+    setCfg(initial);
+  }, [initial]);
   const [showInstructions, setShowInstructions] = useState(true);
 
   const debugPanel = debug ? (
@@ -679,7 +683,7 @@ const SpeakSpellGameBody = ({
             (customGameColor ?? undefined) as GameColorKey | undefined
           }
           config={cfg as unknown as Record<string, unknown>}
-          onConfigChange={() => {}}
+          onConfigChange={(c) => setCfg(resolveWordSpellConfig(c))}
           onSaveCustomGame={async ({ name, color, config, cover }) =>
             save({ gameId, name, color, config, cover })
           }


### PR DESCRIPTION
## Summary

- Adds "Say It!" (`speak-spell`) game — a speech recognition variant of WordSpell
- Player sees a picture/emoji prompt, taps a mic button, and speaks the word
- Uses Web Speech API (`SpeechRecognition`) with `maxAlternatives: 10` for fuzzy matching
- Reuses WordSpell's `useLibraryRounds` for word sourcing and `speak()` for TTS playback
- Registers in game catalog, adds i18n keys (en + pt-BR), wires into game router

## Prototype notes

This is a rapid prototype for a live demo — intentionally minimal:
- No XState machine (pure React state)
- No custom config UI (reuses WordSpell config via `resolveWordSpellConfig`)
- `InstructionsOverlay` `onConfigChange` is a no-op
- Debug panel shows speech alternatives in dev

## Test plan

- [ ] Open `/en/game/speak-spell` in Chrome (Speech API requires Chrome)
- [ ] Grant microphone permission
- [ ] Tap mic → speak the shown word → verify correct/incorrect feedback
- [ ] Verify TTS plays the word on tap
- [ ] Test "Play Again" and "Home" buttons
- [ ] Verify game appears on home screen catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/403/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/403/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/403#issuecomment-)
<!-- /preview-urls -->



