### PR TITLE
fix(voice): correct first-load auto-speak voice (RxDB race + en-AU)

### DIFF
--- a/src/components/answer-game/InstructionsOverlay/InstructionsOverlay.test.tsx
+++ b/src/components/answer-game/InstructionsOverlay/InstructionsOverlay.test.tsx
@@ -26,6 +26,7 @@ import {
   destroyTestDatabase,
 } from '@/db/create-database';
 import { i18n } from '@/lib/i18n/i18n';
+import { speak } from '@/lib/speech/SpeechOutput';
 import { DbProvider } from '@/providers/DbProvider';
 import { ThemeRuntimeProvider } from '@/providers/ThemeRuntimeProvider';
 
@@ -50,6 +51,11 @@ vi.mock('sonner', () => ({
     error: vi.fn(),
     success: vi.fn(),
   },
+}));
+
+vi.mock('@/lib/speech/SpeechOutput', () => ({
+  speak: vi.fn(),
+  cancelSpeech: vi.fn(),
 }));
 
 let db: BaseSkillDatabase;
@@ -730,6 +736,24 @@ describe('InstructionsOverlay error handling', () => {
     expect(onStart).toHaveBeenCalled();
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('InstructionsOverlay auto-speak', () => {
+  it('reads the instructions once settings load, using the en-AU default lang', async () => {
+    await i18n.changeLanguage('en');
+    render(
+      <InstructionsOverlay
+        {...baseProps({ ttsEnabled: true, text: 'Read me' })}
+      />,
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(speak).toHaveBeenCalledWith(
+        'Read me',
+        expect.objectContaining({ lang: 'en-AU' }),
+      );
     });
   });
 });

--- a/src/components/answer-game/InstructionsOverlay/InstructionsOverlay.tsx
+++ b/src/components/answer-game/InstructionsOverlay/InstructionsOverlay.tsx
@@ -24,10 +24,8 @@ import {
 } from '@/games/config-fields-registry';
 import { resolveCover } from '@/games/cover';
 import { DEFAULT_GAME_COLOR, GAME_COLORS } from '@/lib/game-colors';
-import { safeGetVoices } from '@/lib/speech/safe-get-voices';
 import { cancelSpeech, speak } from '@/lib/speech/SpeechOutput';
-import { getSynth } from '@/lib/speech/synth-access';
-import { isVoiceAvailableInList } from '@/lib/speech/voices';
+import { resolveSpeechLang } from '@/lib/speech/voices';
 import { suggestCustomGameName } from '@/lib/suggest-custom-game-name';
 
 type HeaderActionsProps = {
@@ -137,7 +135,7 @@ export const InstructionsOverlay = ({
   onToggleBookmark,
 }: InstructionsOverlayProps): JSX.Element => {
   const { t, i18n } = useTranslation(['games', 'common']);
-  const { settings } = useSettings();
+  const { settings, isLoading } = useSettings();
   const navigate = useNavigate({
     from: '/$locale/game/$gameId',
   });
@@ -175,32 +173,31 @@ export const InstructionsOverlay = ({
     return;
   }, [saveDialogOpen]);
 
+  const spokenRef = useRef(false);
   useEffect(() => {
-    if (ttsEnabled) {
-      const preferredVoice = settings.preferredVoiceURI;
-      const synth = getSynth();
-      const preferredVoiceMissing =
-        preferredVoice !== undefined &&
-        synth !== undefined &&
-        !isVoiceAvailableInList(preferredVoice, safeGetVoices(synth));
-      // Silent-skip when the preferred voice can't be honored. This is an
-      // auto-trigger (instructions read on mount); the global
-      // VoiceUnavailableWarning banner already informs the user. Same
-      // policy as useGameTTS.speakPrompt (see F14).
-      if (!preferredVoiceMissing) {
-        speak(text, {
-          rate: settings.speechRate,
-          volume: settings.voiceVolume,
-          voiceName: preferredVoice,
-          lang: i18n.language,
-        });
-      }
-    }
-    return () => {
-      cancelSpeech();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on mount to speak instructions once
-  }, []);
+    if (!ttsEnabled) return;
+    // Wait for RxDB to hydrate the saved voice before reading the
+    // instructions — speaking earlier drops the preference and falls back to
+    // the OS default voice. When the saved voice is genuinely missing,
+    // resolveSpeechVoice (inside speak) picks the best on-device voice for the
+    // language instead of going silent. Speak only once.
+    if (isLoading) return;
+    if (spokenRef.current) return;
+    spokenRef.current = true;
+    speak(text, {
+      rate: settings.speechRate,
+      volume: settings.voiceVolume,
+      voiceName: settings.preferredVoiceURI,
+      lang: resolveSpeechLang({
+        activeLanguage: settings.activeLanguage,
+        uiLanguage: i18n.language,
+      }),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- speak instructions once, after settings finish loading
+  }, [isLoading, ttsEnabled]);
+
+  // Stop reading the instructions when the overlay unmounts (e.g. "Let's go").
+  useEffect(() => () => cancelSpeech(), []);
 
   const settingsColors = GAME_COLORS[draftApi.draft.color];
   const resolvedCover = resolveCover(

--- a/src/components/answer-game/useGameTTS.test.tsx
+++ b/src/components/answer-game/useGameTTS.test.tsx
@@ -177,7 +177,7 @@ describe('useGameTTS', () => {
       );
     });
 
-    it('speakPrompt is a no-op when preferred voice is unavailable (silent guard)', () => {
+    it('speakPrompt still calls speak() when preferred voice is unavailable (graceful fallback)', () => {
       settingsMock.preferredVoiceURI = 'FakeVoice';
       vi.stubGlobal('speechSynthesis', {
         getVoices: vi.fn().mockReturnValue([{ name: 'Samantha' }]),
@@ -188,8 +188,26 @@ describe('useGameTTS', () => {
         wrapper: createWrapper(ttsConfig),
       });
       result.current.speakPrompt('Some prompt');
-      expect(speak).not.toHaveBeenCalled();
       expect(showVoiceDialog).not.toHaveBeenCalled();
+      expect(speak).toHaveBeenCalledWith(
+        'Some prompt',
+        expect.objectContaining({
+          voiceName: 'FakeVoice',
+          lang: 'en-AU',
+        }),
+      );
+    });
+
+    it('speakPrompt resolves a region-less "en" UI language to en-AU', () => {
+      settingsMock.preferredVoiceURI = undefined;
+      const { result } = renderHook(() => useGameTTS(), {
+        wrapper: createWrapper(ttsConfig),
+      });
+      result.current.speakPrompt('What is this animal?');
+      expect(speak).toHaveBeenCalledWith(
+        'What is this animal?',
+        expect.objectContaining({ lang: 'en-AU' }),
+      );
     });
   });
 });

--- a/src/components/answer-game/useGameTTS.ts
+++ b/src/components/answer-game/useGameTTS.ts
@@ -5,7 +5,10 @@ import { useSettings } from '@/db/hooks/useSettings';
 import { safeGetVoices } from '@/lib/speech/safe-get-voices';
 import { isSpeechActive, speak } from '@/lib/speech/SpeechOutput';
 import { getSynth } from '@/lib/speech/synth-access';
-import { isVoiceAvailableInList } from '@/lib/speech/voices';
+import {
+  isVoiceAvailableInList,
+  resolveSpeechLang,
+} from '@/lib/speech/voices';
 import { useVoiceUnavailableDialog } from '@/providers/VoiceUnavailableDialogProvider';
 
 export interface GameTTS {
@@ -28,6 +31,13 @@ export const useGameTTS = (): GameTTS => {
   const { i18n } = useTranslation();
   const { show: showVoiceDialog } = useVoiceUnavailableDialog();
 
+  // en-AU by default (region-less 'en' maps to en-AU) so the spoken accent
+  // matches the project default instead of the browser's US fallback.
+  const lang = resolveSpeechLang({
+    activeLanguage: settings.activeLanguage,
+    uiLanguage: i18n.language,
+  });
+
   const speakTile = useCallback(
     (label: string) => {
       if (!config.ttsEnabled) return;
@@ -39,7 +49,7 @@ export const useGameTTS = (): GameTTS => {
         rate: settings.speechRate ?? 1,
         volume: settings.voiceVolume ?? 0.8,
         voiceName: settings.preferredVoiceURI,
-        lang: i18n.language,
+        lang,
       });
     },
     [
@@ -47,24 +57,23 @@ export const useGameTTS = (): GameTTS => {
       settings.speechRate,
       settings.voiceVolume,
       settings.preferredVoiceURI,
-      i18n.language,
+      lang,
     ],
   );
 
   const speakPrompt = useCallback(
     (text: string) => {
       if (!config.ttsEnabled) return;
-      if (
-        settings.preferredVoiceURI &&
-        !isPreferredVoiceAvailable(settings.preferredVoiceURI)
-      ) {
-        return;
-      }
+      // No availability bail: when the saved voice is missing,
+      // resolveSpeechVoice (inside speak) gracefully falls back to the best
+      // on-device voice for the language instead of going silent. The
+      // VoiceUnavailableWarning banner still tells the user their exact pick
+      // is unavailable.
       speak(text, {
         rate: settings.speechRate ?? 1,
         volume: settings.voiceVolume ?? 0.8,
         voiceName: settings.preferredVoiceURI,
-        lang: i18n.language,
+        lang,
       });
     },
     [
@@ -72,7 +81,7 @@ export const useGameTTS = (): GameTTS => {
       settings.speechRate,
       settings.voiceVolume,
       settings.preferredVoiceURI,
-      i18n.language,
+      lang,
     ],
   );
 
@@ -93,7 +102,7 @@ export const useGameTTS = (): GameTTS => {
           rate: settings.speechRate ?? 1,
           volume: settings.voiceVolume ?? 0.8,
           voiceName: settings.preferredVoiceURI,
-          lang: i18n.language,
+          lang,
         });
       };
       doSpeak(text);
@@ -103,8 +112,9 @@ export const useGameTTS = (): GameTTS => {
       settings.speechRate,
       settings.voiceVolume,
       settings.preferredVoiceURI,
-      i18n.language,
+      lang,
       showVoiceDialog,
+      i18n.language,
     ],
   );
 

--- a/src/components/answer-game/useRoundTTS.test.tsx
+++ b/src/components/answer-game/useRoundTTS.test.tsx
@@ -25,6 +25,16 @@ vi.mock('@/lib/audio/AudioFeedback', () => ({
   whenSoundEnds: vi.fn().mockImplementation(() => Promise.resolve()),
 }));
 
+const mockSettingsState = { isLoading: false };
+
+vi.mock('@/db/hooks/useSettings', () => ({
+  useSettings: () => ({
+    settings: {},
+    update: vi.fn(),
+    isLoading: mockSettingsState.isLoading,
+  }),
+}));
+
 const ttsConfig: AnswerGameConfig = {
   gameId: 'test',
   inputMethod: 'drag',
@@ -62,6 +72,7 @@ function createWrapper(config: AnswerGameConfig) {
 describe('useRoundTTS', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSettingsState.isLoading = false;
   });
 
   it('calls speakPrompt on mount with the prompt', async () => {
@@ -104,5 +115,23 @@ describe('useRoundTTS', () => {
     await waitFor(() => {
       expect(mockSpeakPrompt).toHaveBeenCalledWith('cat');
     });
+  });
+
+  it('waits for settings to load before speaking, then speaks once', async () => {
+    mockSettingsState.isLoading = true;
+    const { rerender } = renderHook(() => useRoundTTS('cat'), {
+      wrapper: createWrapper(ttsConfig),
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockSpeakPrompt).not.toHaveBeenCalled();
+
+    mockSettingsState.isLoading = false;
+    rerender();
+    await waitFor(() => {
+      expect(mockSpeakPrompt).toHaveBeenCalledWith('cat');
+    });
+    expect(mockSpeakPrompt).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/answer-game/useRoundTTS.ts
+++ b/src/components/answer-game/useRoundTTS.ts
@@ -1,15 +1,20 @@
 import { useEffect } from 'react';
 import { useAnswerGameContext } from './useAnswerGameContext';
 import { useGameTTS } from './useGameTTS';
+import { useSettings } from '@/db/hooks/useSettings';
 import { whenSoundEnds } from '@/lib/audio/AudioFeedback';
 
 export const useRoundTTS = (prompt: string): void => {
   const { roundIndex, config } = useAnswerGameContext();
   const { speakPrompt } = useGameTTS();
+  const { isLoading } = useSettings();
 
   useEffect(() => {
     if (!config.ttsEnabled) return;
     if (!prompt) return;
+    // Wait for RxDB so the saved voice is honoured. Speaking before settings
+    // hydrate drops the preferred voice and falls back to the OS default.
+    if (isLoading) return;
     let cancelled = false;
     void whenSoundEnds().then(() => {
       if (!cancelled) speakPrompt(prompt);
@@ -17,6 +22,6 @@ export const useRoundTTS = (prompt: string): void => {
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally omit speakPrompt and prompt to only re-speak on round change
-  }, [roundIndex, config.ttsEnabled]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- omit speakPrompt/prompt; re-speak only on round change or once settings finish loading
+  }, [roundIndex, config.ttsEnabled, isLoading]);
 };

--- a/src/db/hooks/useSettings.test.tsx
+++ b/src/db/hooks/useSettings.test.tsx
@@ -15,8 +15,8 @@ let db: BaseSkillDatabase | undefined;
 
 function useSettingsUnderTest() {
   const { isReady } = useRxDB();
-  const { settings, update } = useSettings();
-  return { isReady, settings, update };
+  const { settings, update, isLoading } = useSettings();
+  return { isReady, settings, update, isLoading };
 }
 
 const makeWrapper = (testDb: BaseSkillDatabase) => {
@@ -84,5 +84,30 @@ describe('useSettings', () => {
       expect(result.current.settings.speechRate).toBe(1.5);
       expect(result.current.settings.soundEffectsVolume).toBe(0.8);
     });
+  });
+
+  it('reports isLoading=false once the database is ready', async () => {
+    db = await createTestDatabase();
+    const { result } = renderHook(() => useSettingsUnderTest(), {
+      wrapper: makeWrapper(db),
+    });
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
+  it('stays isLoading=true while the database is still opening', () => {
+    const Pending = ({ children }: { children: ReactNode }) => {
+      const openDatabase = useCallback(
+        () => new Promise<BaseSkillDatabase>(() => {}),
+        [],
+      );
+      return (
+        <DbProvider openDatabase={openDatabase}>{children}</DbProvider>
+      );
+    };
+    const { result } = renderHook(() => useSettingsUnderTest(), {
+      wrapper: Pending,
+    });
+    expect(result.current.isLoading).toBe(true);
   });
 });

--- a/src/db/hooks/useSettings.ts
+++ b/src/db/hooks/useSettings.ts
@@ -33,9 +33,21 @@ function plainSettingsFromQuery(
   return doc as SettingsDoc;
 }
 
+// Distinct from `null` (which is a real "no settings doc" emission) so we can
+// tell "RxDB hasn't emitted yet" apart from "emitted, but no doc exists".
+const UNLOADED = Symbol('settings-unloaded');
+
+type RawDoc = SettingsDoc | { toJSON: () => SettingsDoc } | null;
+
 type UseSettingsResult = {
   settings: typeof DEFAULT_SETTINGS & Partial<SettingsDoc>;
   update: (patch: Partial<SettingsDoc>) => Promise<void>;
+  /**
+   * True while a DbProvider is present and the settings query has not emitted
+   * yet. False outside a provider (Storybook, partial tests) or after a
+   * db-open error, so callers that gate on it never wait forever.
+   */
+  isLoading: boolean;
 };
 
 export function useSettings(): UseSettingsResult {
@@ -52,11 +64,21 @@ export function useSettings(): UseSettingsResult {
     [db],
   );
 
-  const rawDoc = useRxQuery<
-    SettingsDoc | { toJSON: () => SettingsDoc } | null
-  >(query$, null);
+  const rawDoc = useRxQuery<RawDoc | typeof UNLOADED>(
+    query$,
+    ctx ? UNLOADED : null,
+  );
+
+  // Loading only while a provider is present, hasn't errored, and the query
+  // has not emitted yet. Outside a provider or on error we fall through to
+  // defaults so callers gating on this are never blocked forever.
+  const isLoading =
+    ctx !== null && ctx.error === undefined && rawDoc === UNLOADED;
 
   const settings = useMemo((): UseSettingsResult['settings'] => {
+    if (rawDoc === UNLOADED) {
+      return { ...DEFAULT_SETTINGS };
+    }
     const doc = plainSettingsFromQuery(rawDoc);
     if (doc === null) {
       return { ...DEFAULT_SETTINGS };
@@ -82,5 +104,5 @@ export function useSettings(): UseSettingsResult {
     }
   };
 
-  return { settings, update };
+  return { settings, update, isLoading };
 }

--- a/src/lib/speech/SpeechOutput.test.ts
+++ b/src/lib/speech/SpeechOutput.test.ts
@@ -73,9 +73,13 @@ describe('SpeechOutput', () => {
     expect(utterance.voice).toBe(danielVoice);
   });
 
-  it('speak leaves utterance.voice unset when the named voice is not found', () => {
-    const knownVoice = { name: 'Samantha' } as SpeechSynthesisVoice;
-    const synth = makeSynth([knownVoice]);
+  it('speak falls back to a target-language voice when the named voice is missing', () => {
+    const karen = {
+      name: 'Karen',
+      lang: 'en-AU',
+      localService: true,
+    } as SpeechSynthesisVoice;
+    const synth = makeSynth([karen]);
     vi.stubGlobal('speechSynthesis', synth);
     vi.stubGlobal(
       'SpeechSynthesisUtterance',
@@ -87,16 +91,45 @@ describe('SpeechOutput', () => {
         constructor(public text: string) {}
       },
     );
-    speak('hello', { voiceName: 'UnknownVoice' });
+    speak('hello', { voiceName: 'UnknownVoice', lang: 'en-AU' });
+    const utterance = synth.speak.mock.calls[0]?.[0] as {
+      voice: SpeechSynthesisVoice | null;
+    };
+    expect(utterance.voice).toBe(karen);
+  });
+
+  it('speak leaves utterance.voice unset when no voice matches the language', () => {
+    const pt = {
+      name: 'Luciana',
+      lang: 'pt-BR',
+      localService: true,
+    } as SpeechSynthesisVoice;
+    const synth = makeSynth([pt]);
+    vi.stubGlobal('speechSynthesis', synth);
+    vi.stubGlobal(
+      'SpeechSynthesisUtterance',
+      class {
+        voice: SpeechSynthesisVoice | null = null;
+        rate = 1;
+        volume = 1;
+        lang = '';
+        constructor(public text: string) {}
+      },
+    );
+    speak('hello', { voiceName: 'UnknownVoice', lang: 'en-AU' });
     const utterance = synth.speak.mock.calls[0]?.[0] as {
       voice: SpeechSynthesisVoice | null;
     };
     expect(utterance.voice).toBeNull();
   });
 
-  it('speak leaves utterance.voice unset when no voiceName is provided so the OS default applies', () => {
-    const danielVoice = { name: 'Daniel' } as SpeechSynthesisVoice;
-    const synth = makeSynth([danielVoice]);
+  it('speak picks the best target-language voice when no voiceName is provided', () => {
+    const karen = {
+      name: 'Karen',
+      lang: 'en-AU',
+      localService: true,
+    } as SpeechSynthesisVoice;
+    const synth = makeSynth([karen]);
     vi.stubGlobal('speechSynthesis', synth);
     vi.stubGlobal(
       'SpeechSynthesisUtterance',
@@ -112,7 +145,29 @@ describe('SpeechOutput', () => {
     const utterance = synth.speak.mock.calls[0]?.[0] as {
       voice: SpeechSynthesisVoice | null;
     };
-    expect(utterance.voice).toBeNull();
+    expect(utterance.voice).toBe(karen);
+  });
+
+  it('speak sets utterance.lang from options.lang', () => {
+    const synth = makeSynth([
+      { name: 'Karen', lang: 'en-AU' } as SpeechSynthesisVoice,
+    ]);
+    vi.stubGlobal('speechSynthesis', synth);
+    vi.stubGlobal(
+      'SpeechSynthesisUtterance',
+      class {
+        voice: SpeechSynthesisVoice | null = null;
+        rate = 1;
+        volume = 1;
+        lang = '';
+        constructor(public text: string) {}
+      },
+    );
+    speak('hello', { lang: 'en-AU' });
+    const utterance = synth.speak.mock.calls[0]?.[0] as {
+      lang: string;
+    };
+    expect(utterance.lang).toBe('en-AU');
   });
 
   it('speak applies rate and volume from SpeakOptions', () => {

--- a/src/lib/speech/SpeechOutput.ts
+++ b/src/lib/speech/SpeechOutput.ts
@@ -1,4 +1,5 @@
 import { safeGetVoices } from './safe-get-voices';
+import { resolveSpeechVoice } from './voices';
 
 export interface SpeakOptions {
   rate?: number;
@@ -24,10 +25,14 @@ function buildUtterance(
   if (options.rate !== undefined) u.rate = options.rate;
   if (options.volume !== undefined) u.volume = options.volume;
   if (options.lang !== undefined) u.lang = options.lang;
-  if (options.voiceName !== undefined) {
-    const voice = voices.find((v) => v.name === options.voiceName);
-    if (voice) u.voice = voice;
-  }
+  // Device-aware, AU-first resolution: exact saved voice, else best
+  // matching voice for the language, else leave unset (u.lang biases the
+  // browser's own fallback). Runs on the deferred voiceschanged path too.
+  const voice = resolveSpeechVoice(voices, {
+    preferredVoiceName: options.voiceName,
+    lang: options.lang ?? 'en-AU',
+  });
+  if (voice) u.voice = voice;
   return u;
 }
 

--- a/src/lib/speech/voices.test.ts
+++ b/src/lib/speech/voices.test.ts
@@ -6,6 +6,8 @@ import {
   groupVoicesByLanguage,
   isOnlineVoice,
   isVoiceAvailableInList,
+  resolveSpeechLang,
+  resolveSpeechVoice,
 } from './voices';
 
 describe('isOnlineVoice', () => {
@@ -180,5 +182,103 @@ describe('isVoiceAvailableInList', () => {
 
   it('returns false for an empty list', () => {
     expect(isVoiceAvailableInList('Samantha', [])).toBe(false);
+  });
+});
+
+describe('resolveSpeechVoice', () => {
+  const auLocal = {
+    name: 'Karen',
+    lang: 'en-AU',
+    localService: true,
+  } as SpeechSynthesisVoice;
+  const auOnline = {
+    name: 'Zoe',
+    lang: 'en-AU',
+    localService: false,
+  } as SpeechSynthesisVoice;
+  const gb = {
+    name: 'Daniel',
+    lang: 'en-GB',
+    localService: true,
+  } as SpeechSynthesisVoice;
+  const us = {
+    name: 'Samantha',
+    lang: 'en-US',
+    localService: true,
+  } as SpeechSynthesisVoice;
+  const pt = {
+    name: 'Luciana',
+    lang: 'pt-BR',
+    localService: true,
+  } as SpeechSynthesisVoice;
+
+  it('returns the exact saved voice by name when present (even if not the target lang)', () => {
+    expect(
+      resolveSpeechVoice([auLocal, us, pt], {
+        preferredVoiceName: 'Samantha',
+        lang: 'en-AU',
+      }),
+    ).toBe(us);
+  });
+
+  it('falls back to a target-language (en-AU) voice when the saved voice is missing', () => {
+    expect(
+      resolveSpeechVoice([auLocal, gb, us], {
+        preferredVoiceName: 'Nonexistent',
+        lang: 'en-AU',
+      }),
+    ).toBe(auLocal);
+  });
+
+  it('prefers a local (offline) voice over an online one for the target lang', () => {
+    expect(
+      resolveSpeechVoice([auOnline, auLocal], { lang: 'en-AU' }),
+    ).toBe(auLocal);
+  });
+
+  it('falls back to any English voice when no en-AU voice exists', () => {
+    const result = resolveSpeechVoice([gb, us, pt], { lang: 'en-AU' });
+    expect(result?.lang.startsWith('en')).toBe(true);
+  });
+
+  it('returns undefined when no voice matches the language family', () => {
+    expect(resolveSpeechVoice([pt], { lang: 'en-AU' })).toBeUndefined();
+  });
+
+  it('returns undefined for an empty voice list', () => {
+    expect(resolveSpeechVoice([], { lang: 'en-AU' })).toBeUndefined();
+  });
+
+  it('ignores voices with no lang when matching by language', () => {
+    const noLang = { name: 'Mystery' } as SpeechSynthesisVoice;
+    expect(
+      resolveSpeechVoice([noLang], { lang: 'en-AU' }),
+    ).toBeUndefined();
+  });
+});
+
+describe('resolveSpeechLang', () => {
+  it('uses activeLanguage when set', () => {
+    expect(
+      resolveSpeechLang({ activeLanguage: 'pt-BR', uiLanguage: 'en' }),
+    ).toBe('pt-BR');
+  });
+
+  it('maps a region-less "en" UI language to en-AU', () => {
+    expect(resolveSpeechLang({ uiLanguage: 'en' })).toBe('en-AU');
+  });
+
+  it('keeps a region-specific UI language', () => {
+    expect(resolveSpeechLang({ uiLanguage: 'pt-BR' })).toBe('pt-BR');
+  });
+
+  it('defaults to en-AU when nothing is provided', () => {
+    expect(resolveSpeechLang({})).toBe('en-AU');
+  });
+
+  it('prefers an explicit activeLanguage of en-AU over a bare "en" UI language', () => {
+    expect(
+      resolveSpeechLang({ activeLanguage: 'en-AU', uiLanguage: 'en' }),
+    ).toBe('en-AU');
   });
 });

--- a/src/lib/speech/voices.ts
+++ b/src/lib/speech/voices.ts
@@ -82,3 +82,74 @@ export function getVoiceByName(
   }
   return safeGetVoices(synth).find((v) => v.name === name);
 }
+
+export type ResolveVoiceOptions = {
+  /** The user's saved voice name (stored as preferredVoiceURI). */
+  preferredVoiceName?: string;
+  /** Target language for the utterance, e.g. 'en-AU'. */
+  lang: string;
+};
+
+// Voices can arrive without a usable `lang` at runtime (see safe-get-voices);
+// read it defensively so language matching never throws.
+const langOf = (voice: SpeechSynthesisVoice): string =>
+  (voice as { lang?: string }).lang ?? '';
+
+const localServiceFirst = (
+  a: SpeechSynthesisVoice,
+  b: SpeechSynthesisVoice,
+): number => Number(b.localService) - Number(a.localService);
+
+/**
+ * Pick the best voice for an utterance — device-aware and AU-first:
+ * 1. the exact saved voice by name, if present on this device;
+ * 2. else the best voice whose lang matches `lang` exactly (local first);
+ * 3. else the best voice in the same language family, e.g. en-* (local first);
+ * 4. else undefined — the caller leaves utterance.voice unset and relies on
+ *    utterance.lang to bias the browser's own fallback.
+ *
+ * Voice names differ across devices, so step 1 can miss; steps 2–3 keep the
+ * spoken accent on-target instead of dropping to the OS default (US) voice.
+ */
+export const resolveSpeechVoice = (
+  voices: SpeechSynthesisVoice[],
+  { preferredVoiceName, lang }: ResolveVoiceOptions,
+): SpeechSynthesisVoice | undefined => {
+  if (voices.length === 0) return undefined;
+
+  if (preferredVoiceName) {
+    const exact = voices.find((v) => v.name === preferredVoiceName);
+    if (exact) return exact;
+  }
+
+  const target = lang.toLowerCase();
+  const prefix = target.split('-')[0] ?? target;
+
+  const exactLang = voices
+    .filter((v) => langOf(v).toLowerCase() === target)
+    .toSorted(localServiceFirst);
+  if (exactLang[0]) return exactLang[0];
+
+  const family = voices
+    .filter((v) => langOf(v).toLowerCase().startsWith(prefix))
+    .toSorted(localServiceFirst);
+  return family[0];
+};
+
+/**
+ * Resolve the spoken language, defaulting to the project's en-AU.
+ * Chain: Settings.activeLanguage → UI language (when region-specific) → 'en-AU'.
+ * A region-less 'en' maps to 'en-AU' so the browser biases the Australian
+ * accent instead of falling back to a US default voice.
+ */
+export const resolveSpeechLang = ({
+  activeLanguage,
+  uiLanguage,
+}: {
+  activeLanguage?: string;
+  uiLanguage?: string;
+}): string => {
+  const candidate = activeLanguage ?? uiLanguage;
+  if (!candidate || candidate.toLowerCase() === 'en') return 'en-AU';
+  return candidate;
+};


### PR DESCRIPTION
## Summary

On a cold load of a game (e.g. `/en/game/word-spell`), the **auto-speak** (instructions overlay + first round) used the wrong voice — the OS default **US** voice instead of the Australian/saved voice. On-demand clicks (the speaker button) were always correct.

## Root cause

Auto-speak fires on mount, **before `useSettings` hydrates from RxDB**. At that moment `preferredVoiceURI` is still `undefined` and `lang` was the region-less `i18n.language` (`'en'`), so the browser picked its default `en` voice (US on macOS). Clicks worked only because they fire *after* hydration. #409 added voice-picker filtering + unavailability warnings but never touched the auto-speak timing or the `lang` resolution, so the merge didn't fix this.

## Changes (shared TTS path → fixes WordSpell, NumberMatch, SortNumbers, SpotAll)

- **`voices.ts`** — `resolveSpeechVoice` (AU-first: exact saved voice → best en-AU local → any English → OS default) + `resolveSpeechLang` (`activeLanguage → region-specific UI lang → 'en-AU'`; region-less `'en'` maps to `'en-AU'`).
- **`SpeechOutput.ts`** — `buildUtterance` resolves the voice via `resolveSpeechVoice` (also on the deferred `voiceschanged` path).
- **`useSettings.ts`** — exposes `isLoading` via an `UNLOADED` sentinel distinguishing "RxDB hasn't emitted yet" from "emitted, no doc", so first-run users aren't gated forever.
- **`useRoundTTS.ts` + `InstructionsOverlay.tsx`** — auto-speak waits for `isLoading` to clear, then speaks once with the hydrated voice; the silent-skip guard is removed.
- **`useGameTTS.ts`** — resolves `lang` to en-AU; `speakPrompt` no longer bails silently when the saved voice is missing (graceful fallback).

#409's `VoiceUnavailableWarning` banner and the on-demand dialog are intentionally kept.

## Test plan

- [x] `yarn vitest run` — 2005 unit tests pass (new resolver/lang, `isLoading`, hydration-gate, and graceful-fallback specs included)
- [x] `yarn typecheck`
- [ ] **Manual (deployed preview):** cold-load the preview's `/en/game/word-spell`, let the instructions auto-read — confirm it uses the Australian/saved voice, not a US voice. The preview shares IndexedDB with the live site, so your saved voice carries over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-urls -->
---
**Preview:** [App](https://leocaseiro.github.io/base-skill/pr/418/app/) · [Storybook](https://leocaseiro.github.io/base-skill/pr/418/docs/) · [Build details ↓](https://github.com/leocaseiro/base-skill/pull/418#issuecomment-)
<!-- /preview-urls -->
