### PR TITLE
feat(analytics): inline GA4 with consent banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Google Analytics 4 Measurement ID
+#
+# Production: set via GitHub repository secret VITE_GA_MEASUREMENT_ID
+#   (consumed by .github/workflows/deploy.yml during build)
+#
+# Local dev: keep empty to skip GA entirely
+#   (no script loaded, no consent banner shown).
+#   To test the GA flow locally, copy this file to .env.local and set:
+#     VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+#   (.env.local is gitignored)
+VITE_GA_MEASUREMENT_ID=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,6 +81,7 @@ jobs:
           VITE_ONEDRIVE_CLIENT_ID: ${{ secrets.VITE_ONEDRIVE_CLIENT_ID }}
           VITE_CF_WORKER_URL: ${{ secrets.VITE_CF_WORKER_URL }}
           VITE_ANALYTICS_PROVIDER: ${{ vars.VITE_ANALYTICS_PROVIDER }}
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
 
       - name: Copy shell to index.html
         run: cp dist/client/_shell.html dist/client/index.html

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -298,6 +298,12 @@ Analytics provider selection is deferred. The requirement is to build an **analy
 
 **Recommendation**: Implement a `AnalyticsAdapter` interface. Ship with a no-op implementation. Connect a provider via config without touching core logic. See `docs/architecture.md` for the interface spec.
 
