### PR TITLE
fix: advanced config modal reverts wrongTileBehavior to default

### DIFF
--- a/src/components/AdvancedConfigModal.test.tsx
+++ b/src/components/AdvancedConfigModal.test.tsx
@@ -429,4 +429,41 @@ describe('AdvancedConfigModal', () => {
     );
     expect(screen.queryByLabelText(/distractor count/i)).toBeNull();
   });
+
+  it('stamps configMode: "advanced" on live field changes so the route resolver treats them as advanced config', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <AdvancedConfigModal
+        open
+        onOpenChange={() => {}}
+        gameId="word-spell"
+        mode={{ kind: 'default' }}
+        value={draftFor({
+          name: 'Test',
+          config: {
+            configMode: 'simple',
+            wrongTileBehavior: 'lock-manual',
+            inputMethod: 'drag',
+          },
+        })}
+        onChange={onChange}
+        onCancel={() => {}}
+        onSaveNew={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    const select = screen.getByLabelText(/wrong tile behaviour/i);
+    await user.selectOptions(select, 'reject');
+
+    const configPatch = onChange.mock.calls.find(
+      (args) => args[0]?.config !== undefined,
+    );
+    expect(configPatch).toBeDefined();
+
+    expect(configPatch![0].config).toEqual(
+      expect.objectContaining({ configMode: 'advanced' }),
+    );
+  });
 });

--- a/src/components/AdvancedConfigModal.tsx
+++ b/src/components/AdvancedConfigModal.tsx
@@ -221,13 +221,21 @@ export const AdvancedConfigModal = ({
           {HeaderRenderer && (
             <HeaderRenderer
               config={value.config}
-              onChange={(next) => onChange({ config: next })}
+              onChange={(next) =>
+                onChange({
+                  config: { ...next, configMode: 'advanced' },
+                })
+              }
             />
           )}
           <ConfigFormFields
             fields={fields}
             config={value.config}
-            onChange={(next) => onChange({ config: next })}
+            onChange={(next) =>
+              onChange({
+                config: { ...next, configMode: 'advanced' },
+              })
+            }
           />
 
           {errorMessage && (


### PR DESCRIPTION
## Summary

- **Bug:** Changing `wrongTileBehavior` (or any field) in the Advanced Config Modal had no effect — the selection immediately reverted to `lock-manual`.
- **Root cause:** The modal's live `onChange` handler passed config with `configMode: 'simple'` to the route's resolve function, which re-routed it through the simple resolver that hardcodes `wrongTileBehavior: 'lock-manual'`. The save path (`buildPayload`) already stamped `configMode: 'advanced'`, but the live editing path did not.
- **Fix:** Stamp `configMode: 'advanced'` on both `ConfigFormFields` and `HeaderRenderer` onChange handlers in `AdvancedConfigModal.tsx`, matching what `buildPayload` already does.
- **Affected games:** WordSpell, SortNumbers (their simple resolvers hardcode `wrongTileBehavior`). NumberMatch was unaffected.

## Test plan

- [x] Regression test: `AdvancedConfigModal.test.tsx` — new test confirms live field changes stamp `configMode: 'advanced'`
- [x] All 18 AdvancedConfigModal tests pass
- [x] All 45 InstructionsOverlay tests pass (no regression)
- [x] All 15 resolveWordSpellConfig + mode-default-invariant tests pass
- [x] All 83 pre-push related tests pass
- [ ] Manual: open WordSpell → Advanced Settings → change "Wrong tile behaviour" to "reject" → save → verify it sticks
- [ ] Manual: repeat for SortNumbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/404/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/404/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/404#issuecomment-)
<!-- /preview-urls -->