+> **Spec Delta (2026-05-25): v1 ships inline GA4, not `AnalyticsAdapter`.**
+>
+> Trade-off: simpler implementation now (~150 lines vs ~300 for the abstraction), refactor cost deferred until a second provider is needed. The PRD's privacy concerns about GA4 (Low rating, blocked by ~30–40% of users) are partially mitigated by a consent banner that defaults to opt-out (no script load until the user clicks Accept).
+>
+> Tracked in [#415](https://github.com/leocaseiro/base-skill/issues/415). Revisit when: a second provider becomes needed, the kids' app privacy story requires a swap, or call sites accumulate enough to benefit from a typed interface.
+
 ### 5.15 Extension Points
 
 The app exposes an **event bus and plugin hook system** so future premium features (from separate private repos) can:

--- a/src/components/ConsentBanner.test.tsx
+++ b/src/components/ConsentBanner.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConsentBanner } from './ConsentBanner';
+import * as ga4 from '@/lib/analytics/ga4';
+
+vi.mock('@/lib/analytics/ga4', async (importOriginal) => {
+  const original =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- vitest mock factory
+    await importOriginal<typeof import('@/lib/analytics/ga4')>();
+  return {
+    ...original,
+    isAnalyticsEnabled: vi.fn(),
+  };
+});
+
+const enabledMock = vi.mocked(ga4.isAnalyticsEnabled);
+const STORAGE_KEY = 'baseskill:analytics-consent';
+
+describe('ConsentBanner', () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear();
+    enabledMock.mockReset();
+  });
+
+  it('renders nothing when analytics is disabled', () => {
+    enabledMock.mockReturnValue(false);
+    render(<ConsentBanner />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders nothing when consent is already granted', () => {
+    enabledMock.mockReturnValue(true);
+    globalThis.localStorage.setItem(STORAGE_KEY, 'granted');
+    render(<ConsentBanner />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders nothing when consent is denied', () => {
+    enabledMock.mockReturnValue(true);
+    globalThis.localStorage.setItem(STORAGE_KEY, 'denied');
+    render(<ConsentBanner />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders banner when analytics enabled and consent unset', () => {
+    enabledMock.mockReturnValue(true);
+    render(<ConsentBanner />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Accept' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Reject' }),
+    ).toBeInTheDocument();
+  });
+
+  it('clicking Accept stores "granted" and hides the banner', async () => {
+    const user = userEvent.setup();
+    enabledMock.mockReturnValue(true);
+    render(<ConsentBanner />);
+    await user.click(screen.getByRole('button', { name: 'Accept' }));
+    expect(globalThis.localStorage.getItem(STORAGE_KEY)).toBe(
+      'granted',
+    );
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('clicking Reject stores "denied" and hides the banner', async () => {
+    const user = userEvent.setup();
+    enabledMock.mockReturnValue(true);
+    render(<ConsentBanner />);
+    await user.click(screen.getByRole('button', { name: 'Reject' }));
+    expect(globalThis.localStorage.getItem(STORAGE_KEY)).toBe('denied');
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});

--- a/src/components/ConsentBanner.tsx
+++ b/src/components/ConsentBanner.tsx
@@ -1,0 +1,54 @@
+import { useSyncExternalStore } from 'react';
+import type { ConsentState } from '@/lib/analytics/consent';
+import { Button } from '@/components/ui/button';
+import {
+  getConsent,
+  setConsent,
+  subscribeConsent,
+} from '@/lib/analytics/consent';
+import { isAnalyticsEnabled } from '@/lib/analytics/ga4';
+
+const SSR_CONSENT: ConsentState = 'unset';
+
+export const ConsentBanner = () => {
+  const consent = useSyncExternalStore(
+    subscribeConsent,
+    getConsent,
+    () => SSR_CONSENT,
+  );
+
+  if (!isAnalyticsEnabled()) return null;
+  if (consent !== 'unset') return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Analytics consent"
+      className="fixed inset-x-0 bottom-0 z-50 border-t border-[var(--line)] bg-background p-4 shadow-lg"
+    >
+      <div className="mx-auto flex max-w-3xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-foreground">
+          BaseSkill uses Google Analytics to help us improve the app. No
+          personal data is collected.
+        </p>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => {
+              setConsent('denied');
+            }}
+          >
+            Reject
+          </Button>
+          <Button
+            onClick={() => {
+              setConsent('granted');
+            }}
+          >
+            Accept
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/lib/analytics/consent.test.ts
+++ b/src/lib/analytics/consent.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getConsent, setConsent, subscribeConsent } from './consent.js';
+
+const STORAGE_KEY = 'baseskill:analytics-consent';
+
+describe('consent', () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear();
+  });
+
+  describe('getConsent', () => {
+    it('returns "unset" when nothing stored', () => {
+      expect(getConsent()).toBe('unset');
+    });
+
+    it('returns "granted" when "granted" stored', () => {
+      globalThis.localStorage.setItem(STORAGE_KEY, 'granted');
+      expect(getConsent()).toBe('granted');
+    });
+
+    it('returns "denied" when "denied" stored', () => {
+      globalThis.localStorage.setItem(STORAGE_KEY, 'denied');
+      expect(getConsent()).toBe('denied');
+    });
+
+    it('returns "unset" when stored value is garbage', () => {
+      globalThis.localStorage.setItem(STORAGE_KEY, 'bogus');
+      expect(getConsent()).toBe('unset');
+    });
+  });
+
+  describe('setConsent', () => {
+    it('writes "granted" to localStorage', () => {
+      setConsent('granted');
+      expect(globalThis.localStorage.getItem(STORAGE_KEY)).toBe(
+        'granted',
+      );
+    });
+
+    it('writes "denied" to localStorage', () => {
+      setConsent('denied');
+      expect(globalThis.localStorage.getItem(STORAGE_KEY)).toBe(
+        'denied',
+      );
+    });
+  });
+
+  describe('subscribeConsent', () => {
+    it('fires listener after setConsent', () => {
+      const listener = vi.fn();
+      const unsub = subscribeConsent(listener);
+      setConsent('granted');
+      expect(listener).toHaveBeenCalledOnce();
+      unsub();
+    });
+
+    it('unsubscribe stops listener firing', () => {
+      const listener = vi.fn();
+      const unsub = subscribeConsent(listener);
+      unsub();
+      setConsent('granted');
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('multiple listeners all fire', () => {
+      const a = vi.fn();
+      const b = vi.fn();
+      subscribeConsent(a);
+      subscribeConsent(b);
+      setConsent('denied');
+      expect(a).toHaveBeenCalledOnce();
+      expect(b).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/lib/analytics/consent.ts
+++ b/src/lib/analytics/consent.ts
@@ -1,0 +1,33 @@
+export type ConsentState = 'granted' | 'denied' | 'unset';
+
+const STORAGE_KEY = 'baseskill:analytics-consent';
+const listeners = new Set<() => void>();
+
+export const getConsent = (): ConsentState => {
+  if (!('window' in globalThis)) return 'unset';
+  try {
+    const value = globalThis.localStorage.getItem(STORAGE_KEY);
+    return value === 'granted' || value === 'denied' ? value : 'unset';
+  } catch {
+    return 'unset';
+  }
+};
+
+export const setConsent = (value: 'granted' | 'denied'): void => {
+  if (!('window' in globalThis)) return;
+  try {
+    globalThis.localStorage.setItem(STORAGE_KEY, value);
+    for (const listener of listeners) listener();
+  } catch {
+    // localStorage unavailable (private mode, quota, blocked)
+  }
+};
+
+export const subscribeConsent = (
+  listener: () => void,
+): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};

--- a/src/lib/analytics/ga4.test.ts
+++ b/src/lib/analytics/ga4.test.ts
@@ -1,0 +1,92 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { isAnalyticsEnabled, loadGtag, trackPageView } from './ga4.js';
+
+describe('ga4', () => {
+  beforeEach(() => {
+    delete globalThis.dataLayer;
+    delete globalThis.gtag;
+    for (const script of document.querySelectorAll(
+      'script[data-ga-loaded]',
+    )) {
+      script.remove();
+    }
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('isAnalyticsEnabled', () => {
+    it('returns false when VITE_GA_MEASUREMENT_ID is empty', () => {
+      vi.stubEnv('VITE_GA_MEASUREMENT_ID', '');
+      expect(isAnalyticsEnabled()).toBe(false);
+    });
+
+    it('returns true when VITE_GA_MEASUREMENT_ID is set', () => {
+      vi.stubEnv('VITE_GA_MEASUREMENT_ID', 'G-TEST123');
+      expect(isAnalyticsEnabled()).toBe(true);
+    });
+  });
+
+  describe('loadGtag', () => {
+    it('no-ops when measurement ID is empty', () => {
+      vi.stubEnv('VITE_GA_MEASUREMENT_ID', '');
+      loadGtag();
+      expect(
+        document.querySelector('script[data-ga-loaded]'),
+      ).toBeNull();
+      expect(globalThis.gtag).toBeUndefined();
+    });
+
+    it('injects gtag script tag and initializes gtag/dataLayer', () => {
+      vi.stubEnv('VITE_GA_MEASUREMENT_ID', 'G-TEST123');
+      loadGtag();
+      const script = document.querySelector('script[data-ga-loaded]');
+      expect(script).not.toBeNull();
+      expect(script?.getAttribute('src')).toContain('id=G-TEST123');
+      expect(globalThis.gtag).toBeTypeOf('function');
+      expect(Array.isArray(globalThis.dataLayer)).toBe(true);
+    });
+
+    it('is idempotent across repeated calls', () => {
+      vi.stubEnv('VITE_GA_MEASUREMENT_ID', 'G-TEST123');
+      loadGtag();
+      loadGtag();
+      loadGtag();
+      const scripts = document.querySelectorAll(
+        'script[data-ga-loaded]',
+      );
+      expect(scripts).toHaveLength(1);
+    });
+
+    it('preserves an existing dataLayer if already on window', () => {
+      vi.stubEnv('VITE_GA_MEASUREMENT_ID', 'G-TEST123');
+      const existing: unknown[] = [{ pre: 'existing' }];
+      globalThis.dataLayer = existing;
+      loadGtag();
+      expect(globalThis.dataLayer).toBe(existing);
+    });
+  });
+
+  describe('trackPageView', () => {
+    it('does not throw when gtag is missing', () => {
+      expect(() => trackPageView('/foo')).not.toThrow();
+    });
+
+    it('calls gtag with page_view event when loaded', () => {
+      const gtagSpy = vi.fn();
+      globalThis.gtag = gtagSpy;
+      trackPageView('/some/path');
+      expect(gtagSpy).toHaveBeenCalledWith('event', 'page_view', {
+        page_path: '/some/path',
+      });
+    });
+  });
+});

--- a/src/lib/analytics/ga4.ts
+++ b/src/lib/analytics/ga4.ts
@@ -1,0 +1,38 @@
+declare global {
+  var dataLayer: unknown[] | undefined;
+  var gtag: ((...args: unknown[]) => void) | undefined;
+}
+
+const SCRIPT_MARKER_ATTR = 'data-ga-loaded';
+
+const getMeasurementId = (): string =>
+  import.meta.env.VITE_GA_MEASUREMENT_ID ?? '';
+
+export const isAnalyticsEnabled = (): boolean =>
+  getMeasurementId().length > 0;
+
+export const loadGtag = (): void => {
+  if (!('window' in globalThis)) return;
+  const id = getMeasurementId();
+  if (!id) return;
+  if (document.querySelector(`script[${SCRIPT_MARKER_ATTR}]`)) return;
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${id}`;
+  script.setAttribute(SCRIPT_MARKER_ATTR, '1');
+  document.head.append(script);
+
+  globalThis.dataLayer = globalThis.dataLayer ?? [];
+  globalThis.gtag = (...args: unknown[]): void => {
+    globalThis.dataLayer?.push(args);
+  };
+  globalThis.gtag('js', new Date());
+  globalThis.gtag('config', id);
+};
+
+export const trackPageView = (path: string): void => {
+  if (!('window' in globalThis)) return;
+  if (!globalThis.gtag) return;
+  globalThis.gtag('event', 'page_view', { page_path: path });
+};

--- a/src/lib/analytics/useAnalytics.test.tsx
+++ b/src/lib/analytics/useAnalytics.test.tsx
@@ -1,0 +1,99 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setConsent } from './consent.js';
+import * as ga4 from './ga4.js';
+import { useAnalytics } from './useAnalytics.js';
+
+type RouterSubscribe = (
+  event: string,
+  handler: (e: { toLocation: { pathname: string } }) => void,
+) => () => void;
+
+const noop = (): void => undefined;
+const subscribeMock = vi.fn<RouterSubscribe>(() => noop);
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({
+    state: { location: { pathname: '/current' } },
+    subscribe: subscribeMock,
+  }),
+}));
+
+vi.mock('./ga4.js', () => ({
+  isAnalyticsEnabled: vi.fn(),
+  loadGtag: vi.fn(),
+  trackPageView: vi.fn(),
+}));
+
+const enabledMock = vi.mocked(ga4.isAnalyticsEnabled);
+const loadGtagMock = vi.mocked(ga4.loadGtag);
+const trackPageViewMock = vi.mocked(ga4.trackPageView);
+
+describe('useAnalytics', () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear();
+    subscribeMock.mockClear().mockReturnValue(noop);
+    enabledMock.mockReset();
+    loadGtagMock.mockReset();
+    trackPageViewMock.mockReset();
+  });
+
+  it('does nothing when analytics is disabled', () => {
+    enabledMock.mockReturnValue(false);
+    setConsent('granted');
+    renderHook(() => {
+      useAnalytics();
+    });
+    expect(loadGtagMock).not.toHaveBeenCalled();
+    expect(subscribeMock).not.toHaveBeenCalled();
+    expect(trackPageViewMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when consent is not granted', () => {
+    enabledMock.mockReturnValue(true);
+    // consent stays 'unset' (default)
+    renderHook(() => {
+      useAnalytics();
+    });
+    expect(loadGtagMock).not.toHaveBeenCalled();
+    expect(subscribeMock).not.toHaveBeenCalled();
+    expect(trackPageViewMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when consent is denied', () => {
+    enabledMock.mockReturnValue(true);
+    setConsent('denied');
+    renderHook(() => {
+      useAnalytics();
+    });
+    expect(loadGtagMock).not.toHaveBeenCalled();
+    expect(subscribeMock).not.toHaveBeenCalled();
+  });
+
+  it('loads gtag, tracks current page, and subscribes to router when consent granted', () => {
+    enabledMock.mockReturnValue(true);
+    setConsent('granted');
+    renderHook(() => {
+      useAnalytics();
+    });
+    expect(loadGtagMock).toHaveBeenCalledOnce();
+    expect(trackPageViewMock).toHaveBeenCalledWith('/current');
+    expect(subscribeMock).toHaveBeenCalledWith(
+      'onResolved',
+      expect.any(Function),
+    );
+  });
+
+  it('subscriber fires trackPageView for new locations', () => {
+    enabledMock.mockReturnValue(true);
+    setConsent('granted');
+    renderHook(() => {
+      useAnalytics();
+    });
+    const [, handler] = subscribeMock.mock.calls[0]!;
+    (handler as (e: { toLocation: { pathname: string } }) => void)({
+      toLocation: { pathname: '/next' },
+    });
+    expect(trackPageViewMock).toHaveBeenCalledWith('/next');
+  });
+});

--- a/src/lib/analytics/useAnalytics.ts
+++ b/src/lib/analytics/useAnalytics.ts
@@ -1,0 +1,33 @@
+import { useRouter } from '@tanstack/react-router';
+import { useEffect, useSyncExternalStore } from 'react';
+import { getConsent, subscribeConsent } from './consent.js';
+import { isAnalyticsEnabled, loadGtag, trackPageView } from './ga4.js';
+import type { ConsentState } from './consent.js';
+
+const SSR_CONSENT: ConsentState = 'unset';
+
+export const useAnalytics = (): void => {
+  const router = useRouter();
+  const consent = useSyncExternalStore(
+    subscribeConsent,
+    getConsent,
+    () => SSR_CONSENT,
+  );
+
+  useEffect(() => {
+    if (!isAnalyticsEnabled()) return;
+    if (consent !== 'granted') return;
+
+    loadGtag();
+    trackPageView(router.state.location.pathname);
+
+    const unsubscribe = router.subscribe(
+      'onResolved',
+      ({ toLocation }) => {
+        trackPageView(toLocation.pathname);
+      },
+    );
+
+    return unsubscribe;
+  }, [consent, router]);
+};

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,8 +7,10 @@ import {
 import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools';
 
 import appCss from '../styles.css?url';
+import { ConsentBanner } from '@/components/ConsentBanner';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { Toaster } from '@/components/ui/sonner';
+import { useAnalytics } from '@/lib/analytics/useAnalytics';
 import { ServiceWorkerProvider } from '@/lib/service-worker/ServiceWorkerProvider';
 
 /**
@@ -32,33 +34,39 @@ const SPA_REDIRECT_SCRIPT = String.raw`(function(){try{var b=${JSON.stringify(im
 const THEME_INIT_SCRIPT =
   "(function(){try{var prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;var resolved=prefersDark?'dark':'light';var root=document.documentElement;root.classList.remove('light','dark');root.classList.add(resolved);root.removeAttribute('data-theme');root.style.colorScheme=resolved;}catch(e){}})();";
 
-const RootDocument = ({ children }: { children: React.ReactNode }) => (
-  <html lang="en" suppressHydrationWarning>
-    <head>
-      <script
-        dangerouslySetInnerHTML={{ __html: SPA_REDIRECT_SCRIPT }}
-      />
-      <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
-      <HeadContent />
-    </head>
-    <body className="font-sans antialiased">
-      <ErrorBoundary>
-        <ServiceWorkerProvider>{children}</ServiceWorkerProvider>
-      </ErrorBoundary>
-      <Toaster />
-      <TanStackDevtools
-        config={{ position: 'bottom-right' }}
-        plugins={[
-          {
-            name: 'Tanstack Router',
-            render: <TanStackRouterDevtoolsPanel />,
-          },
-        ]}
-      />
-      <Scripts />
-    </body>
-  </html>
-);
+const RootDocument = ({ children }: { children: React.ReactNode }) => {
+  useAnalytics();
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{ __html: SPA_REDIRECT_SCRIPT }}
+        />
+        <script
+          dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }}
+        />
+        <HeadContent />
+      </head>
+      <body className="font-sans antialiased">
+        <ErrorBoundary>
+          <ServiceWorkerProvider>{children}</ServiceWorkerProvider>
+        </ErrorBoundary>
+        <Toaster />
+        <ConsentBanner />
+        <TanStackDevtools
+          config={{ position: 'bottom-right' }}
+          plugins={[
+            {
+              name: 'Tanstack Router',
+              render: <TanStackRouterDevtoolsPanel />,
+            },
+          ]}
+        />
+        <Scripts />
+      </body>
+    </html>
+  );
+};
 
 export const Route = createRootRoute({
   head: () => ({

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_APP_VERSION: string;
+  readonly VITE_GA_MEASUREMENT_ID?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Ships Google Analytics 4 tracking gated by a consent banner. Six baby-step commits:

1. `cd0f08cd0` env var infrastructure (`VITE_GA_MEASUREMENT_ID` wired into deploy.yml + .env.example)
2. `dc78023c5` Spec Delta in PRD §5.14 justifying inline-over-adapter
3. `931ef11a8` `src/lib/analytics/{consent,ga4}.ts` pure modules + tests
4. `820d3e770` `useAnalytics` hook (consent + router subscription glue)
5. `a6a3b045d` `ConsentBanner` component (bottom-fixed Accept/Reject)
6. `5e453043a` `__root.tsx` mounts both

**Behaviour:**

- `VITE_GA_MEASUREMENT_ID` unset → banner hidden, no gtag script, no events. (Default in local dev.)
- `VITE_GA_MEASUREMENT_ID` set + consent `unset` → banner visible, no script yet.
- Banner Accept → consent `granted`, script loads, current + future page_views fire.
- Banner Reject → consent `denied`, script never loads.

## Spec Delta

PRD §5.14 specifies an `AnalyticsAdapter` interface for provider-swap. This PR ships **inline GA4 instead** — see the new callout in [docs/prd.md §5.14](docs/prd.md). Migration to the adapter pattern is tracked in [#415](https://github.com/leocaseiro/base-skill/issues/415); triggers to revisit are documented there.

## Test plan

- [x] `yarn test` — 1978 tests pass (28 new across the analytics surface)
- [x] `yarn typecheck` — clean
- [x] `yarn build` — production SPA build succeeds with new code
- [x] `yarn lint` — eslint + knip clean (actionlint not installed locally; runs in CI)
- [ ] Smoke test in dev: create `.env.local` with `VITE_GA_MEASUREMENT_ID=G-...`, run `yarn dev`, confirm banner appears, click Accept, verify Network tab loads `gtag/js`, verify GA4 Realtime shows the hit
- [ ] Production deploy: confirm GitHub secret `VITE_GA_MEASUREMENT_ID` is set (✓ already done by author), merge, verify deployed app loads gtag after consent

## Skip flags used

- `SKIP_LINT=1` on push — `actionlint` not installed in author's local toolchain. The deploy.yml change is a single env-var addition mirroring the existing `VITE_GOOGLE_CLIENT_ID` line. CI runs actionlint with the proper toolchain.

## Manual setup

GitHub repository secret `VITE_GA_MEASUREMENT_ID` (value: `G-EP8TL0HGH2`) — **already configured** by author.

## Follow-ups

- [#415](https://github.com/leocaseiro/base-skill/issues/415) — Refactor inline GA4 to `AnalyticsAdapter` (PRD-aligned migration)
- Banner copy not yet i18n'd — captured in #415 scope
- PR previews intentionally don't have the secret, so they won't fire GA events (good for not polluting production data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/416/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/416/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/416#issuecomment-)
<!-- /preview-urls -->
